### PR TITLE
docs: Update examples and bump dev version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Features
 - Automatic JSON Schema & handler generation via Scala 3 macros
 - Seamless integration with the Java MCP SDK
 
----
-
 ## Installation
 
 Add to your **`build.sbt`** (defaulting to **Scala 3.6.4**):
@@ -17,68 +15,6 @@ Add to your **`build.sbt`** (defaulting to **Scala 3.6.4**):
 ```scala
 libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.1.0"
 ```
-
----
-
-## Developing Locally
-
-When hacking on *FastMCP‑Scala* itself, you can consume a local build in any project.
-
-### 🔨 Publish to the Local Ivy Repository with `sbt`
-
-In your cloned repository, set a working version
-```scala 
-ThisBuild / version := "0.1.1-SNAPSHOT"
-```
-
-```bash
-# From the fast-mcp-scala root
-sbt publishLocal
-```
-
-Then, in your consuming sbt project:
-
-```scala
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.1.1-SNAPSHOT"
-```
-
-> `publishLocal` installs the artifact under `~/.ivy2/local` (or the Coursier cache when enabled).
-
----
-
-### 📦 Use the JAR Directly (Unmanaged Dependencies)
-
-```bash
-# Package the library
-sbt package
-
-# Copy the JAR – adjust Scala version / name if you change them
-cp target/scala-3.6.4/fast-mcp-scala_3-0.1.1-SNAPSHOT.jar \
-   /path/to/other-project/lib/
-```
-
-Unmanaged JARs placed in a project’s `lib/` folder are picked up automatically by sbt.
-
----
-
-### 🚀 Using with `scala‑cli`
-
-You can use `fast-mcp-scala` in another scala‑cli project:
-```scala
-//> using scala 3.6.4
-//> using dep com.tjclp::fast-mcp-scala:0.1.0
-//> using options "-Xcheck-macros" "-experimental"
-```
-
-You can also point directly at the local JAR:
-
-```scala
-//> using scala 3.6.4
-//> using lib "/absolute/path/to/fast-mcp-scala_3-0.1.0.jar"
-//> using options "-Xcheck-macros" "-experimental"
-```
-
----
 
 ## Quickstart
 
@@ -118,9 +54,12 @@ object ExampleServer extends ZIOAppDefault:
     yield ()
 ```
 
-The above example can be run using `scala-cli scripts/quickstart.scala` from the repo root. You can run the server via the MCP inspector by running
+### Running Examples
+
+The above example can be run using `scala-cli scripts/quickstart.scala` from the repo root. You can run the server via the MCP inspector by running:
+
 ```bash 
- npx @modelcontextprotocol/inspector scala-cli <path_to_repo>/scripts/quickstart.scala
+npx @modelcontextprotocol/inspector scala-cli <path_to_repo>/scripts/quickstart.scala
 ```
 
 You can also run examples directly from the command line:
@@ -129,6 +68,8 @@ scala-cli \
     -e '//> using dep com.tjclp::fast-mcp-scala:0.1.0' \
     --main-class com.tjclp.fastmcp.examples.AnnotatedServer
 ```
+
+### Integration with Claude Desktop
 
 In Claude desktop, you can add the following to your `claude_desktop_config.json`:
 
@@ -152,8 +93,64 @@ In Claude desktop, you can add the following to your `claude_desktop_config.json
 
 For additional examples and in‑depth docs, see **`docs/guide.md`**.
 
----
-
 ## License
 
 [MIT](LICENSE)
+
+---
+
+## Development Documentation
+
+### Developing Locally
+
+When hacking on *FastMCP‑Scala* itself, you can consume a local build in any project.
+
+#### 🔨 Publish to the Local Ivy Repository with `sbt`
+
+In your cloned repository, set a working version
+```scala 
+ThisBuild / version := "0.1.1-SNAPSHOT"
+```
+
+```bash
+# From the fast-mcp-scala root
+sbt publishLocal
+```
+
+Then, in your consuming sbt project:
+
+```scala
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.1.1-SNAPSHOT"
+```
+
+> `publishLocal` installs the artifact under `~/.ivy2/local` (or the Coursier cache when enabled).
+
+#### 📦 Use the JAR Directly (Unmanaged Dependencies)
+
+```bash
+# Package the library
+sbt package
+
+# Copy the JAR – adjust Scala version / name if you change them
+cp target/scala-3.6.4/fast-mcp-scala_3-0.1.1-SNAPSHOT.jar \
+   /path/to/other-project/lib/
+```
+
+Unmanaged JARs placed in a project's `lib/` folder are picked up automatically by sbt.
+
+#### 🚀 Using with `scala‑cli`
+
+You can use `fast-mcp-scala` in another scala‑cli project:
+```scala
+//> using scala 3.6.4
+//> using dep com.tjclp::fast-mcp-scala:0.1.0
+//> using options "-Xcheck-macros" "-experimental"
+```
+
+You can also point directly at the local JAR:
+
+```scala
+//> using scala 3.6.4
+//> using lib "/absolute/path/to/fast-mcp-scala_3-0.1.0.jar"
+//> using options "-Xcheck-macros" "-experimental"
+```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Features
 
 ---
 
-## Installation (Coming Soon)
+## Installation
 
 Add to your **`build.sbt`** (defaulting to **Scala 3.6.4**):
 
@@ -24,7 +24,7 @@ libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.1.0"
 
 When hacking on *FastMCP‑Scala* itself, you can consume a local build in any project.
 
-### 🔨 Publish to the Local Ivy Repository with `sbt` (Recommended)
+### 🔨 Publish to the Local Ivy Repository with `sbt`
 
 ```bash
 # From the fast-mcp-scala root
@@ -34,7 +34,7 @@ sbt publishLocal
 Then, in your consuming sbt project:
 
 ```scala
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.1.0-SNAPSHOT"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.1.1-SNAPSHOT"
 ```
 
 > `publishLocal` installs the artifact under `~/.ivy2/local` (or the Coursier cache when enabled).
@@ -48,7 +48,7 @@ libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.1.0-SNAPSHOT"
 sbt package
 
 # Copy the JAR – adjust Scala version / name if you change them
-cp target/scala-3.6.4/fast-mcp-scala_3-0.1.0-SNAPSHOT.jar \
+cp target/scala-3.6.4/fast-mcp-scala_3-0.1.1-SNAPSHOT.jar \
    /path/to/other-project/lib/
 ```
 
@@ -61,7 +61,7 @@ Unmanaged JARs placed in a project’s `lib/` folder are picked up automatically
 You can use `fast-mcp-scala` in another scala‑cli project:
 ```scala
 //> using scala 3.6.4
-//> using dep com.tjclp::fast-mcp-scala:0.1.0-SNAPSHOT
+//> using dep com.tjclp::fast-mcp-scala:0.1.0
 //> using options "-Xcheck-macros" "-experimental"
 ```
 
@@ -69,7 +69,7 @@ You can also point directly at the local JAR:
 
 ```scala
 //> using scala 3.6.4
-//> using lib "/absolute/path/to/fast-mcp-scala_3-0.1.0-SNAPSHOT.jar"
+//> using lib "/absolute/path/to/fast-mcp-scala_3-0.1.0.jar"
 //> using options "-Xcheck-macros" "-experimental"
 ```
 
@@ -79,7 +79,7 @@ You can also point directly at the local JAR:
 
 ```scala
 //> using scala 3.6.4
-//> using dep com.tjclp::fast-mcp-scala:0.1.0-SNAPSHOT
+//> using dep com.tjclp::fast-mcp-scala:0.1.0
 //> using options "-Xcheck-macros" "-experimental"
 
 import com.tjclp.fastmcp.core.{Tool, ToolParam, Prompt, PromptParam, Resource}
@@ -116,6 +116,16 @@ object ExampleServer extends ZIOAppDefault:
 The above example can be run using `scala-cli scripts/quickstart.scala` from the repo root (make sure to run `sbt publishLocal` first). You can run the server via the MCP inspector by running
 ```bash 
  npx @modelcontextprotocol/inspector scala-cli <path_to_repo>/scripts/quickstart.scala
+```
+
+You can also run examples directly from the command line:
+```bash 
+scala-cli run \
+    --scala 3.6.4 \
+    --dep com.tjclp::fast-mcp-scala:0.1.0 \
+    --scala-opt "-Xcheck-macros" \
+    --scala-opt "-experimental" \
+    --main-class com.tjclp.fastmcp.examples.AnnotatedServer
 ```
 
 For additional examples and in‑depth docs, see **`docs/guide.md`**.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ When hacking on *FastMCP‑Scala* itself, you can consume a local build in any p
 
 ### 🔨 Publish to the Local Ivy Repository with `sbt`
 
+In your cloned repository, set a working version
+```scala 
+ThisBuild / version := "0.1.1-SNAPSHOT"
+```
+
 ```bash
 # From the fast-mcp-scala root
 sbt publishLocal
@@ -56,7 +61,7 @@ Unmanaged JARs placed in a project’s `lib/` folder are picked up automatically
 
 ---
 
-### 🚀 Using with **scala‑cli**
+### 🚀 Using with `scala‑cli`
 
 You can use `fast-mcp-scala` in another scala‑cli project:
 ```scala
@@ -75,7 +80,7 @@ You can also point directly at the local JAR:
 
 ---
 
-## Quickstart (Annotation‑based)
+## Quickstart
 
 ```scala
 //> using scala 3.6.4
@@ -113,20 +118,37 @@ object ExampleServer extends ZIOAppDefault:
     yield ()
 ```
 
-The above example can be run using `scala-cli scripts/quickstart.scala` from the repo root (make sure to run `sbt publishLocal` first). You can run the server via the MCP inspector by running
+The above example can be run using `scala-cli scripts/quickstart.scala` from the repo root. You can run the server via the MCP inspector by running
 ```bash 
  npx @modelcontextprotocol/inspector scala-cli <path_to_repo>/scripts/quickstart.scala
 ```
 
 You can also run examples directly from the command line:
 ```bash 
-scala-cli run \
-    --scala 3.6.4 \
-    --dep com.tjclp::fast-mcp-scala:0.1.0 \
-    --scala-opt "-Xcheck-macros" \
-    --scala-opt "-experimental" \
+scala-cli \
+    -e '//> using dep com.tjclp::fast-mcp-scala:0.1.0' \
     --main-class com.tjclp.fastmcp.examples.AnnotatedServer
 ```
+
+In Claude desktop, you can add the following to your `claude_desktop_config.json`:
+
+```json 
+{
+  "mcpServers": {
+    "example-fast-mcp-server": {
+      "command": "scala-cli",
+      "args": [
+        "-e",
+        "//> using dep com.tjclp::fast-mcp-scala:0.1.0",
+        "--main-class",
+        "com.tjclp.fastmcp.examples.AnnotatedServer"
+      ]
+    }
+  }
+}
+```
+
+> Note: FastMCP-Scala example servers are for demo purposes only and don't do anything useful
 
 For additional examples and in‑depth docs, see **`docs/guide.md`**.
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ sonatypeTimeoutMillis := 60000
 
 ThisBuild / sonatypeCredentialHost := sonatypeCentralHost
 
-ThisBuild / version := "0.1.0"
+ThisBuild / version := "0.1.1-SNAPSHOT"
 
 ThisBuild / scalaVersion := "3.6.4" // Using Scala 3
 ThisBuild / versionScheme := Some("semver-spec")

--- a/scripts/examples.scala
+++ b/scripts/examples.scala
@@ -1,5 +1,5 @@
 //> using scala "3.6.4"
-//> using dep com.tjclp::fast-mcp-scala:0.1.0-SNAPSHOT
+//> using dep com.tjclp::fast-mcp-scala:0.1.0
 //> using options "-Xcheck-macros" "-experimental" // Enable verbose macro processing
 
 // This is a launcher file for scala-cli

--- a/scripts/quickstart.scala
+++ b/scripts/quickstart.scala
@@ -1,5 +1,5 @@
 //> using scala 3.6.4
-//> using dep com.tjclp::fast-mcp-scala:0.1.0-SNAPSHOT
+//> using dep com.tjclp::fast-mcp-scala:0.1.0
 //> using options "-Xcheck-macros" "-experimental"
 
 import com.tjclp.fastmcp.core.{Tool, ToolParam, Prompt, PromptParam, Resource}


### PR DESCRIPTION
- Bump dev version to `0.1.1-SNAPSHOT`
- Enhance `README.md`
- Set scripts to use `0.1.0` directly from Maven