### PR TITLE
docs: fix {*, given} import in quickstart + README snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A single-file server with one tool — the same code lives in [`HelloWorld.scala
 //> using dep com.tjclp::fast-mcp-scala:0.3.0-rc3
 //> using options "-Xcheck-macros" "-experimental"
 
-import com.tjclp.fastmcp.*
+import com.tjclp.fastmcp.{*, given}
 
 object HelloWorld extends McpServerApp[Stdio, HelloWorld.type]:
 
@@ -302,7 +302,7 @@ Proof: the conformance suite at [`JsServerConformanceTest.scala`](fast-mcp-scala
 //> using scala 3.8.3
 //> using dep com.tjclp::fast-mcp-scala_sjs1:0.3.0-rc3
 
-import com.tjclp.fastmcp.*
+import com.tjclp.fastmcp.{*, given}
 
 object HelloBun extends McpServerApp[Stdio, HelloBun.type]:
   @Tool(name = Some("add"), description = Some("Add two numbers"), readOnlyHint = Some(true))

--- a/scripts/quickstart.sc
+++ b/scripts/quickstart.sc
@@ -2,7 +2,7 @@
 //> using dep com.tjclp::fast-mcp-scala:0.3.0-rc3
 //> using options "-Xcheck-macros" "-experimental"
 
-import com.tjclp.fastmcp.*
+import com.tjclp.fastmcp.{*, given}
 
 object Example extends McpServerApp[Stdio, Example.type]:
 


### PR DESCRIPTION
## Summary

rc3 publishes correctly and the library resolves fine, but `scripts/quickstart.sc` hit a compile error:

```
No given instance of type com.tjclp.fastmcp.server.McpServerCoreFactory was found
Note: given instance given_McpServerCoreFactory ... was not considered because it
was not imported with `import given`.
```

Scala 3's `import pkg.*` **excludes givens**. In-repo examples don't hit this because their nested `package com.tjclp.fastmcp; package examples` declaration auto-includes givens from the enclosing package. Scripts without a package need the explicit `.given`.

## Changes

- `scripts/quickstart.sc`: `import com.tjclp.fastmcp.*` → `import com.tjclp.fastmcp.{*, given}`.
- `README.md`: both snippets (hero on line 59, Bun example on line 305) updated to match.

`scripts/examples.sc` is a pure launcher comment file with no Scala imports — unchanged.

## Verification

```bash
scala-cli scripts/quickstart.sc
# should compile + start an MCP server on stdio
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)