### PR TITLE
feat: Shared typed contract layer (McpTool/McpPrompt/McpResource)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ object Example:
 object ExampleServer extends ZIOAppDefault:
     override def run =
       for
-        server <- ZIO.succeed(FastMcpServer("ExampleServer", "0.2.0"))
+        server <- ZIO.succeed(McpServer("ExampleServer", "0.2.0"))
         _ <- ZIO.attempt(server.scanAnnotations[Example.type])
         _ <- server.runStdio()
       yield ()
@@ -60,6 +60,53 @@ instances in scope explicitly, use `import com.tjclp.fastmcp.{given, *}`.
 Low-level custom `JacksonConverter` implementations now receive a `JacksonConversionContext`
 instead of direct Jackson mapper/module types. The common DSL stays under
 `import com.tjclp.fastmcp.*`.
+
+### Typed Contracts
+
+For reusable manual definitions across JVM and Scala.js, prefer typed contracts:
+
+```scala 3 raw
+//> using scala 3.7.2
+//> using dep com.tjclp::fast-mcp-scala:0.2.3
+//> using options "-Xcheck-macros" "-experimental"
+
+import sttp.tapir.generic.auto.*
+import zio.*
+import zio.json.*
+
+import com.tjclp.fastmcp.{given, *}
+
+case class AddArgs(
+  @Param(description = "The first number to add", examples = List("2"))
+  a: Int,
+  @Param(description = "The second number to add", examples = List("3"))
+  b: Int
+)
+case class AddResult(sum: Int)
+given JsonEncoder[AddResult] = DeriveJsonEncoder.gen[AddResult]
+
+val addTool = McpTool.derived[AddArgs, AddResult](
+  name = "typed-add",
+  description = Some("Add two numbers")
+) { args =>
+  ZIO.succeed(AddResult(args.a + args.b))
+}
+
+object ContractServer extends ZIOAppDefault:
+  override def run =
+    for
+      server <- ZIO.succeed(McpServer("ContractServer", "0.1.0"))
+      _ <- server.tool(addTool)
+      _ <- server.runStdio()
+    yield ()
+```
+
+The typed contract path is the recommended manual API. Annotation scanning remains a JVM
+convenience layer on top.
+
+On the JVM, `ToolInputSchema.derived[...]` and `McpTool.derived[...]` now also honor
+field-level `@Param` metadata on typed request case classes, including descriptions,
+examples, required flags, and custom schema overrides.
 
 ### Running Examples
 
@@ -100,7 +147,7 @@ object StreamableExample:
 
 object StreamableServer extends ZIOAppDefault:
   override def run =
-    val server = FastMcpServer(
+    val server = McpServer(
       name = "StreamableExample",
       version = "0.1.0",
       settings = FastMcpServerSettings(port = 8090)
@@ -150,7 +197,7 @@ object HttpExample:
 
 object HttpServer extends ZIOAppDefault:
   override def run =
-    val server = FastMcpServer(
+    val server = McpServer(
       name = "HttpExample",
       version = "0.1.0",
       settings = FastMcpServerSettings(port = 8090, stateless = true)

--- a/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/contracts/SharedContractSurfaceTest.scala
+++ b/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/contracts/SharedContractSurfaceTest.scala
@@ -1,0 +1,54 @@
+package com.tjclp.fastmcp.contracts
+
+import org.scalatest.funsuite.AnyFunSuite
+import zio.*
+import zio.json.*
+
+import com.tjclp.fastmcp.*
+
+class SharedContractSurfaceTest extends AnyFunSuite:
+
+  case class AddArgs(a: Int, b: Int)
+  case class AddResult(message: String)
+  case class GreetingArgs(name: String)
+  case class UserProfileArgs(userId: String)
+
+  given JsonEncoder[AddResult] = DeriveJsonEncoder.gen[AddResult]
+
+  test("shared typed contracts compile on Scala.js") {
+    val schema = ToolInputSchema.unsafeFromJsonString(
+      """{"type":"object","properties":{"a":{"type":"integer"},"b":{"type":"integer"}}}"""
+    )
+
+    val tool = McpTool[AddArgs, AddResult](
+      name = "typed-add",
+      description = Some("Add two numbers"),
+      inputSchema = schema
+    ) { args =>
+      ZIO.succeed(AddResult((args.a + args.b).toString))
+    }
+
+    val prompt = McpPrompt[GreetingArgs](
+      name = "typed-prompt",
+      arguments = List(PromptArgument("name", Some("The name"), required = true))
+    ) { args =>
+      ZIO.succeed(List(Message(Role.User, TextContent(s"Hello ${args.name}!"))))
+    }
+
+    val staticResource =
+      McpStaticResource("static://welcome", description = Some("Welcome message"))(
+        ZIO.succeed("welcome")
+      )
+
+    val templateResource = McpTemplateResource[UserProfileArgs](
+      uriPattern = "users://{userId}/profile",
+      arguments = List(ResourceArgument("userId", Some("The user id"), required = true))
+    ) { args =>
+      ZIO.succeed(s"profile:${args.userId}")
+    }
+
+    assert(tool.definition.name == "typed-add")
+    assert(prompt.definition.name == "typed-prompt")
+    assert(staticResource.definition.uri == "static://welcome")
+    assert(templateResource.definition.isTemplate)
+  }

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/Exports.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/Exports.scala
@@ -7,6 +7,14 @@ export core.{
   EmbeddedResource,
   EmbeddedResourceContent,
   ImageContent,
+  McpCodec,
+  McpDecodeContext,
+  McpDecoder,
+  McpEncoder,
+  McpPrompt,
+  McpStaticResource,
+  McpTemplateResource,
+  McpTool,
   Message,
   Param,
   Prompt,
@@ -14,6 +22,8 @@ export core.{
   PromptDefinition,
   PromptParam,
   Resource,
+  ResourceArgument,
+  ResourceDefinition,
   ResourceParam,
   Role,
   TextContent,
@@ -22,7 +32,8 @@ export core.{
   ToolDefinition,
   ToolExample,
   ToolInputSchema,
-  ToolParam
+  ToolParam,
+  ToolSchemaProvider
 }
+export core.McpEncoder.given
 export server.{FastMcpServerSettings, McpContext, McpServer}
-export server.manager.ResourceArgument

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/core/Contracts.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/core/Contracts.scala
@@ -1,0 +1,309 @@
+package com.tjclp.fastmcp.core
+
+import scala.reflect.ClassTag
+
+import zio.*
+import zio.json.*
+
+import com.tjclp.fastmcp.server.McpContext
+
+/** Platform-neutral low-level decode context used by [[McpDecoder]] implementations.
+  *
+  * JVM currently backs this with Jackson 3. JS can provide a different implementation later without
+  * changing the public decoder contract.
+  */
+trait McpDecodeContext:
+  def convertValue[T: ClassTag](name: String, rawValue: Any): T
+  def parseJsonArray(name: String, rawJson: String): List[Any]
+  def parseJsonObject(name: String, rawJson: String): Map[String, Any]
+  def writeValueAsString(value: Any): String
+
+/** Public typed decoder used by the shared contract layer. */
+trait McpDecoder[T]:
+  def decode(name: String, rawValue: Any, context: McpDecodeContext): T
+
+  def contramap[U](f: U => Any): McpDecoder[T] =
+    val self = this
+    new McpDecoder[T]:
+      def decode(name: String, rawValue: Any, context: McpDecodeContext): T =
+        val transformed =
+          try f(rawValue.asInstanceOf[U])
+          catch case _: ClassCastException => rawValue
+        self.decode(name, transformed, context)
+
+object McpDecoder:
+  def apply[T](using decoder: McpDecoder[T]): McpDecoder[T] = decoder
+
+  def instance[T](f: (String, Any, McpDecodeContext) => T): McpDecoder[T] =
+    new McpDecoder[T]:
+      def decode(name: String, rawValue: Any, context: McpDecodeContext): T =
+        f(name, rawValue, context)
+
+/** Public typed result encoder used by mounted tool contracts. */
+trait McpEncoder[-A]:
+  def encode(value: A): List[Content]
+
+  def contramap[B](f: B => A): McpEncoder[B] =
+    val self = this
+    new McpEncoder[B]:
+      def encode(value: B): List[Content] =
+        self.encode(f(value))
+
+trait McpEncoderLowPriority:
+
+  given [A](using encoder: JsonEncoder[A]): McpEncoder[A] with
+
+    def encode(value: A): List[Content] =
+      List(TextContent(value.toJson))
+
+object McpEncoder extends McpEncoderLowPriority:
+  def apply[A](using encoder: McpEncoder[A]): McpEncoder[A] = encoder
+
+  def instance[A](f: A => List[Content]): McpEncoder[A] =
+    new McpEncoder[A]:
+      def encode(value: A): List[Content] =
+        f(value)
+
+  given McpEncoder[String] with
+
+    def encode(value: String): List[Content] =
+      List(TextContent(value))
+
+  given McpEncoder[Int] with
+
+    def encode(value: Int): List[Content] =
+      List(TextContent(value.toString))
+
+  given McpEncoder[Long] with
+
+    def encode(value: Long): List[Content] =
+      List(TextContent(value.toString))
+
+  given McpEncoder[Double] with
+
+    def encode(value: Double): List[Content] =
+      List(TextContent(value.toString))
+
+  given McpEncoder[Float] with
+
+    def encode(value: Float): List[Content] =
+      List(TextContent(value.toString))
+
+  given McpEncoder[Boolean] with
+
+    def encode(value: Boolean): List[Content] =
+      List(TextContent(value.toString))
+
+  given McpEncoder[Unit] with
+
+    def encode(value: Unit): List[Content] =
+      Nil
+
+  given McpEncoder[Content] with
+
+    def encode(value: Content): List[Content] =
+      List(value)
+
+  given McpEncoder[List[Content]] with
+
+    def encode(value: List[Content]): List[Content] =
+      value
+
+  given McpEncoder[Seq[Content]] with
+
+    def encode(value: Seq[Content]): List[Content] =
+      value.toList
+
+trait McpCodec[A] extends McpDecoder[A] with McpEncoder[A]
+
+object McpCodec:
+  def apply[A](using codec: McpCodec[A]): McpCodec[A] = codec
+
+/** Platform hook for deriving a tool input schema from a typed request. */
+trait ToolSchemaProvider[A]:
+  def inputSchema: ToolInputSchema
+
+object ToolSchemaProvider:
+  def apply[A](using provider: ToolSchemaProvider[A]): ToolSchemaProvider[A] = provider
+
+  def instance[A](schema: ToolInputSchema): ToolSchemaProvider[A] =
+    new ToolSchemaProvider[A]:
+      val inputSchema: ToolInputSchema = schema
+
+/** Public resource template argument metadata. */
+case class ResourceArgument(
+    name: String,
+    description: Option[String],
+    required: Boolean = true
+)
+
+/** Public resource definition metadata. */
+case class ResourceDefinition(
+    uri: String,
+    name: Option[String],
+    description: Option[String],
+    mimeType: Option[String] = Some("text/plain"),
+    isTemplate: Boolean = false,
+    arguments: Option[List[ResourceArgument]] = None
+)
+
+/** Shared typed contract for MCP tools. */
+final case class McpTool[In, Out] private (
+    definition: ToolDefinition,
+    handler: (In, Option[McpContext]) => ZIO[Any, Throwable, Out]
+)
+
+object McpTool:
+
+  def withDefinition[In, Out](
+      definition: ToolDefinition
+  )(handler: In => ZIO[Any, Throwable, Out]): McpTool[In, Out] =
+    contextualWithDefinition(definition)((input, _) => handler(input))
+
+  def contextualWithDefinition[In, Out](
+      definition: ToolDefinition
+  )(handler: (In, Option[McpContext]) => ZIO[Any, Throwable, Out]): McpTool[In, Out] =
+    new McpTool(definition, handler)
+
+  def apply[In, Out](
+      name: String,
+      description: Option[String] = None,
+      inputSchema: ToolInputSchema = ToolInputSchema.default,
+      annotations: Option[ToolAnnotations] = None
+  )(handler: In => ZIO[Any, Throwable, Out]): McpTool[In, Out] =
+    withDefinition(
+      ToolDefinition(
+        name = name,
+        description = description,
+        inputSchema = inputSchema,
+        annotations = annotations
+      )
+    )(handler)
+
+  def contextual[In, Out](
+      name: String,
+      description: Option[String] = None,
+      inputSchema: ToolInputSchema = ToolInputSchema.default,
+      annotations: Option[ToolAnnotations] = None
+  )(handler: (In, Option[McpContext]) => ZIO[Any, Throwable, Out]): McpTool[In, Out] =
+    contextualWithDefinition(
+      ToolDefinition(
+        name = name,
+        description = description,
+        inputSchema = inputSchema,
+        annotations = annotations
+      )
+    )(handler)
+
+  def derived[In, Out](
+      name: String,
+      description: Option[String] = None,
+      annotations: Option[ToolAnnotations] = None
+  )(handler: In => ZIO[Any, Throwable, Out])(using
+      schemaProvider: ToolSchemaProvider[In]
+  ): McpTool[In, Out] =
+    apply(name, description, schemaProvider.inputSchema, annotations)(handler)
+
+  def derivedContextual[In, Out](
+      name: String,
+      description: Option[String] = None,
+      annotations: Option[ToolAnnotations] = None
+  )(handler: (In, Option[McpContext]) => ZIO[Any, Throwable, Out])(using
+      schemaProvider: ToolSchemaProvider[In]
+  ): McpTool[In, Out] =
+    contextual(name, description, schemaProvider.inputSchema, annotations)(handler)
+
+/** Shared typed contract for MCP prompts. */
+final case class McpPrompt[In] private (
+    definition: PromptDefinition,
+    handler: In => ZIO[Any, Throwable, List[Message]]
+)
+
+object McpPrompt:
+
+  private def normalizeArguments(arguments: List[PromptArgument]): Option[List[PromptArgument]] =
+    Option.when(arguments.nonEmpty)(arguments)
+
+  def withDefinition[In](
+      definition: PromptDefinition
+  )(handler: In => ZIO[Any, Throwable, List[Message]]): McpPrompt[In] =
+    new McpPrompt(definition, handler)
+
+  def apply[In](
+      name: String,
+      description: Option[String] = None,
+      arguments: List[PromptArgument] = Nil
+  )(handler: In => ZIO[Any, Throwable, List[Message]]): McpPrompt[In] =
+    withDefinition(
+      PromptDefinition(
+        name = name,
+        description = description,
+        arguments = normalizeArguments(arguments)
+      )
+    )(handler)
+
+/** Shared typed contract for static MCP resources. */
+final case class McpStaticResource private (
+    definition: ResourceDefinition,
+    handler: () => ZIO[Any, Throwable, String | Array[Byte]]
+)
+
+object McpStaticResource:
+
+  def withDefinition(
+      definition: ResourceDefinition
+  )(handler: => ZIO[Any, Throwable, String | Array[Byte]]): McpStaticResource =
+    new McpStaticResource(definition.copy(isTemplate = false, arguments = None), () => handler)
+
+  def apply(
+      uri: String,
+      name: Option[String] = None,
+      description: Option[String] = None,
+      mimeType: Option[String] = Some("text/plain")
+  )(handler: => ZIO[Any, Throwable, String | Array[Byte]]): McpStaticResource =
+    withDefinition(
+      ResourceDefinition(
+        uri = uri,
+        name = name,
+        description = description,
+        mimeType = mimeType,
+        isTemplate = false,
+        arguments = None
+      )
+    )(handler)
+
+/** Shared typed contract for templated MCP resources. */
+final case class McpTemplateResource[In] private (
+    definition: ResourceDefinition,
+    handler: In => ZIO[Any, Throwable, String | Array[Byte]]
+)
+
+object McpTemplateResource:
+
+  private def normalizeArguments(
+      arguments: List[ResourceArgument]
+  ): Option[List[ResourceArgument]] =
+    Option.when(arguments.nonEmpty)(arguments)
+
+  def withDefinition[In](
+      definition: ResourceDefinition
+  )(handler: In => ZIO[Any, Throwable, String | Array[Byte]]): McpTemplateResource[In] =
+    new McpTemplateResource(definition.copy(isTemplate = true), handler)
+
+  def apply[In](
+      uriPattern: String,
+      name: Option[String] = None,
+      description: Option[String] = None,
+      mimeType: Option[String] = Some("text/plain"),
+      arguments: List[ResourceArgument] = Nil
+  )(handler: In => ZIO[Any, Throwable, String | Array[Byte]]): McpTemplateResource[In] =
+    withDefinition(
+      ResourceDefinition(
+        uri = uriPattern,
+        name = name,
+        description = description,
+        mimeType = mimeType,
+        isTemplate = true,
+        arguments = normalizeArguments(arguments)
+      )
+    )(handler)

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/core/Types.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/core/Types.scala
@@ -32,6 +32,9 @@ object ToolInputSchema:
 
   val default: ToolInputSchema = unsafeFromJsonString(DefaultJson)
 
+  def derived[A](using provider: ToolSchemaProvider[A]): ToolInputSchema =
+    provider.inputSchema
+
   def fromJsonString(schema: String): Either[String, ToolInputSchema] =
     schema.fromJson[Json].map(_ => schema)
 

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServer.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServer.scala
@@ -4,17 +4,36 @@ package server
 import zio.*
 
 import com.tjclp.fastmcp.core.*
-import com.tjclp.fastmcp.server.manager.*
+import com.tjclp.fastmcp.server.manager.ContextualToolHandler
+import com.tjclp.fastmcp.server.manager.PromptHandler
+import com.tjclp.fastmcp.server.manager.ResourceHandler
+import com.tjclp.fastmcp.server.manager.ResourceTemplateHandler
+import com.tjclp.fastmcp.server.manager.ToolRegistrationOptions
 
 /** Platform-independent MCP server API.
   *
   * This is the trait that macros (`scanAnnotations`, `@Tool`, `@Resource`, `@Prompt`) target. Users
-  * write against this API; the JVM backend (`FastMcpServer`) and JS backend delegate to their
-  * respective SDK implementations.
+  * write against this API; the JVM backend (`FastMcpServer`) and future JS backends delegate to
+  * their respective runtime implementations.
   */
-trait McpServer:
+trait McpServerPlatform:
+
+  /** Platform-specific decode context used by typed contract mounting. */
+  protected def decodeContext: McpDecodeContext
 
   // --- Tool registration ---
+
+  def tool(
+      definition: ToolDefinition,
+      handler: ContextualToolHandler,
+      options: ToolRegistrationOptions
+  ): ZIO[Any, Throwable, McpServerPlatform]
+
+  def tool(
+      definition: ToolDefinition,
+      handler: ContextualToolHandler
+  ): ZIO[Any, Throwable, McpServerPlatform] =
+    tool(definition, handler, ToolRegistrationOptions())
 
   def tool(
       name: String,
@@ -23,9 +42,49 @@ trait McpServer:
       inputSchema: ToolInputSchema = ToolInputSchema.default,
       options: ToolRegistrationOptions = ToolRegistrationOptions(),
       annotations: Option[ToolAnnotations] = None
-  ): ZIO[Any, Throwable, McpServer]
+  ): ZIO[Any, Throwable, McpServerPlatform] =
+    tool(
+      definition = ToolDefinition(
+        name = name,
+        description = description,
+        inputSchema = inputSchema,
+        annotations = annotations
+      ),
+      handler = handler,
+      options = options
+    )
+
+  def tool[In, Out](
+      contract: McpTool[In, Out]
+  )(using
+      decoder: McpDecoder[In],
+      encoder: McpEncoder[Out]
+  ): ZIO[Any, Throwable, McpServerPlatform] =
+    tool(contract, ToolRegistrationOptions())
+
+  def tool[In, Out](
+      contract: McpTool[In, Out],
+      options: ToolRegistrationOptions
+  )(using
+      decoder: McpDecoder[In],
+      encoder: McpEncoder[Out]
+  ): ZIO[Any, Throwable, McpServerPlatform] =
+    tool(
+      definition = contract.definition,
+      handler = (args: Map[String, Any], ctxOpt: Option[McpContext]) =>
+        ZIO
+          .attempt(decoder.decode(contract.definition.name, args, decodeContext))
+          .flatMap(input => contract.handler(input, ctxOpt))
+          .map(encoder.encode),
+      options = options
+    )
 
   // --- Resource registration ---
+
+  def resource(
+      definition: ResourceDefinition,
+      handler: ResourceHandler
+  ): ZIO[Any, Throwable, McpServerPlatform]
 
   def resource(
       uri: String,
@@ -33,7 +92,37 @@ trait McpServer:
       name: Option[String] = None,
       description: Option[String] = None,
       mimeType: Option[String] = Some("text/plain")
-  ): ZIO[Any, Throwable, McpServer]
+  ): ZIO[Any, Throwable, McpServerPlatform] =
+    resource(
+      definition = ResourceDefinition(
+        uri = uri,
+        name = name,
+        description = description,
+        mimeType = mimeType,
+        isTemplate = false,
+        arguments = None
+      ),
+      handler = handler
+    )
+
+  def resource(
+      contract: McpStaticResource
+  ): ZIO[Any, Throwable, McpServerPlatform] =
+    resource(contract.definition, contract.handler)
+
+  def resource[In](
+      contract: McpTemplateResource[In]
+  )(using
+      decoder: McpDecoder[In]
+  ): ZIO[Any, Throwable, McpServerPlatform] =
+    resourceTemplate(contract)
+
+  // --- Template resource registration ---
+
+  def resourceTemplate(
+      definition: ResourceDefinition,
+      handler: ResourceTemplateHandler
+  ): ZIO[Any, Throwable, McpServerPlatform]
 
   def resourceTemplate(
       uriPattern: String,
@@ -42,19 +131,67 @@ trait McpServer:
       description: Option[String] = None,
       mimeType: Option[String] = Some("text/plain"),
       arguments: Option[List[ResourceArgument]] = None
-  ): ZIO[Any, Throwable, McpServer]
+  ): ZIO[Any, Throwable, McpServerPlatform] =
+    resourceTemplate(
+      definition = ResourceDefinition(
+        uri = uriPattern,
+        name = name,
+        description = description,
+        mimeType = mimeType,
+        isTemplate = true,
+        arguments = arguments
+      ),
+      handler = handler
+    )
+
+  def resourceTemplate[In](
+      contract: McpTemplateResource[In]
+  )(using
+      decoder: McpDecoder[In]
+  ): ZIO[Any, Throwable, McpServerPlatform] =
+    resourceTemplate(
+      definition = contract.definition,
+      handler = params =>
+        ZIO
+          .attempt(decoder.decode(contract.definition.uri, params, decodeContext))
+          .flatMap(contract.handler)
+    )
 
   // --- Prompt registration ---
+
+  def prompt(
+      definition: PromptDefinition,
+      handler: PromptHandler
+  ): ZIO[Any, Throwable, McpServerPlatform]
 
   def prompt(
       name: String,
       handler: PromptHandler,
       description: Option[String] = None,
       arguments: Option[List[PromptArgument]] = None
-  ): ZIO[Any, Throwable, McpServer]
+  ): ZIO[Any, Throwable, McpServerPlatform] =
+    prompt(
+      definition = PromptDefinition(name, description, arguments),
+      handler = handler
+    )
+
+  def prompt[In](
+      contract: McpPrompt[In]
+  )(using
+      decoder: McpDecoder[In]
+  ): ZIO[Any, Throwable, McpServerPlatform] =
+    prompt(
+      definition = contract.definition,
+      handler = args =>
+        ZIO
+          .attempt(decoder.decode(contract.definition.name, args, decodeContext))
+          .flatMap(contract.handler)
+    )
 
   // --- Server lifecycle ---
 
   def runStdio(): ZIO[Any, Throwable, Unit]
 
   def runHttp(): ZIO[Any, Throwable, Unit]
+
+type McpServer = McpServerPlatform

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/ResourceManager.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/ResourceManager.scala
@@ -7,23 +7,9 @@ import scala.util.matching.Regex
 
 import zio.*
 
+import com.tjclp.fastmcp.core.ResourceArgument
+import com.tjclp.fastmcp.core.ResourceDefinition
 import com.tjclp.fastmcp.server.McpContext
-
-/** Describes one argument for a resource template placeholder. */
-case class ResourceArgument(
-    name: String,
-    description: Option[String],
-    required: Boolean = true
-)
-
-case class ResourceDefinition(
-    uri: String,
-    name: Option[String],
-    description: Option[String],
-    mimeType: Option[String] = Some("text/plain"),
-    isTemplate: Boolean = false,
-    arguments: Option[List[ResourceArgument]] = None
-)
 
 /** Function type for resource handlers */
 type ResourceHandler = () => ZIO[Any, Throwable, String | Array[Byte]]

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/ResourceTypesCompat.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/ResourceTypesCompat.scala
@@ -1,0 +1,7 @@
+package com.tjclp.fastmcp.server.manager
+
+val ResourceArgument = com.tjclp.fastmcp.core.ResourceArgument
+val ResourceDefinition = com.tjclp.fastmcp.core.ResourceDefinition
+
+type ResourceArgument = com.tjclp.fastmcp.core.ResourceArgument
+type ResourceDefinition = com.tjclp.fastmcp.core.ResourceDefinition

--- a/fast-mcp-scala/src/com/tjclp/fastmcp/ExportsJvm.scala
+++ b/fast-mcp-scala/src/com/tjclp/fastmcp/ExportsJvm.scala
@@ -1,5 +1,7 @@
 package com.tjclp.fastmcp
 
+export core.JvmToolSchemaProviders.given
+export core.McpEncoders.given
 export macros.{DeriveJacksonConverter, JacksonConversionContext, JacksonConverter}
 export macros.JacksonConverter.given
 export macros.RegistrationMacro.*

--- a/fast-mcp-scala/src/com/tjclp/fastmcp/core/Types.scala
+++ b/fast-mcp-scala/src/com/tjclp/fastmcp/core/Types.scala
@@ -1,9 +1,13 @@
 package com.tjclp.fastmcp.core
 
+import java.util.Base64
+
 import scala.jdk.CollectionConverters.*
 
 import io.modelcontextprotocol.json.McpJsonDefaults
 import io.modelcontextprotocol.spec.McpSchema
+
+import com.tjclp.fastmcp.macros.JsonSchemaMacro
 
 private[fastmcp] object JvmToolInputSchemaSupport:
   private val jsonMapper = McpJsonDefaults.getMapper()
@@ -15,6 +19,32 @@ private[fastmcp] object JvmToolInputSchemaSupport:
     schema match
       case Left(javaSchema) => fromJavaSchema(javaSchema)
       case Right(json) => ToolInputSchema.unsafeFromJsonString(json)
+
+object JvmToolSchemaProviders:
+
+  given ToolSchemaProvider[Unit] with
+
+    val inputSchema: ToolInputSchema =
+      ToolInputSchema.unsafeFromJsonString(
+        """{"type":"object","properties":{},"additionalProperties":false}"""
+      )
+
+  inline given [A]: ToolSchemaProvider[A] =
+    ToolSchemaProvider.instance(
+      ToolInputSchema.unsafeFromJsonString(JsonSchemaMacro.schemaForType[A].spaces2)
+    )
+
+object McpEncoders:
+
+  given McpEncoder[Array[Byte]] with
+
+    def encode(value: Array[Byte]): List[Content] =
+      List(
+        ImageContent(
+          data = Base64.getEncoder.encodeToString(value),
+          mimeType = "application/octet-stream"
+        )
+      )
 
 /** JVM-only toJava extension methods for shared MCP types. These are internal to fast-mcp-scala and
   * not part of the user-facing DSL.

--- a/fast-mcp-scala/src/com/tjclp/fastmcp/examples/ContractServer.scala
+++ b/fast-mcp-scala/src/com/tjclp/fastmcp/examples/ContractServer.scala
@@ -1,0 +1,71 @@
+package com.tjclp.fastmcp.examples
+
+import sttp.tapir.generic.auto.*
+import zio.*
+import zio.json.*
+
+import com.tjclp.fastmcp.{*, given}
+
+/** Example server using the shared typed contract layer instead of raw map handlers.
+  */
+object ContractServer extends ZIOAppDefault:
+
+  case class AddArgs(
+      @Param(description = "The first number to add", examples = List("2"))
+      a: Int,
+      @Param(description = "The second number to add", examples = List("3"))
+      b: Int
+  )
+  case class AddResult(sum: Int)
+
+  case class GreetingArgs(
+      @Param(description = "The name to greet", examples = List("Ada"))
+      name: String
+  )
+
+  case class UserProfileArgs(
+      @Param(description = "The user id from the resource URI")
+      userId: String
+  )
+
+  given JsonEncoder[AddResult] = DeriveJsonEncoder.gen[AddResult]
+
+  private val addTool = McpTool.derived[AddArgs, AddResult](
+    name = "typed-add",
+    description = Some("Add two numbers using a typed request/response contract")
+  ) { args =>
+    ZIO.succeed(AddResult(args.a + args.b))
+  }
+
+  private val greetingPrompt = McpPrompt[GreetingArgs](
+    name = "typed-greeting",
+    description = Some("Render a greeting prompt from a typed request"),
+    arguments = List(PromptArgument("name", Some("The name to greet"), required = true))
+  ) { args =>
+    ZIO.succeed(List(Message(Role.User, TextContent(s"Hello ${args.name}!"))))
+  }
+
+  private val welcomeResource = McpStaticResource(
+    uri = "static://welcome",
+    description = Some("A static welcome message")
+  ) {
+    ZIO.succeed("Welcome to typed FastMCP-Scala")
+  }
+
+  private val userProfileResource = McpTemplateResource[UserProfileArgs](
+    uriPattern = "users://{userId}/profile",
+    description = Some("A typed resource template"),
+    arguments = List(ResourceArgument("userId", Some("The user id"), required = true))
+  ) { args =>
+    ZIO.succeed(s"Profile for ${args.userId}")
+  }
+
+  override def run: ZIO[Any, Throwable, Unit] =
+    for
+      server <- ZIO.succeed(McpServer(name = "ContractServer", version = "0.1.0"))
+      _ <- server.tool(addTool)
+      _ <- server.prompt(greetingPrompt)
+      _ <- server.resource(welcomeResource)
+      _ <- server.resource(userProfileResource)
+      _ <- server.runStdio()
+    yield ()

--- a/fast-mcp-scala/src/com/tjclp/fastmcp/macros/JacksonConversionContext.scala
+++ b/fast-mcp-scala/src/com/tjclp/fastmcp/macros/JacksonConversionContext.scala
@@ -6,11 +6,14 @@ import scala.reflect.ClassTag
 import tools.jackson.databind.DeserializationFeature
 import tools.jackson.databind.json.JsonMapper
 
+import com.tjclp.fastmcp.core.McpDecodeContext
+
 /** Shared Jackson 3-backed conversion helpers for low-level [[JacksonConverter]] implementations.
   */
-final class JacksonConversionContext private[macros] (private val mapper: JsonMapper):
+final class JacksonConversionContext private[macros] (private val mapper: JsonMapper)
+    extends McpDecodeContext:
 
-  def convertValue[T: ClassTag](name: String, rawValue: Any): T =
+  override def convertValue[T: ClassTag](name: String, rawValue: Any): T =
     val runtimeClass = summon[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]]
     try mapper.convertValue(rawValue, runtimeClass)
     catch
@@ -20,7 +23,7 @@ final class JacksonConversionContext private[macros] (private val mapper: JsonMa
           e
         )
 
-  def parseJsonArray(name: String, rawJson: String): List[Any] =
+  override def parseJsonArray(name: String, rawJson: String): List[Any] =
     try mapper.readValue(rawJson, classOf[java.util.List[Any]]).asScala.toList
     catch
       case e: Exception =>
@@ -29,7 +32,7 @@ final class JacksonConversionContext private[macros] (private val mapper: JsonMa
           e
         )
 
-  def parseJsonObject(name: String, rawJson: String): Map[String, Any] =
+  override def parseJsonObject(name: String, rawJson: String): Map[String, Any] =
     try mapper.readValue(rawJson, classOf[java.util.Map[String, Any]]).asScala.toMap
     catch
       case e: Exception =>
@@ -38,7 +41,7 @@ final class JacksonConversionContext private[macros] (private val mapper: JsonMa
           e
         )
 
-  def writeValueAsString(value: Any): String =
+  override def writeValueAsString(value: Any): String =
     try mapper.writeValueAsString(value)
     catch
       case e: Exception =>

--- a/fast-mcp-scala/src/com/tjclp/fastmcp/macros/JacksonConverter.scala
+++ b/fast-mcp-scala/src/com/tjclp/fastmcp/macros/JacksonConverter.scala
@@ -5,6 +5,8 @@ import scala.jdk.CollectionConverters.*
 import scala.reflect.ClassTag
 import scala.util.NotGiven
 
+import com.tjclp.fastmcp.core.McpDecodeContext
+import com.tjclp.fastmcp.core.McpDecoder
 import com.tjclp.fastmcp.server.McpContext
 
 /** Typeclass that converts a raw `Any` value (from a Map) to `T`.
@@ -12,11 +14,20 @@ import com.tjclp.fastmcp.server.McpContext
   * Low-level custom implementations receive a shared [[JacksonConversionContext]] backed by Jackson
   * 3.
   */
-trait JacksonConverter[T]:
+trait JacksonConverter[T] extends McpDecoder[T]:
   def convert(name: String, rawValue: Any, context: JacksonConversionContext): T
 
+  final override def decode(name: String, rawValue: Any, context: McpDecodeContext): T =
+    context match
+      case jackson: JacksonConversionContext =>
+        convert(name, rawValue, jackson)
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Unsupported decode context ${context.getClass.getName} for JacksonConverter"
+        )
+
   /** Create a new converter by transforming the input before conversion. */
-  def contramap[U](f: U => Any): JacksonConverter[T] =
+  override def contramap[U](f: U => Any): JacksonConverter[T] =
     val self = this
     new JacksonConverter[T]:
       def convert(name: String, rawValue: Any, context: JacksonConversionContext): T =
@@ -107,6 +118,18 @@ object JacksonConverter extends JacksonConverterLowPriority:
     def convert(name: String, rawValue: Any, context: JacksonConversionContext): Int =
       if rawValue == null then failNull(name, "Int")
       doConvert[Int](name, rawValue, context)
+
+  given JacksonConverter[Unit] with
+
+    def convert(name: String, rawValue: Any, context: JacksonConversionContext): Unit =
+      rawValue match
+        case null | None => ()
+        case m: Map[?, ?] if m.isEmpty => ()
+        case jMap: java.util.Map[?, ?] if jMap.isEmpty => ()
+        case _ =>
+          throw new RuntimeException(
+            s"Cannot convert non-empty value for parameter '$name' to Unit. Value: $rawValue"
+          )
 
   // Option instance treats null or missing as None
   given [A: ClassTag](using JacksonConverter[A]): JacksonConverter[Option[A]] with

--- a/fast-mcp-scala/src/com/tjclp/fastmcp/macros/JsonSchemaMacro.scala
+++ b/fast-mcp-scala/src/com/tjclp/fastmcp/macros/JsonSchemaMacro.scala
@@ -11,6 +11,7 @@ import sttp.tapir.SchemaType.SProductField
 import sttp.tapir.docs.apispec.schema.TapirSchemaToJsonSchema
 
 import com.tjclp.fastmcp.macros.schema.FunctionAnalyzer
+import com.tjclp.fastmcp.macros.schema.SchemaExtractor
 import com.tjclp.fastmcp.macros.schema.SchemaGenerator
 
 /** Macro that generates JSON Schema for function parameters. The implementation is split across
@@ -41,6 +42,10 @@ object JsonSchemaMacro:
     */
   inline def schemaForFunctionArgs[F](inline fn: F, inline exclude: List[String]): Json =
     ${ schemaForFunctionArgsImpl('fn, 'exclude) }
+
+  /** Produces a JSON schema describing a single request type `T`. */
+  inline def schemaForType[T]: Json =
+    ${ schemaForTypeImpl[T] }
 
   private def schemaForFunctionArgsImpl[F: Type](fn: Expr[F], exclude: Expr[List[String]])(using
       Quotes
@@ -81,4 +86,24 @@ object JsonSchemaMacro:
       // Post-process the JSON to resolve and inline references
       MacroUtils.resolveJsonRefs(initialJson)
     }
+
+  private def schemaForTypeImpl[T: Type](using Quotes): Expr[Json] =
+    import quotes.reflect.*
+
+    if TypeRepr.of[T] =:= TypeRepr.of[Unit] then
+      '{
+        Json.obj(
+          "type" -> Json.fromString("object"),
+          "properties" -> Json.obj(),
+          "additionalProperties" -> Json.fromBoolean(false)
+        )
+      }
+    else
+      val (_, schemaExpr) = SchemaExtractor.createSchemaFor[T](Type.show[T])
+      val metadataExpr = MacroUtils.schemaMetadataForType[T]
+      '{
+        val apispecSchema = TapirSchemaToJsonSchema($schemaExpr, markOptionsAsNullable = true)
+        val resolvedSchema = MacroUtils.resolveJsonRefs(apispecSchema.asJson)
+        MacroUtils.injectSchemaMetadata(resolvedSchema, $metadataExpr)
+      }
 end JsonSchemaMacro

--- a/fast-mcp-scala/src/com/tjclp/fastmcp/macros/MacroUtils.scala
+++ b/fast-mcp-scala/src/com/tjclp/fastmcp/macros/MacroUtils.scala
@@ -16,6 +16,13 @@ case class ParamMetadata(
     schema: Option[String] = None
 )
 
+/** Recursive metadata tree used to inject `@Param` metadata into typed request schemas. */
+case class SchemaMetadataNode(
+    metadata: Option[ParamMetadata] = None,
+    properties: Map[String, SchemaMetadataNode] = Map.empty,
+    items: Option[SchemaMetadataNode] = None
+)
+
 /** Utility methods shared between the processor objects (Compressed)
   */
 private[macros] object MacroUtils:
@@ -269,6 +276,124 @@ private[macros] object MacroUtils:
         (paramDesc, paramExamples, paramRequired, paramSchema)
       case None => (None, Nil, true, None) // Defaults if no @Param
     }
+
+  def schemaMetadataForType[T: Type](using Quotes): Expr[SchemaMetadataNode] =
+    import quotes.reflect.*
+    schemaMetadataForTypeRepr(TypeRepr.of[T]).getOrElse('{ SchemaMetadataNode() })
+
+  private def schemaMetadataForTypeRepr(using Quotes)(
+      rawTpe: quotes.reflect.TypeRepr
+  ): Option[Expr[SchemaMetadataNode]] =
+    import quotes.reflect.*
+
+    val tpe = rawTpe.dealias.simplified
+
+    def hasDefaultValue(owner: Symbol, fieldIndex: Int): Boolean =
+      if owner == Symbol.noSymbol then false
+      else
+        val candidateNames = List(
+          s"$$lessinit$$greater$$default$$${fieldIndex + 1}",
+          s"apply$$default$$${fieldIndex + 1}"
+        )
+        candidateNames.exists(name => owner.methodMember(name).nonEmpty)
+
+    def fieldAnnotation(fieldSym: Symbol, ctorParams: List[Symbol]): Option[Term] =
+      extractAnnotation[com.tjclp.fastmcp.core.Param](fieldSym).orElse {
+        ctorParams
+          .find(_.name == fieldSym.name)
+          .flatMap(param => extractAnnotation[com.tjclp.fastmcp.core.Param](param))
+      }
+
+    tpe.asType match
+      case '[Option[a]] =>
+        schemaMetadataForTypeRepr(TypeRepr.of[a])
+      case '[List[a]] =>
+        schemaMetadataForTypeRepr(TypeRepr.of[a]).map { item =>
+          '{ SchemaMetadataNode(items = Some($item)) }
+        }
+      case '[Seq[a]] =>
+        schemaMetadataForTypeRepr(TypeRepr.of[a]).map { item =>
+          '{ SchemaMetadataNode(items = Some($item)) }
+        }
+      case '[Array[a]] =>
+        schemaMetadataForTypeRepr(TypeRepr.of[a]).map { item =>
+          '{ SchemaMetadataNode(items = Some($item)) }
+        }
+      case _ =>
+        val tpeSym = tpe.typeSymbol
+        val isProduct = tpeSym.isClassDef && tpeSym.caseFields.nonEmpty
+
+        if !isProduct then None
+        else
+          val ctorParams = tpeSym.primaryConstructor.paramSymss.flatten
+          val companion = tpeSym.companionModule
+
+          val entries = tpeSym.caseFields.zipWithIndex.flatMap { case (fieldSym, idx) =>
+            val fieldTpe = tpe.memberType(fieldSym)
+            val nested = schemaMetadataForTypeRepr(fieldTpe)
+            val parsedMeta = fieldAnnotation(fieldSym, ctorParams).map { annot =>
+              val (desc, examples, required, schema) = parseToolParam(Some(annot))
+              if !required then
+                val isOption = fieldTpe <:< TypeRepr.of[Option[?]]
+                val hasDefault = hasDefaultValue(companion, idx)
+                if !isOption && !hasDefault then
+                  report.errorAndAbort(
+                    s"Field '${fieldSym.name}' in typed request ${tpeSym.name} is marked as required=false " +
+                      s"but is not an Option type and has no default value."
+                  )
+              ParamMetadata(desc, examples, required, schema)
+            }
+
+            if parsedMeta.isDefined || nested.isDefined then
+              val fieldNameExpr = Expr(fieldSym.name)
+              val isCollectionType = fieldTpe.asType match
+                case '[List[?]] | '[Seq[?]] | '[Array[?]] => true
+                case _ => false
+              val metaExpr = parsedMeta match
+                case Some(meta) =>
+                  '{
+                    Some(
+                      ParamMetadata(
+                        description = ${ Expr(meta.description) },
+                        examples = ${ Expr(meta.examples) },
+                        required = ${ Expr(meta.required) },
+                        schema = ${ Expr(meta.schema) }
+                      )
+                    )
+                  }
+                case None => '{ None }
+
+              val nestedExpr = nested match
+                case Some(node) => '{ $node.properties }
+                case None => '{ Map.empty[String, SchemaMetadataNode] }
+
+              val itemsExpr = nested match
+                case Some(node) if isCollectionType =>
+                  '{ Some($node) }
+                case _ => '{ None }
+
+              val propertiesExpr =
+                if isCollectionType then '{ Map.empty[String, SchemaMetadataNode] }
+                else
+                  nested match
+                    case Some(node) => '{ $node.properties }
+                    case None => '{ Map.empty[String, SchemaMetadataNode] }
+
+              Some(
+                '{
+                  $fieldNameExpr -> SchemaMetadataNode(
+                    metadata = $metaExpr,
+                    properties = $propertiesExpr,
+                    items = $itemsExpr
+                  )
+                }
+              )
+            else None
+          }
+
+          if entries.nonEmpty then
+            Some('{ SchemaMetadataNode(properties = Map(${ Varargs(entries) }*)) })
+          else None
 
   // Helper to parse @Resource annotation arguments
   def parseResourceParams(using quotes: Quotes)(
@@ -547,6 +672,90 @@ private[macros] object MacroUtils:
         withProps.add("required", Json.fromValues(newRequired.toSeq.sorted.map(Json.fromString)))
       else
         withProps.remove("required")
+    }
+  }
+
+  /** Recursively injects `@Param` metadata collected from typed request fields into an already
+    * generated JSON schema.
+    */
+  def injectSchemaMetadata(schemaJson: Json, metadataNode: SchemaMetadataNode): Json = {
+    import io.circe.parser.parse
+
+    def applyOwnMetadata(currentJson: Json, metadata: Option[ParamMetadata]): Json =
+      metadata match {
+        case Some(meta) if meta.schema.isDefined =>
+          parse(meta.schema.get).getOrElse(currentJson)
+        case Some(meta) =>
+          val baseObj = currentJson.asObject.getOrElse(JsonObject.empty)
+          val withDesc =
+            meta.description.fold(baseObj)(d => baseObj.add("description", Json.fromString(d)))
+          val withExamples =
+            if (meta.examples.nonEmpty) then
+              withDesc.add("examples", Json.fromValues(meta.examples.map(Json.fromString)))
+            else withDesc
+          Json.fromJsonObject(withExamples)
+        case None =>
+          currentJson
+      }
+
+    val withOwnMetadata = applyOwnMetadata(schemaJson, metadataNode.metadata)
+
+    // Custom schema replaces the field entirely.
+    if metadataNode.metadata.exists(_.schema.isDefined) then withOwnMetadata
+    else {
+      val withItems =
+        metadataNode.items match {
+          case Some(itemNode) =>
+            withOwnMetadata.hcursor.downField("items").focus match {
+              case Some(itemsJson) =>
+                withOwnMetadata.mapObject(
+                  _.add("items", injectSchemaMetadata(itemsJson, itemNode))
+                )
+              case None =>
+                withOwnMetadata
+            }
+          case None =>
+            withOwnMetadata
+        }
+
+      withItems.hcursor.downField("properties").focus.flatMap(_.asObject) match {
+        case Some(propsObj) if metadataNode.properties.nonEmpty =>
+          val currentRequired =
+            withItems.hcursor.downField("required").as[List[String]].getOrElse(Nil).toSet
+
+          val updatedRequired = metadataNode.properties.foldLeft(currentRequired) {
+            case (acc, (fieldName, childNode)) =>
+              childNode.metadata match {
+                case Some(meta) =>
+                  if meta.required then acc + fieldName else acc - fieldName
+                case None =>
+                  acc
+              }
+          }
+
+          val updatedProps = propsObj.toMap.map { case (fieldName, fieldJson) =>
+            metadataNode.properties.get(fieldName) match {
+              case Some(childNode) =>
+                fieldName -> injectSchemaMetadata(fieldJson, childNode)
+              case None =>
+                fieldName -> fieldJson
+            }
+          }
+
+          withItems.mapObject { obj =>
+            val withProps =
+              obj.add("properties", Json.fromJsonObject(JsonObject.fromMap(updatedProps)))
+            if updatedRequired.nonEmpty then
+              withProps.add(
+                "required",
+                Json.fromValues(updatedRequired.toSeq.sorted.map(Json.fromString))
+              )
+            else withProps.remove("required")
+          }
+
+        case _ =>
+          withItems
+      }
     }
   }
 end MacroUtils

--- a/fast-mcp-scala/src/com/tjclp/fastmcp/macros/ResourceProcessor.scala
+++ b/fast-mcp-scala/src/com/tjclp/fastmcp/macros/ResourceProcessor.scala
@@ -7,7 +7,8 @@ import zio.*
 
 import com.tjclp.fastmcp.core.*
 import com.tjclp.fastmcp.server.*
-import com.tjclp.fastmcp.server.manager.*
+import com.tjclp.fastmcp.server.manager.ResourceHandler
+import com.tjclp.fastmcp.server.manager.ResourceTemplateHandler
 
 /** Refactored Resource processor that utilises [[AnnotationProcessorBase]]. The remaining logic is
   * limited to URI‑template handling and @Resource‑specific parameter processing.

--- a/fast-mcp-scala/src/com/tjclp/fastmcp/server/FastMcpServer.scala
+++ b/fast-mcp-scala/src/com/tjclp/fastmcp/server/FastMcpServer.scala
@@ -29,7 +29,15 @@ import zio.http.Server as ZHttpServer
 import com.tjclp.fastmcp.core.*
 import com.tjclp.fastmcp.core.JvmToolInputSchemaSupport.*
 import com.tjclp.fastmcp.core.TypeConversions.*
-import com.tjclp.fastmcp.server.manager.*
+import com.tjclp.fastmcp.macros.JacksonConversionContext
+import com.tjclp.fastmcp.server.manager.ContextualToolHandler
+import com.tjclp.fastmcp.server.manager.PromptHandler
+import com.tjclp.fastmcp.server.manager.PromptManager
+import com.tjclp.fastmcp.server.manager.ResourceHandler
+import com.tjclp.fastmcp.server.manager.ResourceManager
+import com.tjclp.fastmcp.server.manager.ResourceTemplateHandler
+import com.tjclp.fastmcp.server.manager.ToolManager
+import com.tjclp.fastmcp.server.manager.ToolRegistrationOptions
 import com.tjclp.fastmcp.server.manager.ResourceConversions.*
 import com.tjclp.fastmcp.server.transport.ZioHttpStatelessTransport
 import com.tjclp.fastmcp.server.transport.ZioHttpStreamableTransportProvider
@@ -45,6 +53,7 @@ class FastMcpServer(
     settings: FastMcpServerSettings = FastMcpServerSettings()
 ) extends com.tjclp.fastmcp.server.McpServer:
   val dependencies: List[String] = settings.dependencies
+  protected val decodeContext: McpDecodeContext = JacksonConversionContext.default
   // Initialize managers
   val toolManager = new ToolManager()
   val resourceManager = new ResourceManager()
@@ -58,7 +67,20 @@ class FastMcpServer(
 
   /** Register a tool with the server
     */
-  def tool(
+  override def tool(
+      definition: ToolDefinition,
+      handler: ContextualToolHandler,
+      options: ToolRegistrationOptions
+  ): ZIO[Any, Throwable, FastMcpServer] =
+    toolManager.addTool(definition.name, handler, definition, options).as(this)
+
+  override def tool(
+      definition: ToolDefinition,
+      handler: ContextualToolHandler
+  ): ZIO[Any, Throwable, FastMcpServer] =
+    tool(definition, handler, ToolRegistrationOptions())
+
+  override def tool(
       name: String,
       handler: ContextualToolHandler,
       description: Option[String] = None,
@@ -66,13 +88,16 @@ class FastMcpServer(
       options: ToolRegistrationOptions = ToolRegistrationOptions(),
       annotations: Option[ToolAnnotations] = None
   ): ZIO[Any, Throwable, FastMcpServer] =
-    val definition = ToolDefinition(
-      name = name,
-      description = description,
-      inputSchema = inputSchema,
-      annotations = annotations
+    tool(
+      definition = ToolDefinition(
+        name = name,
+        description = description,
+        inputSchema = inputSchema,
+        annotations = annotations
+      ),
+      handler = handler,
+      options = options
     )
-    toolManager.addTool(name, handler, definition, options).as(this)
 
   def tool(
       name: String,
@@ -93,27 +118,41 @@ class FastMcpServer(
 
   /** Register a **static** resource with the server.
     */
-  def resource(
+  override def resource(
+      definition: ResourceDefinition,
+      handler: ResourceHandler
+  ): ZIO[Any, Throwable, FastMcpServer] =
+    resourceManager.addStaticResource(definition.uri, handler, definition).as(this)
+
+  override def resource(
       uri: String,
       handler: ResourceHandler, // () => ZIO[Any, Throwable, String | Array[Byte]]
       name: Option[String] = None,
       description: Option[String] = None,
       mimeType: Option[String] = Some("text/plain") // Default mimeType here
   ): ZIO[Any, Throwable, FastMcpServer] = {
-    val definition = ResourceDefinition(
-      uri = uri,
-      name = name,
-      description = description,
-      mimeType = mimeType,
-      isTemplate = false,
-      arguments = None
+    resource(
+      definition = ResourceDefinition(
+        uri = uri,
+        name = name,
+        description = description,
+        mimeType = mimeType,
+        isTemplate = false,
+        arguments = None
+      ),
+      handler = handler
     )
-    resourceManager.addStaticResource(uri, handler, definition).as(this)
   }
 
   /** Register a **templated** resource with the server.
     */
-  def resourceTemplate(
+  override def resourceTemplate(
+      definition: ResourceDefinition,
+      handler: ResourceTemplateHandler
+  ): ZIO[Any, Throwable, FastMcpServer] =
+    resourceManager.addTemplateResource(definition.uri, handler, definition).as(this)
+
+  override def resourceTemplate(
       uriPattern: String,
       handler: ResourceTemplateHandler, // Map[String, String] => ZIO[Any, Throwable, String | Array[Byte]]
       name: Option[String] = None,
@@ -121,27 +160,37 @@ class FastMcpServer(
       mimeType: Option[String] = Some("text/plain"), // Default mimeType here
       arguments: Option[List[ResourceArgument]] = None // Arguments might be passed by macro
   ): ZIO[Any, Throwable, FastMcpServer] = {
-    val definition = ResourceDefinition(
-      uri = uriPattern,
-      name = name,
-      description = description,
-      mimeType = mimeType,
-      isTemplate = true,
-      arguments = arguments
+    resourceTemplate(
+      definition = ResourceDefinition(
+        uri = uriPattern,
+        name = name,
+        description = description,
+        mimeType = mimeType,
+        isTemplate = true,
+        arguments = arguments
+      ),
+      handler = handler
     )
-    resourceManager.addTemplateResource(uriPattern, handler, definition).as(this)
   }
 
   /** Register a prompt with the server
     */
-  def prompt(
+  override def prompt(
+      definition: PromptDefinition,
+      handler: PromptHandler
+  ): ZIO[Any, Throwable, FastMcpServer] =
+    promptManager.addPrompt(definition.name, handler, definition).as(this)
+
+  override def prompt(
       name: String,
       handler: PromptHandler,
       description: Option[String] = None,
       arguments: Option[List[PromptArgument]] = None
   ): ZIO[Any, Throwable, FastMcpServer] =
-    val definition = PromptDefinition(name, description, arguments)
-    promptManager.addPrompt(name, handler, definition).as(this)
+    prompt(
+      definition = PromptDefinition(name, description, arguments),
+      handler = handler
+    )
 
   // --- Public Registration Methods ---
 
@@ -986,7 +1035,7 @@ object FastMcpServer:
       version: String = "0.1.0",
       settings: FastMcpServerSettings = FastMcpServerSettings()
   ): ZIO[Any, Throwable, Unit] =
-    ZIO.succeed(apply(name, version, settings)).flatMap(_.runHttp())
+    McpServer.http(name, version, settings)
 
   /** Create a new FastMCPScala instance and run it with stdio transport
     */
@@ -995,7 +1044,7 @@ object FastMcpServer:
       version: String = "0.1.0",
       settings: FastMcpServerSettings = FastMcpServerSettings()
   ): ZIO[Any, Throwable, Unit] =
-    ZIO.succeed(apply(name, version, settings)).flatMap(_.runStdio())
+    McpServer.stdio(name, version, settings)
 
   /** Create a new FastMCPScala instance with the given settings
     */
@@ -1004,6 +1053,6 @@ object FastMcpServer:
       version: String = "0.1.0",
       settings: FastMcpServerSettings = FastMcpServerSettings()
   ): FastMcpServer =
-    new FastMcpServer(name, version, settings) // comment
+    McpServer(name, version, settings)
 
 end FastMcpServer

--- a/fast-mcp-scala/src/com/tjclp/fastmcp/server/McpServerBuilders.scala
+++ b/fast-mcp-scala/src/com/tjclp/fastmcp/server/McpServerBuilders.scala
@@ -1,0 +1,34 @@
+package com.tjclp.fastmcp
+package server
+
+import zio.*
+
+/** Public JVM builder namespace for the MCP server surface. */
+object McpServer:
+
+  def apply(
+      name: String = "FastMCPScala",
+      version: String = "0.1.0",
+      settings: FastMcpServerSettings = FastMcpServerSettings()
+  ): FastMcpServer =
+    new FastMcpServer(name, version, settings)
+
+  /** Create a new server and run it with HTTP transport.
+    *
+    * Uses streamable transport (sessions + SSE) by default. Set `settings.stateless = true` for
+    * stateless transport (no sessions, no SSE).
+    */
+  def http(
+      name: String = "FastMCPScala",
+      version: String = "0.1.0",
+      settings: FastMcpServerSettings = FastMcpServerSettings()
+  ): ZIO[Any, Throwable, Unit] =
+    ZIO.succeed(apply(name, version, settings)).flatMap(_.runHttp())
+
+  /** Create a new server and run it with stdio transport. */
+  def stdio(
+      name: String = "FastMCPScala",
+      version: String = "0.1.0",
+      settings: FastMcpServerSettings = FastMcpServerSettings()
+  ): ZIO[Any, Throwable, Unit] =
+    ZIO.succeed(apply(name, version, settings)).flatMap(_.runStdio())

--- a/fast-mcp-scala/test/src/com/tjclp/fastmcp/server/TypedContractsTest.scala
+++ b/fast-mcp-scala/test/src/com/tjclp/fastmcp/server/TypedContractsTest.scala
@@ -1,0 +1,188 @@
+package com.tjclp.fastmcp.server
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import io.circe.parser.parse
+import sttp.tapir.generic.auto.*
+import zio.*
+import zio.json.*
+
+import com.tjclp.fastmcp.{given, *}
+
+class TypedContractsTest extends AnyFunSuite with Matchers:
+
+  case class AddArgs(a: Int, b: Int)
+  case class AddResult(sum: Int)
+  case class GreetingArgs(name: String)
+  case class UserProfileArgs(userId: String)
+  case class AddressArgs(
+      @Param(description = "Street name", examples = List("Main St"))
+      street: String,
+      @Param(description = "Postal code", required = false)
+      postalCode: Option[String] = None
+  )
+  case class ProfileArgs(
+      @Param(description = "Display name")
+      name: String,
+      @Param(description = "Primary address")
+      address: AddressArgs,
+      @Param(
+        description = "Current account status",
+        schema = Some("""{"type":"string","enum":["active","disabled"],"description":"Current account status"}""")
+      )
+      status: String
+  )
+
+  given JsonEncoder[AddResult] = DeriveJsonEncoder.gen[AddResult]
+
+  private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
+    Unsafe.unsafe { implicit unsafe =>
+      Runtime.default.unsafe.run(effect).getOrThrowFiberFailure()
+    }
+
+  test("typed tool contracts decode request types and encode structured results") {
+    val server = McpServer("TypedToolServer")
+
+    runUnsafe(
+      server.tool(
+        McpTool.derived[AddArgs, AddResult](
+          name = "typed-add",
+          description = Some("Add two numbers")
+        ) { args =>
+          ZIO.succeed(AddResult(args.a + args.b))
+        }
+      )
+    )
+
+    val schema = server.toolManager.getToolDefinition("typed-add").get.inputSchema.toJsonString
+    schema should include(""""a"""")
+    schema should include(""""b"""")
+
+    val result = runUnsafe(
+      server.toolManager.callTool("typed-add", Map("a" -> 2, "b" -> 5), None)
+    )
+
+    result match
+      case List(TextContent(text, _, _)) =>
+        text shouldBe """{"sum":7}"""
+      case other =>
+        fail(s"Unexpected typed tool result: $other")
+  }
+
+  test("typed contextual tool contracts receive McpContext") {
+    val server = McpServer("TypedContextServer")
+
+    runUnsafe(
+      server.tool(
+        McpTool.derivedContextual[AddArgs, String](
+          name = "typed-context",
+          description = Some("Context-aware typed tool")
+        ) { (args, ctxOpt) =>
+          val suffix = if ctxOpt.isDefined then "ctx" else "missing"
+          ZIO.succeed(s"${args.a + args.b}:$suffix")
+        }
+      )
+    )
+
+    val result = runUnsafe(
+      server.toolManager.callTool(
+        "typed-context",
+        Map("a" -> 1, "b" -> 4),
+        Some(McpContext.empty)
+      )
+    )
+
+    result shouldBe List(TextContent("5:ctx"))
+  }
+
+  test("typed prompt and resource contracts mount through the existing managers") {
+    val server = McpServer("TypedSupportServer")
+
+    runUnsafe(
+      server.prompt(
+        McpPrompt[GreetingArgs](
+          name = "typed-prompt",
+          arguments = List(PromptArgument("name", Some("The name to greet"), required = true))
+        ) { args =>
+          ZIO.succeed(List(Message(Role.User, TextContent(s"Hello ${args.name}!"))))
+        }
+      )
+    )
+
+    runUnsafe(
+      server.resource(
+        McpStaticResource(
+          uri = "static://welcome",
+          description = Some("Welcome message")
+        )(ZIO.succeed("welcome"))
+      )
+    )
+
+    runUnsafe(
+      server.resource(
+        McpTemplateResource[UserProfileArgs](
+          uriPattern = "users://{userId}/profile",
+          description = Some("User profile"),
+          arguments = List(ResourceArgument("userId", Some("The user id"), required = true))
+        ) { args =>
+          ZIO.succeed(s"profile:${args.userId}")
+        }
+      )
+    )
+
+    val promptResult =
+      runUnsafe(server.promptManager.getPrompt("typed-prompt", Map("name" -> "Ada"), None))
+    promptResult shouldBe List(Message(Role.User, TextContent("Hello Ada!")))
+
+    val staticResult = runUnsafe(server.resourceManager.readResource("static://welcome", None))
+    staticResult shouldBe "welcome"
+
+    val templateResult =
+      runUnsafe(server.resourceManager.readResource("users://42/profile", None))
+    templateResult shouldBe "profile:42"
+  }
+
+  test("typed request schemas include @Param metadata on fields and nested fields") {
+    val schema = parse(ToolInputSchema.derived[ProfileArgs].toJsonString).toOption.get
+
+    val nameDesc =
+      schema.hcursor.downField("properties").downField("name").downField("description").as[String]
+    nameDesc shouldBe Right("Display name")
+
+    val addressDesc =
+      schema.hcursor.downField("properties").downField("address").downField("description").as[String]
+    addressDesc shouldBe Right("Primary address")
+
+    val nestedStreetDesc =
+      schema.hcursor
+        .downField("properties")
+        .downField("address")
+        .downField("properties")
+        .downField("street")
+        .downField("description")
+        .as[String]
+    nestedStreetDesc shouldBe Right("Street name")
+
+    val nestedStreetExamples =
+      schema.hcursor
+        .downField("properties")
+        .downField("address")
+        .downField("properties")
+        .downField("street")
+        .downField("examples")
+        .as[List[String]]
+    nestedStreetExamples shouldBe Right(List("Main St"))
+
+    val addressRequired =
+      schema.hcursor
+        .downField("properties")
+        .downField("address")
+        .downField("required")
+        .as[List[String]]
+        .getOrElse(Nil)
+    addressRequired should not contain "postalCode"
+
+    val statusEnum =
+      schema.hcursor.downField("properties").downField("status").downField("enum").as[List[String]]
+    statusEnum shouldBe Right(List("active", "disabled"))
+  }

--- a/fast-mcp-scala/test/src/com/tjclp/fastmcp/surface/RootImportSurfaceTest.scala
+++ b/fast-mcp-scala/test/src/com/tjclp/fastmcp/surface/RootImportSurfaceTest.scala
@@ -1,6 +1,9 @@
 package com.tjclp.fastmcp.surface
 
 import org.scalatest.funsuite.AnyFunSuite
+import sttp.tapir.generic.auto.*
+import zio.*
+import zio.json.*
 
 import com.tjclp.fastmcp.{given, *}
 
@@ -11,10 +14,14 @@ class RootImportSurfaceTest extends AnyFunSuite {
     def hello(@Param("Person to greet") name: String): String =
       s"Hello, $name!"
 
+  case class HelloArgs(name: String)
+  case class HelloResult(message: String)
   case class TaggedId(value: String)
 
-  given JacksonConverter[TaggedId] with
-    def convert(name: String, rawValue: Any, context: JacksonConversionContext): TaggedId =
+  given JsonEncoder[HelloResult] = DeriveJsonEncoder.gen[HelloResult]
+
+  given McpDecoder[TaggedId] with
+    def decode(name: String, rawValue: Any, context: McpDecodeContext): TaggedId =
       rawValue match
         case s: String if s.startsWith("{") =>
           TaggedId(context.parseJsonObject(name, s)("value").toString)
@@ -26,15 +33,46 @@ class RootImportSurfaceTest extends AnyFunSuite {
           TaggedId(context.convertValue[String](name, other))
 
   test("root import exposes the public JVM API surface") {
-    val server = FastMcpServer("RootImportServer")
+    val server = McpServer("RootImportServer")
     val _ = server.scanAnnotations[ExampleTools.type]
 
     val toolDef = server.toolManager.getToolDefinition("hello")
     assert(toolDef.isDefined)
 
-    val schema = ToolInputSchema.unsafeFromJsonString("""{"type":"object"}""")
+    val schema = ToolInputSchema.derived[HelloArgs]
     val typed = ToolDefinition("typed-tool", None, schema)
     assert(typed.inputSchema.toJsonString.contains("object"))
+
+    val typedTool = McpTool.derived[HelloArgs, HelloResult](
+      name = "typed-hello",
+      description = Some("Typed greeting")
+    ) { args =>
+      ZIO.succeed(HelloResult(s"Hello, ${args.name}!"))
+    }
+
+    val typedPrompt = McpPrompt[HelloArgs](
+      name = "typed-prompt",
+      arguments = List(PromptArgument("name", Some("The person to greet"), required = true))
+    ) { args =>
+      ZIO.succeed(List(Message(Role.User, TextContent(s"Prompt for ${args.name}"))))
+    }
+
+    val staticResource =
+      McpStaticResource("static://hello", description = Some("Greeting resource"))(
+        ZIO.succeed("hello")
+      )
+
+    val templateResource = McpTemplateResource[HelloArgs](
+      uriPattern = "users://{name}",
+      arguments = List(ResourceArgument("name", Some("The user name"), required = true))
+    ) { args =>
+      ZIO.succeed(s"user:${args.name}")
+    }
+
+    assert(typedTool.definition.name == "typed-hello")
+    assert(typedPrompt.definition.name == "typed-prompt")
+    assert(staticResource.definition.uri == "static://hello")
+    assert(templateResource.definition.isTemplate)
 
     val ctx = McpContext()
     assert(ctx.getClientInfo.isEmpty)
@@ -42,7 +80,7 @@ class RootImportSurfaceTest extends AnyFunSuite {
     val promptMessage: Message = Message(Role.User, TextContent("hi"))
     assert(promptMessage.role == Role.User)
 
-    val tagged = summon[JacksonConverter[TaggedId]].convert(
+    val tagged = summon[McpDecoder[TaggedId]].decode(
       "tagged",
       """{"value":"abc"}""",
       JacksonConversionContext.default


### PR DESCRIPTION
## Summary

Introduces a platform-neutral typed contract layer that sits above the raw map-based handlers. Contracts are defined once in `shared/` and mount to any `McpServer` implementation via `McpDecoder`/`McpEncoder`.

- **`McpTool[In, Out]`** — typed tool with auto-schema derivation from `@Param`-annotated case classes
- **`McpPrompt[In]`** — typed prompt with manual argument metadata
- **`McpStaticResource` / `McpTemplateResource[In]`** — typed resources
- **`McpDecoder[T]` / `McpEncoder[A]` / `McpDecodeContext`** — platform-neutral codec traits in `shared/`
- **`JacksonConverter extends McpDecoder`** — existing JVM converters bridge automatically
- **`McpEncoder` low-priority** — any `A` with `JsonEncoder[A]` falls back to `TextContent(a.toJson)`
- **`McpServer` companion** — factory methods (`McpServer("name")`, `McpServer.http(...)`, `McpServer.stdio(...)`)
- **`McpTool.derived`** — auto-derives `inputSchema` from request case classes via `ToolSchemaProvider`
- **`ContractServer` example** — complete server using only typed contracts, no raw maps

```scala
val addTool = McpTool.derived[AddArgs, AddResult](
  name = "typed-add",
  description = Some("Add two numbers")
) { args => ZIO.succeed(AddResult(args.a + args.b)) }

server.tool(addTool)
```

## Test plan

- [x] `./mill fast-mcp-scala.test` — all JVM tests pass (including new `TypedContractsTest`)
- [x] `./mill fast-mcp-scala.js.test.bunTest` — all JS tests pass (including `SharedContractSurfaceTest`)
- [x] `./mill fast-mcp-scala.checkFormat` — clean
- [x] Zero deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)