### PR TITLE
docs: bump rc2 → rc3 + flag rc2 as broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to fast-mcp-scala will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 0.3.0-rc2: McpServerApp sugar + unified macros
+## [Unreleased] - 0.3.0-rc3: McpServerApp sugar + unified macros
+
+### Fixed
+
+- **`McpServerApp[T, Self]` annotation scan.** The rc2 tag shipped with a silent bug: the inline `scanAnnotationsQuiet[Self]` call expanded with `Self` still abstract at the trait compile site, so every `@Tool` / `@Prompt` / `@Resource` method on a subclass was invisible to MCP clients. rc3 introduces a `SelfScan[Self]` typeclass whose `inline given` expands at the subclass's instantiation site — where `Self` is concrete — so the macro sees the real singleton and registrations fire. No subclass code changes required.
+
+### Deprecated
+
+- **`0.3.0-rc2` is broken.** The artifact exists on Maven Central but the `McpServerApp` sugar trait does not register annotated methods. Do not use it — skip straight to rc3.
 
 ### Added
 - **`McpServerApp[T, Self]` sugar trait** — declarative entry point for building MCP servers. Extend on a top-level object; transport is a phantom type parameter (`Stdio` / `Http`); no `override def run`, no `import zio.*`, no ZIO ceremony in user code. Eight-line Hello World.
@@ -37,7 +45,7 @@ object HelloWorld extends ZIOAppDefault:
       _      <- server.runStdio()
     yield ()
 
-// After (0.3.0-rc2)
+// After (0.3.0-rc3)
 object HelloWorld extends McpServerApp[Stdio, HelloWorld.type]:
   @Tool(name = Some("add"))
   def add(a: Int, b: Int): Int = a + b

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Built on **ZIO 2**, **Tapir**-derived schemas, **Jackson 3** (JVM) / **zio-json*
 
 ```scala 3 ignore
 // JVM — Java SDK-backed runtime with annotations, derived schemas, HTTP + stdio transports.
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.0-rc2"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.0-rc3"
 
 // Scala.js — TS SDK-backed runtime on Bun/Node + the same annotation and typed-contract APIs.
-libraryDependencies += "com.tjclp" %%% "fast-mcp-scala" % "0.3.0-rc2"
+libraryDependencies += "com.tjclp" %%% "fast-mcp-scala" % "0.3.0-rc3"
 ```
 
 Built against Scala 3.8.3. JVM requires JDK 17+. Scala.js artifact is published for `sjs1_3` (Scala.js 1.x); runs on Bun (first-class) and Node 18+.
@@ -53,7 +53,7 @@ A single-file server with one tool — the same code lives in [`HelloWorld.scala
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc2
+//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc3
 //> using options "-Xcheck-macros" "-experimental"
 
 import com.tjclp.fastmcp.*
@@ -300,7 +300,7 @@ Proof: the conformance suite at [`JsServerConformanceTest.scala`](fast-mcp-scala
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala_sjs1:0.3.0-rc2
+//> using dep com.tjclp::fast-mcp-scala_sjs1:0.3.0-rc3
 
 import com.tjclp.fastmcp.*
 
@@ -377,7 +377,7 @@ Add to `claude_desktop_config.json`:
       "command": "scala-cli",
       "args": [
         "-e",
-        "//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc2",
+        "//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc3",
         "--main-class",
         "com.tjclp.fastmcp.examples.AnnotatedServer"
       ]

--- a/scripts/examples.sc
+++ b/scripts/examples.sc
@@ -1,5 +1,5 @@
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc2
+//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc3
 //> using options "-Xcheck-macros" "-experimental"
 
 // Launcher for fast-mcp-scala example servers. Point `scala-cli` at this file and

--- a/scripts/quickstart.sc
+++ b/scripts/quickstart.sc
@@ -1,5 +1,5 @@
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc2
+//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc3
 //> using options "-Xcheck-macros" "-experimental"
 
 import com.tjclp.fastmcp.*


### PR DESCRIPTION
## Summary

Prep for the `v0.3.0-rc3` tag. Steers users away from the broken rc2 artifact and toward the rc3 release that actually works.

## Background

`v0.3.0-rc2` published to Maven Central during this session, but the `McpServerApp` sugar trait in that artifact silently registers zero annotated methods — the inline `scanAnnotationsQuiet[Self]` expanded with `Self` still abstract at the trait compile site. PR #41 fixed it (merged into main as `aaa5f59`) via a `SelfScan[Self]` typeclass whose `inline given` expands at the subclass site where `Self` is concrete.

Maven Central artifacts are immutable, so rc2 stays out there. This PR updates the docs in main so everyone points at rc3 instead.

## Changes

- **CHANGELOG.md** — `Fixed` subsection on top of the rc3 entry describes the scan bug and the `SelfScan` fix. `Deprecated` subsection tells users `0.3.0-rc2` is broken and to skip straight to rc3.
- **README.md** — all 5 coordinate pins bumped `0.3.0-rc2` → `0.3.0-rc3` (installation snippets, quickstart, Running-on-Bun example).
- **scripts/examples.sc + scripts/quickstart.sc** — dep pin bumped.

## Next step

Merge → tag `v0.3.0-rc3` at the new HEAD → release workflow publishes `com.tjclp:fast-mcp-scala_{3,sjs1_3}:0.3.0-rc3` to Maven Central.

🤖 Generated with [Claude Code](https://claude.com/claude-code)