### PR TITLE
fix: McpServerApp scan bug + port remaining examples/scripts to sugar

### DIFF
--- a/fast-mcp-scala/js/src/com/tjclp/fastmcp/examples/HttpServerJs.scala
+++ b/fast-mcp-scala/js/src/com/tjclp/fastmcp/examples/HttpServerJs.scala
@@ -1,17 +1,15 @@
 package com.tjclp.fastmcp
 package examples
 
-import zio.*
 import zio.json.*
 
-import com.tjclp.fastmcp.core.*
-import com.tjclp.fastmcp.server.*
+import com.tjclp.fastmcp.{*, given}
 
 /** Scala.js Streamable-HTTP MCP server on Bun — mirror of the JVM [[HttpServer]].
   *
-  * `stateless = true` in `McpServerSettings` flips the transport into JSON-response mode (no SSE,
-  * fresh Server + transport per POST). Leaving it `false` (default) uses the full session- based
-  * Streamable HTTP transport keyed by `mcp-session-id`.
+  * Transport is a phantom type parameter on `McpServerApp[Http, HttpServerJs.type]`. Override
+  * `settings` for host / port / endpoint / statelessness. The typed contract below shows explicit
+  * JSON Schema input via `McpTool.withSchema` — mount it in `override val tools`.
   *
   * Bundle and run:
   * {{{
@@ -19,7 +17,7 @@ import com.tjclp.fastmcp.server.*
   *   bun run out/fast-mcp-scala/js/fullLinkJS.dest/main.js
   * }}}
   */
-object HttpServerJs extends ZIOAppDefault:
+object HttpServerJs extends McpServerApp[Http, HttpServerJs.type]:
 
   case class GreetArgs(name: String)
   case class GreetResult(message: String)
@@ -33,22 +31,15 @@ object HttpServerJs extends ZIOAppDefault:
 
   private val greetTool = McpTool.withSchema[GreetArgs, GreetResult](
     name = "greet",
-    description = Some("Say hello"),
-    inputSchema = greetSchema
+    inputSchema = greetSchema,
+    description = Some("Say hello")
   )(args => GreetResult(s"Hello, ${args.name}!"))
 
-  override def run: ZIO[Any, Throwable, Unit] =
-    val server = McpServer(
-      "HttpServerJs",
-      "0.1.0",
-      McpServerSettings(
-        host = "0.0.0.0",
-        port = 8090,
-        httpEndpoint = "/mcp",
-        stateless = false // flip to `true` for request/response-only mode
-      )
-    )
-    for
-      _ <- server.tool(greetTool)
-      _ <- server.runHttp()
-    yield ()
+  override def settings: McpServerSettings = McpServerSettings(
+    host = "0.0.0.0",
+    port = 8090,
+    httpEndpoint = "/mcp",
+    stateless = false
+  )
+
+  override val tools: List[McpTool[?, ?]] = List(greetTool)

--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/examples/AnnotatedServer.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/examples/AnnotatedServer.scala
@@ -1,17 +1,12 @@
 package com.tjclp.fastmcp
 package examples
 
-import java.lang.System as JSystem
-
 import sttp.tapir.*
 import sttp.tapir.Schema.annotations.*
 import sttp.tapir.generic.auto.*
-import zio.*
 import zio.json.*
 
-import com.tjclp.fastmcp.core.*
-import com.tjclp.fastmcp.macros.RegistrationMacro.*
-import com.tjclp.fastmcp.server.*
+import com.tjclp.fastmcp.*
 
 /** Flagship annotation-driven server.
   *
@@ -30,7 +25,9 @@ import com.tjclp.fastmcp.server.*
   * Run with `./mill fast-mcp-scala.jvm.runMain com.tjclp.fastmcp.examples.AnnotatedServer` or
   * attach an MCP Inspector: `npx @modelcontextprotocol/inspector scala-cli scripts/quickstart.sc`.
   */
-object AnnotatedServer extends ZIOAppDefault:
+object AnnotatedServer extends McpServerApp[Stdio, AnnotatedServer.type]:
+
+  override def name: String = "MacroAnnotatedServer"
 
   // JSON codec for the result
   given JsonEncoder[CalculatorResult] = DeriveJsonEncoder.gen[CalculatorResult]
@@ -200,16 +197,6 @@ object AnnotatedServer extends ZIOAppDefault:
         content = TextContent(s"Generate a warm greeting for $fullGreeting.")
       )
     )
-
-  override def run: ZIO[Any, Throwable, Unit] =
-    for
-      server <- ZIO.succeed(FastMcpServer(name = "MacroAnnotatedServer", version = "0.1.0"))
-      _ <- ZIO.attempt {
-        JSystem.err.println("[AnnotatedServer] Scanning for annotated tools...")
-        server.scanAnnotations[AnnotatedServer.type]
-      }
-      _ <- server.runStdio()
-    yield ()
 
   case class CalculatorResult(
       operation: String,

--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/examples/ContextEchoServer.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/examples/ContextEchoServer.scala
@@ -1,54 +1,35 @@
 package com.tjclp.fastmcp
 package examples
 
-import zio.*
+import com.tjclp.fastmcp.*
 
-import com.tjclp.fastmcp.server.*
-
-/** A simple example server demonstrating the use of contextual tool handlers
+/** `McpContext` introspection from inside a tool handler.
   *
-  * This example shows how to access client capabilities and information through the McpContext
-  * passed to contextual tool handlers.
+  * The annotation path detects a parameter named `ctx: McpContext` and threads the runtime context
+  * through instead of decoding it from the JSON-RPC args. The handler below uses it to surface the
+  * client's declared info and capabilities.
   */
-object ContextEchoServer extends ZIOAppDefault:
+object ContextEchoServer extends McpServerApp[Stdio, ContextEchoServer.type]:
 
-  /** Main method that sets up and runs the server
-    */
-  def run: ZIO[Any, Throwable, ExitCode] =
-    // Create a new server instance
-    val server = FastMcpServer("ContextEchoServer", "1.0.0")
+  override def name: String = "ContextEchoServer"
+  override def version: String = "1.0.0"
 
-    // Register a tool that uses context to get client information
-    val registerTool = server.tool(
-      name = "echo",
-      handler = (args: Map[String, Any], ctx: Option[McpContext]) => {
-        // Extract client information from context
-        val clientName = ctx.get.getClientInfo.map(_.name()).getOrElse("Unknown Client")
-        val clientVersion = ctx.get.getClientInfo.map(_.version()).getOrElse("Unknown Version")
-
-        // Extract client capabilities
-        val hasRootListChanges = ctx.get.getClientCapabilities.exists(c =>
-          c.roots() != null && c.roots().listChanged() == true
-        )
-        val hasSampling = ctx.get.getClientCapabilities.exists(c => c.sampling() != null)
-
-        // Create a summary of the client and context information
-        val summary = s"""
-        |Client: $clientName v$clientVersion
-        |Request Arguments: $args
-        |Client Capabilities:
-        |  - Root List Changes: $hasRootListChanges
-        |  - Sampling: $hasSampling
-        """.stripMargin
-
-        ZIO.succeed(summary)
-      },
-      description = Some("Echoes back information about the client and the context of the request")
-    )
-
-    // Register with @Tool annotation
-
-    // Register and run the server
-    registerTool *> server.runStdio().as(ExitCode.success)
-
-end ContextEchoServer
+  @Tool(
+    name = Some("echo"),
+    description = Some("Echoes back information about the client and the context of the request")
+  )
+  def echo(
+      @Param(description = "Optional note to include in the echo", required = false)
+      note: Option[String],
+      ctx: McpContext
+  ): String =
+    val clientName = ctx.getClientInfo.map(_.name()).getOrElse("Unknown Client")
+    val clientVersion = ctx.getClientInfo.map(_.version()).getOrElse("Unknown Version")
+    val hasRootListChanges = ctx.getClientCapabilities
+      .exists(c => c.roots() != null && c.roots().listChanged() == true)
+    val hasSampling = ctx.getClientCapabilities.exists(c => c.sampling() != null)
+    s"""Client: $clientName v$clientVersion
+       |Note: ${note.getOrElse("(none)")}
+       |Client Capabilities:
+       |  - Root List Changes: $hasRootListChanges
+       |  - Sampling: $hasSampling""".stripMargin

--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/examples/HttpServer.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/examples/HttpServer.scala
@@ -1,17 +1,14 @@
 package com.tjclp.fastmcp
 package examples
 
-import zio.*
+import com.tjclp.fastmcp.*
 
-import com.tjclp.fastmcp.core.*
-import com.tjclp.fastmcp.macros.RegistrationMacro.*
-import com.tjclp.fastmcp.server.*
-
-/** MCP server over HTTP.
+/** MCP server over HTTP — transport is a phantom type parameter on `McpServerApp`.
   *
-  * `runHttp()` serves the full MCP Streamable HTTP spec — `POST /mcp` for JSON-RPC, session
-  * tracking via the `mcp-session-id` header, and SSE streams for long-running calls. Switch to
-  * stateless mode with a single flag when sessions aren't needed.
+  * `runHttp()` (dispatched by `McpServerApp[Http, ...]`) serves the full MCP Streamable HTTP spec —
+  * `POST /mcp` for JSON-RPC, session tracking via the `mcp-session-id` header, and SSE streams for
+  * long-running calls. Flip `stateless = true` on the settings for a sessionless, SSE-free
+  * transport.
   *
   * Start with: `./mill fast-mcp-scala.jvm.runMain com.tjclp.fastmcp.examples.HttpServer`
   *
@@ -33,11 +30,10 @@ import com.tjclp.fastmcp.server.*
   *   # 3. Close the session (streamable mode only)
   *   curl -X DELETE http://localhost:8090/mcp -H "mcp-session-id: <id>"
   * }}}
-  *
-  * Flip `stateless = true` on `McpServerSettings` to disable session tracking and SSE — useful
-  * for request/response-style deployments behind a load balancer.
   */
-object HttpServer extends ZIOAppDefault:
+object HttpServer extends McpServerApp[Http, HttpServer.type]:
+
+  override def settings: McpServerSettings = McpServerSettings(port = 8090)
 
   @Tool(
     name = Some("greet"),
@@ -69,15 +65,3 @@ object HttpServer extends ZIOAppDefault:
   @Prompt(name = Some("summarize"), description = Some("Summarize a topic"))
   def summarize(@Param("Topic to summarize") topic: String): List[Message] =
     List(Message(Role.User, TextContent(s"Please summarize: $topic")))
-
-  override def run: ZIO[Any, Throwable, Unit] =
-    // Flip `stateless = true` for a sessionless, SSE-free transport.
-    val server = FastMcpServer(
-      name = "HttpServer",
-      version = "0.1.0",
-      settings = McpServerSettings(port = 8090)
-    )
-    for
-      _ <- ZIO.attempt(server.scanAnnotations[HttpServer.type])
-      _ <- server.runHttp()
-    yield ()

--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/examples/TaskManagerServer.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/examples/TaskManagerServer.scala
@@ -1,4 +1,5 @@
-package com.tjclp.fastmcp.examples
+package com.tjclp.fastmcp
+package examples
 
 import java.time.LocalDateTime
 import java.util.UUID
@@ -7,12 +8,10 @@ import scala.collection.mutable
 
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
-import zio.*
 
-import com.tjclp.fastmcp.core.*
+import com.tjclp.fastmcp.*
 import com.tjclp.fastmcp.macros.*
-import com.tjclp.fastmcp.macros.RegistrationMacro.*
-import com.tjclp.fastmcp.server.*
+import com.tjclp.fastmcp.macros.JacksonConverter.given
 
 /** Domain-shaped MCP server — a task tracker with nested case classes, Scala 3 enums, Java
   * `LocalDateTime`, and mutable in-memory state.
@@ -25,7 +24,7 @@ import com.tjclp.fastmcp.server.*
   *     so clients can call them without confirmation; `updateTask` advertises idempotency; all
   *     tools declare whether they touch an open world (none do — state is in-memory).
   */
-object TaskManagerServer extends ZIOAppDefault:
+object TaskManagerServer extends McpServerApp[Stdio, TaskManagerServer.type]:
 
   // Domain models
   case class Task(
@@ -237,10 +236,4 @@ object TaskManagerServer extends ZIOAppDefault:
       .sortBy(_.createdAt)
       .reverse
 
-  override def run =
-    for
-      _ <- Console.printLine("Starting Task Manager MCP Server...")
-      server <- ZIO.succeed(FastMcpServer("TaskManagerServer"))
-      _ <- ZIO.attempt(server.scanAnnotations[TaskManagerServer.type])
-      _ <- server.runStdio()
-    yield ()
+  override def name: String = "TaskManagerServer"

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServerApp.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServerApp.scala
@@ -6,6 +6,20 @@ import zio.*
 import com.tjclp.fastmcp.core.*
 import com.tjclp.fastmcp.macros.RegistrationMacro.*
 
+/** Runtime-scan capture of annotated methods on a specific singleton type. The `inline given` in
+  * the companion expands at the subclass's *instantiation* site — where `Self` is concrete — so the
+  * embedded `scanAnnotationsQuiet[Self]` macro sees the real singleton and emits registrations for
+  * every `@Tool` / `@Prompt` / `@Resource` method on it.
+  */
+trait SelfScan[Self]:
+  def apply(core: McpServerCore): McpServerCore
+
+object SelfScan:
+
+  inline given [Self <: Singleton]: SelfScan[Self] = new SelfScan[Self]:
+    def apply(core: McpServerCore): McpServerCore =
+      core.scanAnnotationsQuiet[Self]
+
 /** Declarative entry point for building an MCP server.
   *
   * Extend this trait on a top-level `object` to mount annotated tools/prompts/resources and/or
@@ -29,7 +43,8 @@ import com.tjclp.fastmcp.macros.RegistrationMacro.*
   */
 trait McpServerApp[T <: Transport, Self <: Singleton](using
     runner: TransportRunner[T],
-    factory: McpServerCoreFactory
+    factory: McpServerCoreFactory,
+    selfScan: SelfScan[Self]
 ) extends zio.ZIOAppDefault:
 
   def name: String = getClass.getSimpleName.stripSuffix("$")
@@ -41,15 +56,9 @@ trait McpServerApp[T <: Transport, Self <: Singleton](using
   def staticResources: List[McpStaticResource] = Nil
   def templateResources: List[McpTemplateResource[?]] = Nil
 
-  /** Inlined so `Self` specializes at the subclass compilation site — the quiet variant suppresses
-    * the "no annotations found" warning for contract-only servers that still declare Self.
-    */
-  protected inline final def scanSelf(core: McpServerCore): McpServerCore =
-    core.scanAnnotationsQuiet[Self]
-
   final def buildCore: ZIO[Any, Throwable, McpServerCore] =
     val core = factory.build(name, version, settings)
-    val _ = scanSelf(core)
+    val _ = selfScan(core)
     for
       _ <- ZIO.foreachDiscard(tools)(core.tool(_))
       _ <- ZIO.foreachDiscard(prompts)(core.prompt(_))

--- a/scripts/examples.sc
+++ b/scripts/examples.sc
@@ -1,5 +1,5 @@
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc1
+//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc2
 //> using options "-Xcheck-macros" "-experimental"
 
 // Launcher for fast-mcp-scala example servers. Point `scala-cli` at this file and

--- a/scripts/quickstart.sc
+++ b/scripts/quickstart.sc
@@ -1,11 +1,10 @@
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc1
+//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc2
 //> using options "-Xcheck-macros" "-experimental"
 
 import com.tjclp.fastmcp.*
-import zio.*
 
-object Example:
+object Example extends McpServerApp[Stdio, Example.type]:
 
   @Tool(name = Some("add"), description = Some("Add two numbers"), readOnlyHint = Some(true))
   def add(
@@ -23,13 +22,4 @@ object Example:
   @Resource(uri = "user://{userId}", description = Some("Test resource"))
   def getUser(@Param("The user id") userId: String): String = s"User ID: $userId"
 
-object ExampleServer extends ZIOAppDefault:
-
-  override def run =
-    for
-      server <- ZIO.succeed(McpServer("ExampleServer", "0.3.0"))
-      _      <- ZIO.attempt(server.scanAnnotations[Example.type])
-      _      <- server.runStdio()
-    yield ()
-
-ExampleServer.main(args)
+Example.main(args)


### PR DESCRIPTION
## Summary

Critical fix: `McpServerApp[T, Self]` shipped in 0.3.0-rc2 as a no-op scanner. The `inline def scanSelf` referenced `Self` — an abstract type param at the trait compile site — so the macro `scanAnnotationsQuiet[Self]` expanded with `Self` still abstract and emitted zero registrations silently. Caught when porting AnnotatedServer to the sugar: the Bun conformance test spawned it and saw `MCP error -32601: Method not found: tools/list`.

Plus: port the remaining 5 examples + both `scripts/*.sc` launchers to the `McpServerApp` sugar so the repo shows one canonical style instead of two.

## The scan-bug fix

Introduce a `SelfScan[Self]` typeclass with an `inline given` in the companion:

```scala
trait SelfScan[Self]:
  def apply(core: McpServerCore): McpServerCore

object SelfScan:
  inline given [Self <: Singleton]: SelfScan[Self] = new SelfScan[Self]:
    def apply(core: McpServerCore): McpServerCore =
      core.scanAnnotationsQuiet[Self]
```

`McpServerApp` takes `selfScan: SelfScan[Self]` as a third `using` parameter and calls `selfScan(core)` in `buildCore`. The `inline given` expands at the *subclass's* instantiation site — where `Self` is concrete — so the macro sees the real singleton and registrations fire.

No subclass code changes required; the given resolves automatically.

Verified:
- `./mill fast-mcp-scala.jvm.runMain HelloWorld` now logs `Registering 1 tools`.
- `./mill fast-mcp-scala.jvm.runMain AnnotatedServer` registers all 5 tools + 1 resource template + 2 prompts.
- JS conformance test (which spawns AnnotatedServer under the hood) passes again.

## Example/script ports

- **scripts/quickstart.sc** — collapse the two-object `Example` + `ExampleServer extends ZIOAppDefault` pattern into one `object Example extends McpServerApp[Stdio, Example.type]`. 36 lines → 23 lines. Pin 0.3.0-rc1 → 0.3.0-rc2.
- **scripts/examples.sc** — version pin bump.
- **AnnotatedServer**, **HttpServer**, **TaskManagerServer** (JVM) — drop `extends ZIOAppDefault` + `override def run`, add the sugar trait + optional `override def settings`.
- **ContextEchoServer** — imperative `server.tool(name = "echo", handler = ...)` rewritten as a contextual `@Tool` method with a `ctx: McpContext` parameter. The annotation macro's name/type-match for `ctx` threads runtime context through (existing capability in ToolProcessor).
- **HttpServerJs** — mirror HttpServer; keeps the `McpTool.withSchema` typed contract, mounted via `override val tools = List(greetTool)`.

End-to-end grep: `grep -r "import zio" fast-mcp-scala/*/src/com/tjclp/fastmcp/examples/` returns zero hits outside docstrings.

## Test plan

- [x] `./mill fast-mcp-scala.compile` clean
- [x] `./mill fast-mcp-scala.jvm.test` — 138/138 pass
- [x] `./mill fast-mcp-scala.js.test.bunTest` — 39/39 pass (including the conformance suite that previously failed with 'Method not found: tools/list')
- [x] `./mill fast-mcp-scala.checkFormat` clean
- [x] `./mill fast-mcp-scala.jvm.runMain AnnotatedServer` logs tool registrations to stderr
- [ ] Smoke: drive rewritten HelloWorld / HttpServer through MCP Inspector before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)