### PR TITLE
feat: Make @Param annotation example, required, and schema functional

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,189 @@
+# CLAUDE.md - FastMCP-Scala Development Guide
+
+## Project Overview
+
+FastMCP-Scala is a high-level Scala 3 library for building Model Context Protocol (MCP) servers. It provides annotation-driven APIs (`@Tool`, `@Resource`, `@Prompt`) with automatic JSON Schema generation via Scala 3 macros.
+
+## Build System
+
+**Build tool**: Mill 1.1.0-RC3 (configured in `.mill-version`)
+
+### Common Commands
+
+```bash
+# Compile
+./mill fast-mcp-scala.compile
+
+# Run tests
+./mill fast-mcp-scala.test
+
+# Run specific test class
+./mill fast-mcp-scala.test com.tjclp.fastmcp.macros.ToolProcessorTest
+
+# Format code
+./mill fast-mcp-scala.reformat
+
+# Check formatting (CI uses this)
+./mill fast-mcp-scala.checkFormat
+
+# Generate coverage report
+./mill fast-mcp-scala.scoverage.htmlReport
+
+# Publish locally for testing
+./mill fast-mcp-scala.publishLocal
+```
+
+## Project Structure
+
+```
+fast-mcp-scala/
+├── build.mill                 # Mill build definition
+├── .mill-version              # Mill version (1.1.0-RC3)
+├── .mill-jvm-opts             # JVM options for Mill
+├── fast-mcp-scala/
+│   ├── src/com/tjclp/fastmcp/
+│   │   ├── core/              # Core types, annotations, ADTs
+│   │   │   ├── Annotations.scala    # @Tool, @Param, @Resource, @Prompt
+│   │   │   └── Types.scala          # ToolDefinition, Content types, etc.
+│   │   ├── macros/            # Scala 3 macro implementations
+│   │   │   ├── ToolProcessor.scala       # Processes @Tool annotations
+│   │   │   ├── ResourceProcessor.scala   # Processes @Resource annotations
+│   │   │   ├── PromptProcessor.scala     # Processes @Prompt annotations
+│   │   │   ├── MacroUtils.scala          # Shared macro utilities
+│   │   │   ├── JsonSchemaMacro.scala     # JSON Schema generation
+│   │   │   ├── RegistrationMacro.scala   # scanAnnotations entry point
+│   │   │   └── schema/                   # Schema extraction helpers
+│   │   ├── runtime/           # Runtime utilities (RefResolver)
+│   │   ├── server/            # Server implementation
+│   │   │   ├── FastMcpServer.scala       # Main server class
+│   │   │   ├── McpContext.scala          # Request context
+│   │   │   └── manager/                  # Tool/Resource/Prompt managers
+│   │   └── examples/          # Example servers
+│   └── test/src/              # Test sources (mirrors src structure)
+└── scripts/                   # Example scripts for scala-cli
+```
+
+## Key Concepts
+
+### Annotations
+
+- `@Tool` - Marks a method as an MCP tool
+- `@Resource` - Marks a method as an MCP resource (static or templated)
+- `@Prompt` - Marks a method as an MCP prompt
+- `@Param` - Describes method parameters with metadata:
+  - `description: String` - Parameter description
+  - `example: Option[String]` - Example value (adds `examples` array to schema)
+  - `required: Boolean` - Override required status (must use `Option[T]` or default value if `false`)
+  - `schema: Option[String]` - Custom JSON Schema override
+
+### Macro System
+
+The project uses Scala 3 macros extensively. Key compiler options:
+- `-Xcheck-macros` - Enable macro checking
+- `-experimental` - Enable experimental features
+- `-Xmax-inlines:128` - Increase inline limit for complex macros
+
+The main entry point is `scanAnnotations[T]` which:
+1. Finds all `@Tool`, `@Resource`, `@Prompt` methods in type `T`
+2. Generates JSON schemas for parameters
+3. Registers handlers with the appropriate managers
+
+### Java SDK Interop
+
+FastMCP-Scala wraps the Java MCP SDK (`io.modelcontextprotocol:mcp`). Key interop points:
+- `Types.scala` - Scala ADTs with `toJava` methods
+- `FastMcpServer.scala` - Bridges ZIO effects to Reactor Mono
+- Use `@SuppressWarnings(Array("org.wartremover.warts.Null"))` at Java boundaries
+
+## Code Quality
+
+### WartRemover
+
+Configured in `build.mill`:
+- **Errors** (fail build): `Null`, `TryPartial`, `TripleQuestionMark`, `ArrayEquals`
+- **Warnings**: `Var`, `Return`, `AsInstanceOf`, `IsInstanceOf`
+
+To suppress warnings at Java SDK boundaries:
+```scala
+@SuppressWarnings(Array("org.wartremover.warts.Null"))
+```
+
+### Formatting
+
+Uses Scalafmt with config in `.scalafmt.conf`. Always run `./mill fast-mcp-scala.reformat` before committing.
+
+## Testing
+
+Tests are in `fast-mcp-scala/test/src/`. Key test classes:
+- `MacroUtilsTest` - Unit tests for macro utilities
+- `ToolProcessorTest` - Integration tests for @Tool processing
+- `JsonSchemaMacroTest` - Schema generation tests
+- `ContextPropagationTest` - Context injection tests
+
+Run all tests: `./mill fast-mcp-scala.test`
+
+## CI/CD
+
+- **CI** (`.github/workflows/ci.yml`): Runs on PRs and main pushes, tests on JDK 17, 21, 24
+- **Release** (`.github/workflows/release.yml`): Triggered by `v*` tags, publishes to Maven Central
+
+## Common Tasks
+
+### Adding a New Feature
+
+1. Implement in appropriate package under `fast-mcp-scala/src/`
+2. Add tests in `fast-mcp-scala/test/src/`
+3. Run `./mill fast-mcp-scala.test`
+4. Run `./mill fast-mcp-scala.checkFormat` (or `reformat`)
+
+### Modifying Macros
+
+Macros are in `fast-mcp-scala/src/com/tjclp/fastmcp/macros/`. Key files:
+- `ToolProcessor.scala` - Start here for @Tool changes
+- `MacroUtils.scala` - Shared utilities (schema injection, annotation parsing)
+- `JsonSchemaMacro.scala` - Schema generation from types
+
+After macro changes, clean and recompile:
+```bash
+rm -rf out/fast-mcp-scala && ./mill fast-mcp-scala.compile
+```
+
+### Testing Locally with Another Project
+
+```bash
+./mill fast-mcp-scala.publishLocal
+```
+
+Then in your project use version `0.2.2-SNAPSHOT`.
+
+## Dependencies
+
+Key dependencies (versions in `build.mill`):
+- ZIO 2.1.20 - Effect system
+- Tapir 1.11.42 - Schema derivation
+- Circe - JSON handling
+- Java MCP SDK 0.13.1 - Protocol implementation
+- ScalaTest 3.2.19 - Testing
+
+## Troubleshooting
+
+### Macro Compilation Errors
+
+If you see "Cannot prove that X <:< Y" or similar:
+1. Clean: `rm -rf out/fast-mcp-scala`
+2. Recompile: `./mill fast-mcp-scala.compile`
+
+### WartRemover Null Errors
+
+For Java SDK interop, add suppression annotation to the class/object:
+```scala
+@SuppressWarnings(Array("org.wartremover.warts.Null"))
+class MyJavaInteropClass { ... }
+```
+
+### Test Compilation Issues
+
+Macro tests may need a clean rebuild:
+```bash
+rm -rf out/fast-mcp-scala/test && ./mill fast-mcp-scala.test.compile
+```

--- a/README.md
+++ b/README.md
@@ -115,16 +115,32 @@ For additional examples and in‑depth docs, see **`docs/guide.md`**.
 
 When hacking on *FastMCP‑Scala* itself, you can consume a local build in any project.
 
-#### 🔨 Publish to the Local Ivy Repository with `sbt`
+#### 🔨 Build Commands (Mill)
 
-In your cloned repository, set a working version
-```scala 3 ignore
-ThisBuild / version := "0.2.2-SNAPSHOT"
+FastMCP-Scala uses [Mill](https://mill-build.org/) as its build tool.
+
+```bash
+# Compile the library
+./mill fast-mcp-scala.compile
+
+# Run tests
+./mill fast-mcp-scala.test
+
+# Check code formatting
+./mill fast-mcp-scala.checkFormat
+
+# Auto-format code
+./mill fast-mcp-scala.reformat
+
+# Generate test coverage report
+./mill fast-mcp-scala.scoverage.htmlReport
 ```
+
+#### 🔨 Publish to the Local Ivy Repository
 
 ```bash
 # From the fast-mcp-scala root
-sbt publishLocal
+./mill fast-mcp-scala.publishLocal
 ```
 
 Then, in your consuming sbt project:
@@ -133,20 +149,25 @@ Then, in your consuming sbt project:
 libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.2.2-SNAPSHOT"
 ```
 
-> `publishLocal` installs the artifact under `~/.ivy2/local` (or the Coursier cache when enabled).
+Or in Mill:
+
+```scala 3 ignore
+def ivyDeps = Agg(
+  ivy"com.tjclp::fast-mcp-scala:0.2.2-SNAPSHOT"
+)
+```
+
+> `publishLocal` installs the artifact under `~/.ivy2/local`.
 
 #### 📦 Use the JAR Directly (Unmanaged Dependencies)
 
 ```bash
-# Package the library
-sbt package
+# Build the JAR
+./mill fast-mcp-scala.jar
 
-# Copy the JAR – adjust Scala version / name if you change them
-cp target/scala-3.7.2/fast-mcp-scala_3-0.2.2-SNAPSHOT.jar \
-   /path/to/other-project/lib/
+# The JAR is located at:
+# out/fast-mcp-scala/jar.dest/out.jar
 ```
-
-Unmanaged JARs placed in a project's `lib/` folder are picked up automatically by sbt.
 
 #### 🚀 Using with `scala‑cli`
 
@@ -161,6 +182,6 @@ You can also point directly at the local JAR:
 
 ```scala 3 ignore
 //> using scala 3.7.2
-//> using jar "/absolute/path/to/fast-mcp-scala_3-0.2.1.jar"
+//> using jar "/absolute/path/to/out/fast-mcp-scala/jar.dest/out.jar"
 //> using options "-Xcheck-macros" "-experimental"
 ```


### PR DESCRIPTION
## Summary

Fixes #20 - The `@Param` annotation's `example`, `required`, and `schema` parameters were non-functional (only `description` worked).

This PR implements full support for all `@Param` fields:

- **description**: Adds to property object in JSON schema (was already working)
- **example**: Adds `examples` array to property (JSON Schema format)
- **required**: Updates top-level `required` array (with compile-time validation)
- **schema**: Replaces entire property definition with custom JSON schema

### Key Changes

1. **MacroUtils.scala**
   - Added `ParamMetadata` case class to hold all 4 annotation fields
   - Added `injectParamMetadata` function that handles all fields

2. **ToolProcessor.scala**
   - Now uses `parseToolParam` (which already parsed all fields correctly) instead of manually extracting only description
   - Added compile-time validation: `required=false` requires `Option[T]` or default value for type safety

3. **Tests**
   - 9 unit tests for `injectParamMetadata`
   - Integration test for `@Param` with all fields
   - Integration test for custom `schema` override

4. **Documentation**
   - Updated README.md for Mill build system
   - Added CLAUDE.md with comprehensive development documentation

### Example Usage

```scala
@Tool(name = Some("process-task"))
def processTask(
    @Param(description = "Task name")
    name: String,
    @Param(
      description = "Task status",
      schema = Some("""{"type": "string", "enum": ["pending", "active", "completed"]}""")
    )
    status: String,
    @Param(
      description = "Priority level",
      example = Some("high"),
      required = false
    )
    priority: Option[String]
): String = ???
```

## Test plan

- [x] All existing tests pass
- [x] New unit tests for `injectParamMetadata` pass
- [x] Integration test for `@Param` with all fields passes
- [x] Integration test for custom schema override passes
- [x] Compile-time validation catches invalid `required=false` usage
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.ai/code)