### PR TITLE
fix: strip $schema root key from tool inputSchema (#44)

### DIFF
--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/macros/MacroUtils.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/macros/MacroUtils.scala
@@ -545,8 +545,10 @@ private[macros] object MacroUtils:
       )
     }
 
-    // Remove top-level $defs before starting resolution
-    val rootJsonWithoutDefs = inputJson.mapObject(_.remove("$defs"))
+    // Remove top-level $defs and $schema before starting resolution.
+    // $schema (Tapir emits the draft-2020-12 meta-schema URL) violates Anthropic's
+    // tool input_schema key pattern ^[a-zA-Z0-9_.-]{1,64}$ and breaks managed agents. See issue #44.
+    val rootJsonWithoutDefs = inputJson.mapObject(_.remove("$defs").remove("$schema"))
     resolve(rootJsonWithoutDefs, definitions)
   }
 

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/MacroUtilsTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/MacroUtilsTest.scala
@@ -113,6 +113,23 @@ class MacroUtilsTest extends AnyFunSuite { // Ensure this matches the import
     assert(actualJson == expectedJson) // Use ScalaTest's assert
   }
 
+  test("resolveJsonRefs should strip top-level $schema key (issue #44)") {
+    val inputJsonString = """{
+      "$schema": "http://json-schema.org/draft/2020-12/schema#",
+      "type": "object",
+      "properties": { "name": { "type": "string" } }
+    }"""
+    val inputJson = unsafeParse(inputJsonString)
+    val expectedJsonString = """{
+      "type": "object",
+      "properties": { "name": { "type": "string" } }
+    }"""
+    val expectedJson = unsafeParse(expectedJsonString)
+
+    val actualJson = MacroUtils.resolveJsonRefs(inputJson)
+    assert(actualJson == expectedJson)
+  }
+
   // --- injectParamDescriptions Tests ---
 
   test("injectParamDescriptions should add descriptions to properties") {


### PR DESCRIPTION
## Summary

- Tapir's `TapirSchemaToJsonSchema` emits a `"$schema": "http://json-schema.org/draft/2020-12/schema#"` root annotation on every generated schema. Anthropic's tool `input_schema` validator requires every key match `^[a-zA-Z0-9_.-]{1,64}$`, so the leading `$` is rejected — surfacing as `invalid_request_error` in Claude Code and an opaque `model_request_failed_error` in Claude managed agents, which kills the session before any tool call runs.
- `MacroUtils.resolveJsonRefs` already strips the root `$defs` map after inlining every `$ref`; this PR extends that same strip to `$schema`.
- One edit covers both JVM and Scala.js: both `JsonSchemaMacro` entry points (`schemaForFunctionArgsImpl`, `schemaForTypeImpl`) flow through `resolveJsonRefs`, and both `JvmToolSchemaProviders` and `JsToolSchemaProviders` route through `JsonSchemaMacro.schemaForType[A]`.

Fixes #44.

## Risk notes

- Stripping `$defs` at the root is already safe by construction (defs are read into a local `Map` before the root strip, then every `$ref` is inlined).
- `$schema` is a meta-schema URL annotation — removing it has zero behavioral effect on validation.
- `definitions` (JSON Schema draft-07 legacy key) does not apply: Tapir is called with its default `MetaSchemaDraft202012`, which emits `$defs`. Grep confirms no `"definitions":` key anywhere in source or tests.
- Pre-existing latent issue (out of scope): `resolve()` has no cycle detection; a recursive case-class argument type would stack-overflow today. Filing a follow-up — no real-world MCP servers use recursive tool argument schemas, so this is defensive hardening rather than a correctness gap.

## Test plan

- [x] `./mill fast-mcp-scala.jvm.test.testOnly com.tjclp.fastmcp.macros.MacroUtilsTest` — 22/22 pass, including new `resolveJsonRefs should strip top-level $schema key (issue #44)` case
- [x] `./mill fast-mcp-scala.jvm.test` — full JVM suite green
- [x] `./mill fast-mcp-scala.checkFormat` — clean
- [ ] End-to-end sanity after merge: connect a fast-mcp-scala server to a Claude managed agent and confirm `tools/list` responses no longer carry `$schema` at the root

🤖 Generated with [Claude Code](https://claude.com/claude-code)