### PR TITLE
Prepare for 0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to FastMCP-Scala will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.1] - `RefResolver` Patch (2025-05-08)
+
+### Fixed
+- Fixed `RefResolver` to handle functions with more than 3 arguments
+- Added explicit support for functions with 4-22 arguments
+- Added clear error message when attempting to use more than 22 arguments (Scala's built-in limit)
+
+## [0.1.0] - Initial Release (2025-04-25)
+
+### Added
+- Initial public release of FastMCP
+- Support for Scala-native MCP function tools
+- JSON Schema generation for function parameters
+- Runtime function resolution

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Features
 Add to your **`build.sbt`** (defaulting to **Scala 3.6.4**):
 
 ```scala
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.1.0"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.1.1"
 ```
 
 ## Quickstart
 
 ```scala
 //> using scala 3.6.4
-//> using dep com.tjclp::fast-mcp-scala:0.1.0
+//> using dep com.tjclp::fast-mcp-scala:0.1.1
 //> using options "-Xcheck-macros" "-experimental"
 
 import com.tjclp.fastmcp.core.{Tool, ToolParam, Prompt, PromptParam, Resource}
@@ -65,7 +65,7 @@ npx @modelcontextprotocol/inspector scala-cli <path_to_repo>/scripts/quickstart.
 You can also run examples directly from the command line:
 ```bash 
 scala-cli \
-    -e '//> using dep com.tjclp::fast-mcp-scala:0.1.0' \
+    -e '//> using dep com.tjclp::fast-mcp-scala:0.1.1' \
     --main-class com.tjclp.fastmcp.examples.AnnotatedServer
 ```
 
@@ -80,7 +80,7 @@ In Claude desktop, you can add the following to your `claude_desktop_config.json
       "command": "scala-cli",
       "args": [
         "-e",
-        "//> using dep com.tjclp::fast-mcp-scala:0.1.0",
+        "//> using dep com.tjclp::fast-mcp-scala:0.1.1",
         "--main-class",
         "com.tjclp.fastmcp.examples.AnnotatedServer"
       ]
@@ -143,7 +143,7 @@ Unmanaged JARs placed in a project's `lib/` folder are picked up automatically b
 You can use `fast-mcp-scala` in another scala‑cli project:
 ```scala
 //> using scala 3.6.4
-//> using dep com.tjclp::fast-mcp-scala:0.1.0
+//> using dep com.tjclp::fast-mcp-scala:0.1.1
 //> using options "-Xcheck-macros" "-experimental"
 ```
 
@@ -151,6 +151,6 @@ You can also point directly at the local JAR:
 
 ```scala
 //> using scala 3.6.4
-//> using lib "/absolute/path/to/fast-mcp-scala_3-0.1.0.jar"
+//> using lib "/absolute/path/to/fast-mcp-scala_3-0.1.1.jar"
 //> using options "-Xcheck-macros" "-experimental"
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ sonatypeTimeoutMillis := 60000
 
 ThisBuild / sonatypeCredentialHost := sonatypeCentralHost
 
-ThisBuild / version := "0.1.1-SNAPSHOT"
+ThisBuild / version := "0.1.1"
 
 ThisBuild / scalaVersion := "3.6.4" // Using Scala 3
 ThisBuild / versionScheme := Some("semver-spec")

--- a/scripts/examples.scala
+++ b/scripts/examples.scala
@@ -1,5 +1,5 @@
 //> using scala "3.6.4"
-//> using dep com.tjclp::fast-mcp-scala:0.1.0
+//> using dep com.tjclp::fast-mcp-scala:0.1.1
 //> using options "-Xcheck-macros" "-experimental" // Enable verbose macro processing
 
 // This is a launcher file for scala-cli

--- a/scripts/quickstart.scala
+++ b/scripts/quickstart.scala
@@ -1,5 +1,5 @@
 //> using scala 3.6.4
-//> using dep com.tjclp::fast-mcp-scala:0.1.0
+//> using dep com.tjclp::fast-mcp-scala:0.1.1
 //> using options "-Xcheck-macros" "-experimental"
 
 import com.tjclp.fastmcp.core.{Tool, ToolParam, Prompt, PromptParam, Resource}
@@ -29,7 +29,7 @@ object ExampleServer extends ZIOAppDefault:
 
   override def run =
     for
-      server <- ZIO.succeed(FastMcpServer("ExampleServer", "0.1.0"))
+      server <- ZIO.succeed(FastMcpServer("ExampleServer", "0.1.1"))
       _ <- ZIO.attempt(server.scanAnnotations[Example.type])
       _ <- server.runStdio()
     yield ()


### PR DESCRIPTION
- Fix RefResolver to handle functions with 4+ arguments
- Add explicit support for Function4 through Function22
- Add proper error handling for >22 arguments (Scala limitation)
- Update version numbers in build.sbt, README, and example scripts
- Add CHANGELOG.md to track version changes