### PR TITLE
feat: Add MCP Tool Annotations support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,4 @@ build/
 *.txt
 
 ### Environment ###
-.env
+.env.metals/

--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,7 @@ build/
 *.txt
 
 ### Environment ###
-.env.metals/
+.env
+
+### Metals ###
+.metals/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,13 @@ fast-mcp-scala/
 
 ### Annotations
 
-- `@Tool` - Marks a method as an MCP tool
+- `@Tool` - Marks a method as an MCP tool. Supports behavioral hints via MCP Tool Annotations:
+  - `title: Option[String]` - Human-readable title
+  - `readOnlyHint: Option[Boolean]` - Tool only reads data
+  - `destructiveHint: Option[Boolean]` - Tool may be destructive/irreversible
+  - `idempotentHint: Option[Boolean]` - Same args produce same effect
+  - `openWorldHint: Option[Boolean]` - Interacts with external world
+  - `returnDirect: Option[Boolean]` - Result goes directly to user
 - `@Resource` - Marks a method as an MCP resource (static or templated)
 - `@Prompt` - Marks a method as an MCP prompt
 - `@Param` - Describes method parameters with metadata:

--- a/fast-mcp-scala/src/com/tjclp/fastmcp/core/Annotations.scala
+++ b/fast-mcp-scala/src/com/tjclp/fastmcp/core/Annotations.scala
@@ -28,6 +28,18 @@ import scala.annotation.experimental
   *   Optional list of tags to categorize the tool
   * @param timeoutMillis
   *   Optional timeout for tool execution in milliseconds
+  * @param title
+  *   Optional human-readable title for the tool
+  * @param readOnlyHint
+  *   If Some(true), the tool only reads data and does not modify anything
+  * @param destructiveHint
+  *   If Some(true), the tool may perform destructive/irreversible operations
+  * @param idempotentHint
+  *   If Some(true), calling multiple times with the same args has the same effect
+  * @param openWorldHint
+  *   If Some(true), the tool interacts with the external world (network, filesystem, etc.)
+  * @param returnDirect
+  *   If Some(true), the result should go directly to the user without LLM post-processing
   */
 class Tool(
     val name: Option[String] = None,
@@ -37,7 +49,14 @@ class Tool(
     val deprecated: Boolean = false,
     val deprecationMessage: Option[String] = None,
     val tags: List[String] = List.empty,
-    val timeoutMillis: Option[Long] = None
+    val timeoutMillis: Option[Long] = None,
+    // MCP Tool Annotations (behavioral hints for clients)
+    val title: Option[String] = None,
+    val readOnlyHint: Option[Boolean] = None,
+    val destructiveHint: Option[Boolean] = None,
+    val idempotentHint: Option[Boolean] = None,
+    val openWorldHint: Option[Boolean] = None,
+    val returnDirect: Option[Boolean] = None
 ) extends StaticAnnotation
 
 /** Unified annotation for method parameters across Tools, Resources, and Prompts

--- a/fast-mcp-scala/src/com/tjclp/fastmcp/core/Types.scala
+++ b/fast-mcp-scala/src/com/tjclp/fastmcp/core/Types.scala
@@ -9,6 +9,35 @@ import zio.json.* // For Java/Scala collection conversions
 
 // Define basic types mirroring MCP Schema
 
+// --- Tool Annotations (MCP behavioral hints for clients) ---
+
+/** Scala representation of MCP Tool Annotations.
+  *
+  * All hint fields are Option[Boolean] -- None means the hint is not specified, which maps to null
+  * in the Java SDK (nullable Boolean).
+  */
+case class ToolAnnotations(
+    title: Option[String] = None,
+    readOnlyHint: Option[Boolean] = None,
+    destructiveHint: Option[Boolean] = None,
+    idempotentHint: Option[Boolean] = None,
+    openWorldHint: Option[Boolean] = None,
+    returnDirect: Option[Boolean] = None
+)
+
+@SuppressWarnings(Array("org.wartremover.warts.Null"))
+object ToolAnnotations:
+
+  def toJava(ta: ToolAnnotations): McpSchema.ToolAnnotations =
+    new McpSchema.ToolAnnotations(
+      ta.title.orNull,
+      ta.readOnlyHint.map(Boolean.box).orNull,
+      ta.destructiveHint.map(Boolean.box).orNull,
+      ta.idempotentHint.map(Boolean.box).orNull,
+      ta.openWorldHint.map(Boolean.box).orNull,
+      ta.returnDirect.map(Boolean.box).orNull
+    )
+
 // --- Tool Related Types ---
 // For now we'll use a simpler ToolExample representation
 case class ToolExample(
@@ -33,7 +62,8 @@ case class ToolDefinition(
     deprecated: Boolean = false,
     deprecationMessage: Option[String] = None,
     tags: List[String] = List.empty,
-    timeoutMillis: Option[Long] = None
+    timeoutMillis: Option[Long] = None,
+    annotations: Option[ToolAnnotations] = None
 )
 
 @SuppressWarnings(Array("org.wartremover.warts.Null"))
@@ -42,12 +72,17 @@ object ToolDefinition:
   // Helper to convert to Java SDK Tool
   def toJava(td: ToolDefinition): McpSchema.Tool =
     val baseToolBuilder = Tool.Builder().name(td.name).description(td.description.orNull)
+
+    // Set title and annotations from ToolAnnotations if present
+    td.annotations.foreach { ta =>
+      ta.title.foreach(t => baseToolBuilder.title(t))
+      baseToolBuilder.annotations(ToolAnnotations.toJava(ta))
+    }
+
     val toolBuilder = td.inputSchema match {
       case Left(mcpSchema) =>
-        // Directly use McpSchema.JsonSchema
         baseToolBuilder.inputSchema(mcpSchema)
       case Right(stringSchema) =>
-        // Parse string schema to JsonSchema using McpJsonMapper
         val jsonMapper = McpJsonDefaults.getMapper()
         val jsonSchema = jsonMapper.readValue(stringSchema, classOf[McpSchema.JsonSchema])
         baseToolBuilder.inputSchema(jsonSchema)

--- a/fast-mcp-scala/src/com/tjclp/fastmcp/macros/MacroUtils.scala
+++ b/fast-mcp-scala/src/com/tjclp/fastmcp/macros/MacroUtils.scala
@@ -323,6 +323,68 @@ private[macros] object MacroUtils:
         None
     }
 
+  // Helper to parse Option[Boolean] literals from annotation arguments
+  private def parseOptionBooleanLiteral(using quotes: Quotes)(
+      argTerm: quotes.reflect.Term
+  ): Option[Boolean] =
+    import quotes.reflect.*
+
+    def parseLiteral(term: Term): Option[Boolean] = stripTerm(term) match {
+      case Literal(BooleanConstant(b)) => Some(b)
+      case _ => None
+    }
+
+    stripTerm(argTerm) match {
+      case Apply(TypeApply(Select(Ident("Some"), "apply"), _), List(arg)) =>
+        parseLiteral(arg)
+      case Apply(Select(Ident("Some"), "apply"), List(arg)) =>
+        parseLiteral(arg)
+      case Select(Ident("None"), _) | Ident("None") => None
+      case _ => None
+    }
+
+  /** Extract MCP ToolAnnotation hints from a @Tool annotation term.
+    */
+  def parseToolAnnotationHints(using quotes: Quotes)(
+      term: quotes.reflect.Term
+  ): (
+      Option[String],
+      Option[Boolean],
+      Option[Boolean],
+      Option[Boolean],
+      Option[Boolean],
+      Option[Boolean]
+  ) =
+    import quotes.reflect.*
+
+    var title: Option[String] = None
+    var readOnlyHint: Option[Boolean] = None
+    var destructiveHint: Option[Boolean] = None
+    var idempotentHint: Option[Boolean] = None
+    var openWorldHint: Option[Boolean] = None
+    var returnDirect: Option[Boolean] = None
+
+    term match {
+      case Apply(Select(New(_), _), argTerms) =>
+        argTerms.foreach {
+          case NamedArg("title", valueTerm) =>
+            title = parseOptionStringLiteral(valueTerm)
+          case NamedArg("readOnlyHint", valueTerm) =>
+            readOnlyHint = parseOptionBooleanLiteral(valueTerm)
+          case NamedArg("destructiveHint", valueTerm) =>
+            destructiveHint = parseOptionBooleanLiteral(valueTerm)
+          case NamedArg("idempotentHint", valueTerm) =>
+            idempotentHint = parseOptionBooleanLiteral(valueTerm)
+          case NamedArg("openWorldHint", valueTerm) =>
+            openWorldHint = parseOptionBooleanLiteral(valueTerm)
+          case NamedArg("returnDirect", valueTerm) =>
+            returnDirect = parseOptionBooleanLiteral(valueTerm)
+          case _ => ()
+        }
+      case _ => ()
+    }
+    (title, readOnlyHint, destructiveHint, idempotentHint, openWorldHint, returnDirect)
+
   // Helper method to invoke a function (runtime)
   // Delegates to the RefResolver implementation which uses MethodHandles
   def invokeFunctionWithArgs(function: Any, args: List[Any]): Any =

--- a/fast-mcp-scala/src/com/tjclp/fastmcp/macros/ToolProcessor.scala
+++ b/fast-mcp-scala/src/com/tjclp/fastmcp/macros/ToolProcessor.scala
@@ -31,6 +31,42 @@ private[macros] object ToolProcessor extends AnnotationProcessorBase:
     // 2️⃣  Extract name / description (with Scaladoc fallback) --------------------------------
     val (finalName, finalDesc) = nameAndDescription(toolAnnot, methodSym)
 
+    // 2.5  Extract MCP Tool Annotations (behavioral hints) ------------------------------------
+    val (
+      hintTitle,
+      hintReadOnly,
+      hintDestructive,
+      hintIdempotent,
+      hintOpenWorld,
+      hintReturnDirect
+    ) =
+      MacroUtils.parseToolAnnotationHints(toolAnnot)
+
+    val hasAnyAnnotation = List(
+      hintTitle,
+      hintReadOnly,
+      hintDestructive,
+      hintIdempotent,
+      hintOpenWorld,
+      hintReturnDirect
+    ).exists(_.isDefined)
+
+    val annotationsExpr: Expr[Option[com.tjclp.fastmcp.core.ToolAnnotations]] =
+      if (!hasAnyAnnotation) '{ None }
+      else
+        '{
+          Some(
+            com.tjclp.fastmcp.core.ToolAnnotations(
+              title = ${ optionStringExpr(hintTitle) },
+              readOnlyHint = ${ optionBoolExpr(hintReadOnly) },
+              destructiveHint = ${ optionBoolExpr(hintDestructive) },
+              idempotentHint = ${ optionBoolExpr(hintIdempotent) },
+              openWorldHint = ${ optionBoolExpr(hintOpenWorld) },
+              returnDirect = ${ optionBoolExpr(hintReturnDirect) }
+            )
+          )
+        }
+
     // 3️⃣  Stable method reference -------------------------------------------------------------
     val methodRefExpr = methodRef(ownerSym, methodSym)
 
@@ -137,9 +173,20 @@ private[macros] object ToolProcessor extends AnnotationProcessorBase:
         name = ${ Expr(finalName) },
         description = ${ Expr(finalDesc) },
         handler = $handler,
-        inputSchema = Right($schemaWithMetadata.spaces2)
+        inputSchema = Right($schemaWithMetadata.spaces2),
+        annotations = $annotationsExpr
       )
     }
 
     // 8️⃣  Run effect & return server ---------------------------------------------------------
     runAndReturnServer(server)(registration)
+
+  private def optionStringExpr(using Quotes)(opt: Option[String]): Expr[Option[String]] =
+    opt match
+      case Some(s) => '{ Some(${ Expr(s) }) }
+      case None => '{ None }
+
+  private def optionBoolExpr(using Quotes)(opt: Option[Boolean]): Expr[Option[Boolean]] =
+    opt match
+      case Some(b) => '{ Some(${ Expr(b) }) }
+      case None => '{ None }

--- a/fast-mcp-scala/src/com/tjclp/fastmcp/server/FastMcpServer.scala
+++ b/fast-mcp-scala/src/com/tjclp/fastmcp/server/FastMcpServer.scala
@@ -62,12 +62,14 @@ class FastMcpServer(
       inputSchema: Either[McpSchema.JsonSchema, String] = Left(
         new McpSchema.JsonSchema("object", null, null, true, null, null)
       ),
-      options: ToolRegistrationOptions = ToolRegistrationOptions()
+      options: ToolRegistrationOptions = ToolRegistrationOptions(),
+      annotations: Option[ToolAnnotations] = None
   ): ZIO[Any, Throwable, FastMcpServer] =
     val definition = ToolDefinition(
       name = name,
       description = description,
-      inputSchema = inputSchema
+      inputSchema = inputSchema,
+      annotations = annotations
     )
     toolManager.addTool(name, handler, definition, options).as(this)
 

--- a/fast-mcp-scala/test/src/com/tjclp/fastmcp/core/AnnotationsDefaultsTest.scala
+++ b/fast-mcp-scala/test/src/com/tjclp/fastmcp/core/AnnotationsDefaultsTest.scala
@@ -20,6 +20,12 @@ class AnnotationsDefaultsTest extends AnyFlatSpec with Matchers {
     ann.deprecationMessage shouldBe None
     ann.tags shouldBe Nil
     ann.timeoutMillis shouldBe None
+    ann.title shouldBe None
+    ann.readOnlyHint shouldBe None
+    ann.destructiveHint shouldBe None
+    ann.idempotentHint shouldBe None
+    ann.openWorldHint shouldBe None
+    ann.returnDirect shouldBe None
   }
 
   "@ToolParam" should "default to required = true" in {

--- a/fast-mcp-scala/test/src/com/tjclp/fastmcp/core/ToolDefinitionConversionTest.scala
+++ b/fast-mcp-scala/test/src/com/tjclp/fastmcp/core/ToolDefinitionConversionTest.scala
@@ -44,4 +44,67 @@ class ToolDefinitionConversionTest extends AnyFlatSpec with Matchers {
     j.description() shouldBe null // description was None
     j.inputSchema() shouldBe new McpSchema.JsonSchema("object", null, null, null, null, null)
   }
+
+  it should "set annotations on the Java Tool when present" in {
+    val td = ToolDefinition(
+      name = "annotated-tool",
+      description = Some("A tool with annotations"),
+      inputSchema = Right("""{ "type": "object" }"""),
+      annotations = Some(
+        ToolAnnotations(
+          title = Some("Annotated Tool"),
+          readOnlyHint = Some(true),
+          destructiveHint = Some(false)
+        )
+      )
+    )
+    val j = ToolDefinition.toJava(td)
+    j.name() shouldBe "annotated-tool"
+    j.title() shouldBe "Annotated Tool"
+    j.annotations() should not be null
+    j.annotations().title() shouldBe "Annotated Tool"
+    j.annotations().readOnlyHint() shouldBe java.lang.Boolean.TRUE
+    j.annotations().destructiveHint() shouldBe java.lang.Boolean.FALSE
+    j.annotations().idempotentHint() shouldBe null
+  }
+
+  it should "leave annotations null when not specified" in {
+    val td = ToolDefinition(
+      name = "no-annot-tool",
+      description = None,
+      inputSchema = Right("""{ "type": "object" }""")
+    )
+    val j = ToolDefinition.toJava(td)
+    j.annotations() shouldBe null
+    j.title() shouldBe null
+  }
+
+  "ToolAnnotations.toJava" should "convert all-specified annotations" in {
+    val ta = ToolAnnotations(
+      title = Some("My Tool"),
+      readOnlyHint = Some(true),
+      destructiveHint = Some(false),
+      idempotentHint = Some(true),
+      openWorldHint = Some(false),
+      returnDirect = Some(true)
+    )
+    val j = ToolAnnotations.toJava(ta)
+    j.title() shouldBe "My Tool"
+    j.readOnlyHint() shouldBe java.lang.Boolean.TRUE
+    j.destructiveHint() shouldBe java.lang.Boolean.FALSE
+    j.idempotentHint() shouldBe java.lang.Boolean.TRUE
+    j.openWorldHint() shouldBe java.lang.Boolean.FALSE
+    j.returnDirect() shouldBe java.lang.Boolean.TRUE
+  }
+
+  it should "convert None values to null" in {
+    val ta = ToolAnnotations()
+    val j = ToolAnnotations.toJava(ta)
+    j.title() shouldBe null
+    j.readOnlyHint() shouldBe null
+    j.destructiveHint() shouldBe null
+    j.idempotentHint() shouldBe null
+    j.openWorldHint() shouldBe null
+    j.returnDirect() shouldBe null
+  }
 }

--- a/fast-mcp-scala/test/src/com/tjclp/fastmcp/macros/ToolProcessorTest.scala
+++ b/fast-mcp-scala/test/src/com/tjclp/fastmcp/macros/ToolProcessorTest.scala
@@ -124,6 +124,39 @@ class ToolProcessorTest extends AnyFunSuite {
     assert(calculation.operation == "SUBTRACT")
   }
 
+  // Test MCP Tool Annotations propagate through macro
+  test("@Tool annotation with MCP tool annotations should propagate to ToolDefinition") {
+    val annotTestServer = new FastMcpServer("AnnotTestServer", "0.1.0")
+    annotTestServer.scanAnnotations[ToolAnnotationsTestTools.type]
+
+    // Tool with annotations
+    val readOnlyTool = annotTestServer.toolManager.getToolDefinition("read-only-tool")
+    assert(readOnlyTool.isDefined, "Tool 'read-only-tool' should be registered")
+    assert(readOnlyTool.get.annotations.isDefined, "annotations should be Some(...)")
+    val annots = readOnlyTool.get.annotations.get
+    assert(annots.title.contains("Read Only Tool"))
+    assert(annots.readOnlyHint.contains(true))
+    assert(annots.destructiveHint.contains(false))
+    assert(annots.openWorldHint.contains(true))
+    assert(annots.idempotentHint.isEmpty, "idempotentHint should be None when not specified")
+    assert(annots.returnDirect.isEmpty, "returnDirect should be None when not specified")
+
+    // Tool without annotations -- should have None
+    val noHintsTool = annotTestServer.toolManager.getToolDefinition("no-hints-tool")
+    assert(noHintsTool.isDefined)
+    assert(
+      noHintsTool.get.annotations.isEmpty,
+      "annotations should be None when no hints specified"
+    )
+
+    // Verify Java SDK Tool has annotations set
+    val javaTool = ToolDefinition.toJava(readOnlyTool.get)
+    assert(javaTool.title() == "Read Only Tool")
+    assert(javaTool.annotations() != null)
+    assert(javaTool.annotations().readOnlyHint() == java.lang.Boolean.TRUE)
+    assert(javaTool.annotations().destructiveHint() == java.lang.Boolean.FALSE)
+  }
+
   // Test @Param annotation with all fields (description, examples, required, schema)
   test("@Param annotation with all fields generates correct schema") {
     // Create a separate server for this test to avoid interference
@@ -246,6 +279,26 @@ object ToolProcessorTest {
     def apply(op: Operation, numbers: List[Double], result: Double): CalculationResult =
       new CalculationResult(op.toString, numbers, result)
   }
+}
+
+/** Test object for MCP Tool Annotations */
+object ToolAnnotationsTestTools {
+  @Tool(
+    name = Some("read-only-tool"),
+    description = Some("A tool that only reads data"),
+    title = Some("Read Only Tool"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    openWorldHint = Some(true)
+  )
+  def readData(@Param("Query string") query: String): String =
+    s"Results for: $query"
+
+  @Tool(
+    name = Some("no-hints-tool"),
+    description = Some("A tool with no annotation hints")
+  )
+  def noHints(@Param("Input") input: String): String = input
 }
 
 /** Test object for @Param annotation with all fields */


### PR DESCRIPTION
## Summary

- Adds MCP Tool Annotations (behavioral hints) to the `@Tool` annotation: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`, `returnDirect`
- Propagates annotations through the macro system into `ToolDefinition` and the Java SDK `McpSchema.Tool`
- Adds `.metals/` to `.gitignore` and restores accidentally removed `.env` entry

## Test plan

- [x] Unit tests for `ToolAnnotations.toJava` conversion (all-specified and all-None cases)
- [x] Unit tests for `ToolDefinition.toJava` with and without annotations
- [x] Macro integration test verifying annotations propagate from `@Tool` through `scanAnnotations`
- [x] Annotation defaults test updated for new fields
- [ ] CI passes on JDK 17, 21, 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)