### PR TITLE
docs: bump rc3 → rc4 + flag rc3 as broken on Anthropic clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,17 @@ All notable changes to fast-mcp-scala will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 0.3.0-rc3: McpServerApp sugar + unified macros
+## [Unreleased] - 0.3.0-rc4: Strip `$schema` root key from tool inputSchema
 
 ### Fixed
 
+- **`$schema` root key in generated tool `inputSchema` breaks Anthropic clients.** Tapir's `TapirSchemaToJsonSchema` emits a `"$schema": "http://json-schema.org/draft/2020-12/schema#"` annotation on every generated schema. Anthropic validates tool `input_schema` keys against `^[a-zA-Z0-9_.-]{1,64}$`, so the leading `$` triggers `invalid_request_error` in Claude Code and an opaque `model_request_failed_error` in Claude managed agents — killing the session before any tool call runs. `MacroUtils.resolveJsonRefs` now strips the root `$schema` key alongside `$defs`. See issue #44.
 - **`McpServerApp[T, Self]` annotation scan.** The rc2 tag shipped with a silent bug: the inline `scanAnnotationsQuiet[Self]` call expanded with `Self` still abstract at the trait compile site, so every `@Tool` / `@Prompt` / `@Resource` method on a subclass was invisible to MCP clients. rc3 introduces a `SelfScan[Self]` typeclass whose `inline given` expands at the subclass's instantiation site — where `Self` is concrete — so the macro sees the real singleton and registrations fire. No subclass code changes required.
 
 ### Deprecated
 
-- **`0.3.0-rc2` is broken.** The artifact exists on Maven Central but the `McpServerApp` sugar trait does not register annotated methods. Do not use it — skip straight to rc3.
+- **`0.3.0-rc2` is broken.** The artifact exists on Maven Central but the `McpServerApp` sugar trait does not register annotated methods. Do not use it — skip straight to rc4.
+- **`0.3.0-rc3` is broken on Anthropic clients.** Every tool registered via `@Tool` or `McpTool` ships a `$schema` root key in its `inputSchema` that Anthropic's tool_use validator rejects — Claude Code surfaces `invalid_request_error`, and Claude managed agents surface an opaque `model_request_failed_error` that kills the session before any tool call runs. Do not use rc3 with Anthropic clients — skip to rc4.
 
 ### Added
 - **`McpServerApp[T, Self]` sugar trait** — declarative entry point for building MCP servers. Extend on a top-level object; transport is a phantom type parameter (`Stdio` / `Http`); no `override def run`, no `import zio.*`, no ZIO ceremony in user code. Eight-line Hello World.
@@ -45,7 +47,7 @@ object HelloWorld extends ZIOAppDefault:
       _      <- server.runStdio()
     yield ()
 
-// After (0.3.0-rc3)
+// After (0.3.0-rc4)
 object HelloWorld extends McpServerApp[Stdio, HelloWorld.type]:
   @Tool(name = Some("add"))
   def add(a: Int, b: Int): Int = a + b

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Built on **ZIO 2**, **Tapir**-derived schemas, **Jackson 3** (JVM) / **zio-json*
 
 ```scala 3 ignore
 // JVM — Java SDK-backed runtime with annotations, derived schemas, HTTP + stdio transports.
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.0-rc3"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.0-rc4"
 
 // Scala.js — TS SDK-backed runtime on Bun/Node + the same annotation and typed-contract APIs.
-libraryDependencies += "com.tjclp" %%% "fast-mcp-scala" % "0.3.0-rc3"
+libraryDependencies += "com.tjclp" %%% "fast-mcp-scala" % "0.3.0-rc4"
 ```
 
 Built against Scala 3.8.3. JVM requires JDK 17+. Scala.js artifact is published for `sjs1_3` (Scala.js 1.x); runs on Bun (first-class) and Node 18+.
@@ -53,7 +53,7 @@ A single-file server with one tool — the same code lives in [`HelloWorld.scala
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc3
+//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc4
 //> using options "-Xcheck-macros" "-experimental"
 
 import com.tjclp.fastmcp.{*, given}
@@ -300,7 +300,7 @@ Proof: the conformance suite at [`JsServerConformanceTest.scala`](fast-mcp-scala
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala_sjs1:0.3.0-rc3
+//> using dep com.tjclp::fast-mcp-scala_sjs1:0.3.0-rc4
 
 import com.tjclp.fastmcp.{*, given}
 
@@ -377,7 +377,7 @@ Add to `claude_desktop_config.json`:
       "command": "scala-cli",
       "args": [
         "-e",
-        "//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc3",
+        "//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc4",
         "--main-class",
         "com.tjclp.fastmcp.examples.AnnotatedServer"
       ]

--- a/scripts/examples.sc
+++ b/scripts/examples.sc
@@ -1,5 +1,5 @@
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc3
+//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc4
 //> using options "-Xcheck-macros" "-experimental"
 
 // Launcher for fast-mcp-scala example servers. Point `scala-cli` at this file and

--- a/scripts/quickstart.sc
+++ b/scripts/quickstart.sc
@@ -1,5 +1,5 @@
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc3
+//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc4
 //> using options "-Xcheck-macros" "-experimental"
 
 import com.tjclp.fastmcp.{*, given}


### PR DESCRIPTION
## Summary

Prep for the `v0.3.0-rc4` tag. Steers users away from the rc3 artifact that breaks against Claude Code and Claude managed agents toward the rc4 release that actually works with Anthropic products.

## Background

rc3 published to Maven Central, but every tool it registers emits a `"$schema": "http://json-schema.org/draft/2020-12/schema#"` root key in its `inputSchema`. Anthropic's tool-use validator rejects keys with `$` — Claude Code surfaces `invalid_request_error`, Claude managed agents surface an opaque `model_request_failed_error` that kills the session before any tool call runs. Since Anthropic products are the primary target for fast-mcp-scala users, rc3 is effectively unusable.

PR #45 (merged as `d952be5`) fixed the root cause — `MacroUtils.resolveJsonRefs` now strips `$schema` alongside `$defs`. Maven Central artifacts are immutable, so rc3 stays out there; this PR updates the docs in main so everyone points at rc4 instead.

## Changes

- **CHANGELOG.md** — new `Fixed` entry at the top of the rc4 section describing the `$schema` strip and its Anthropic-client impact. New `Deprecated` entry explaining why rc3 is broken on Anthropic clients (the rc2-is-broken notice stays for historical context). rc3 heading rolls forward to rc4.
- **README.md** — all 5 coordinate pins bumped `0.3.0-rc3` → `0.3.0-rc4` (installation snippets, quickstart, Running-on-Bun example).
- **scripts/examples.sc + scripts/quickstart.sc** — dep pin bumped.

## Next step

Merge → tag `v0.3.0-rc4` at the new HEAD → release workflow publishes `com.tjclp:fast-mcp-scala_{3,sjs1_3}:0.3.0-rc4` to Maven Central.

🤖 Generated with [Claude Code](https://claude.com/claude-code)