### PR TITLE
feat: Update to MCP SDK 0.13.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val Versions = new {
   val jackson = "2.20.0"
   val tapir = "1.11.42"
   val jsonSchemaCirce = "0.11.10"
-  val mcpSdk = "0.11.3"
+  val mcpSdk = "0.13.1"
   val scalaTest = "3.2.19"
 }
 

--- a/src/main/scala/com/tjclp/fastmcp/core/Types.scala
+++ b/src/main/scala/com/tjclp/fastmcp/core/Types.scala
@@ -1,5 +1,6 @@
 package com.tjclp.fastmcp.core
 
+import io.modelcontextprotocol.json.McpJsonMapper
 import io.modelcontextprotocol.spec.McpSchema
 import io.modelcontextprotocol.spec.McpSchema.Tool
 import zio.json.*
@@ -45,8 +46,10 @@ object ToolDefinition:
         // Directly use McpSchema.JsonSchema
         baseToolBuilder.inputSchema(mcpSchema)
       case Right(stringSchema) =>
-        // Use string schema - MCP SDK will parse it
-        baseToolBuilder.inputSchema(stringSchema)
+        // Parse string schema to JsonSchema using McpJsonMapper
+        val jsonMapper = McpJsonMapper.createDefault()
+        val jsonSchema = jsonMapper.readValue(stringSchema, classOf[McpSchema.JsonSchema])
+        baseToolBuilder.inputSchema(jsonSchema)
     }
     toolBuilder.build()
 

--- a/src/main/scala/com/tjclp/fastmcp/server/FastMcpServer.scala
+++ b/src/main/scala/com/tjclp/fastmcp/server/FastMcpServer.scala
@@ -3,6 +3,7 @@ package server
 
 import com.tjclp.fastmcp.core.*
 import com.tjclp.fastmcp.server.manager.*
+import io.modelcontextprotocol.json.McpJsonMapper
 import io.modelcontextprotocol.server.McpAsyncServer
 import io.modelcontextprotocol.server.McpAsyncServerExchange
 import io.modelcontextprotocol.server.McpServer
@@ -160,7 +161,8 @@ class FastMcpServer(
     ZIO.scoped { // ⬅ drops the `Scope` requirement
       ZIO.acquireRelease(
         for {
-          provider <- ZIO.attempt(new StdioServerTransportProvider())
+          jsonMapper <- ZIO.attempt(McpJsonMapper.createDefault())
+          provider <- ZIO.attempt(new StdioServerTransportProvider(jsonMapper))
           _ <- ZIO.attempt(setupServer(provider))
           _ <- ZIO.attempt(
             JSystem.err.println(

--- a/src/test/scala/com/tjclp/fastmcp/TestFixtures.scala
+++ b/src/test/scala/com/tjclp/fastmcp/TestFixtures.scala
@@ -1,7 +1,7 @@
 package com.tjclp.fastmcp
 
-import com.fasterxml.jackson.core.`type`.TypeReference
 import com.tjclp.fastmcp.server.McpContext
+import io.modelcontextprotocol.json.TypeRef
 import io.modelcontextprotocol.server.McpAsyncServerExchange
 import io.modelcontextprotocol.spec.McpLoggableSession
 import io.modelcontextprotocol.spec.McpSchema
@@ -19,7 +19,7 @@ object TestFixtures {
     override def sendRequest[T](
         method: String,
         params: Object,
-        typeRef: TypeReference[T]
+        typeRef: TypeRef[T]
     ): Mono[T] = Mono.empty()
     override def sendNotification(method: String): Mono[Void] = Mono.empty()
     override def sendNotification(method: String, obj: Object): Mono[Void] = Mono.empty()

--- a/src/test/scala/com/tjclp/fastmcp/macros/ContextPropagationTest.scala
+++ b/src/test/scala/com/tjclp/fastmcp/macros/ContextPropagationTest.scala
@@ -1,7 +1,7 @@
 package com.tjclp.fastmcp
 package macros
 
-import com.fasterxml.jackson.core.`type`.TypeReference
+import io.modelcontextprotocol.json.TypeRef
 import io.modelcontextprotocol.server.McpAsyncServerExchange
 import io.modelcontextprotocol.spec.McpSchema
 import org.scalatest.funsuite.AnyFunSuite
@@ -130,7 +130,7 @@ class NoopLoggableSession extends io.modelcontextprotocol.spec.McpLoggableSessio
   override def sendRequest[T](
       method: String,
       params: Object,
-      typeRef: TypeReference[T]
+      typeRef: TypeRef[T]
   ): reactor.core.publisher.Mono[T] = reactor.core.publisher.Mono.empty()
 
   override def sendNotification(method: String): reactor.core.publisher.Mono[Void] =


### PR DESCRIPTION
## Summary
- Updated MCP SDK from 0.11.3 to 0.13.1
- Fixed all breaking changes introduced in the new SDK version
- All tests passing (139 tests)

## Changes Made

### Dependency Update
- Updated `mcpSdk` version in `build.sbt` from 0.11.3 to 0.13.1

### Breaking Changes Fixed

1. **StdioServerTransportProvider Constructor**
   - Now requires `McpJsonMapper` parameter
   - Updated to use `McpJsonMapper.createDefault()`

2. **InputSchema Type Handling**  
   - Fixed string schema parsing using `McpJsonMapper.readValue()`
   - Properly converts string schemas to `McpSchema.JsonSchema` objects

3. **Test Updates**
   - Replaced deprecated `TypeReference` with `TypeRef` in test files
   - Updated `TestFixtures.scala` and `ContextPropagationTest.scala`

## Test Results
✅ All 139 tests passing
- Compilation successful with only minor warnings
- No functionality regression

🤖 Generated with [Claude Code](https://claude.ai/code)