### PR TITLE
chore: Prepare v0.3.0 release notes and version references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to fast-mcp-scala will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 0.3.0-rc5: GraalVM native-image reachability metadata
+## [0.3.0] - 2026-04-22
 
 ### Added
 
 - **GraalVM native-image reachability metadata** shipped with the JVM artifact at `META-INF/native-image/com.tjclp/fast-mcp-scala_3/reachability-metadata.json`. Covers Jackson record introspection over `io.modelcontextprotocol.spec.McpSchema$*`, zio-json's derivation, reactor-core, izumi-reflect, and `JacksonConversionContext`. Downstream apps can now build a working `native-image` of a fast-mcp-scala stdio server with zero hand-written config — just add `mill.javalib.NativeImageModule` and `jvmId = "graalvm-community:25.0.1"`. Covers initialize / notifications/initialized / tools/list / tools/call / ping / resources/list / prompts/list — the full protocol surface the Claude Agent SDK exercises during handshake.
+
+See the `[0.3.0-rc4]` section below for the cumulative rc1..rc4 changes rolled into this release (shared typed contracts, `McpServerApp` sugar, Jackson 3 migration, cross-platform Scala.js split, unified HTTP transport, MCP Tool Annotations, `$schema` key fix).
 
 ## [0.3.0-rc4] - Strip `$schema` root key from tool inputSchema
 
@@ -84,29 +86,6 @@ val server: McpServer = concrete
 val settings = McpServerSettings(port = 8090)
 val server: McpServerCore = concrete
 ```
-
-## [0.3.0] - Cross-Platform Contracts & Jackson 3 (2026-04-16)
-
-### Added
-- Shared typed contract layer — `McpTool`, `McpPrompt`, `McpStaticResource`, `McpTemplateResource` with platform-neutral `McpDecoder` / `McpEncoder` codecs (#32)
-- Cross-platform Scala.js support via `shared/src/` + `src/` (JVM) + `js/src/` layout; typed contracts compile to Scala.js, and a JS conformance test harness exercises the JVM server over stdio (#30)
-- MCP Tool Annotations support — `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`, `returnDirect` on `@Tool` (#29)
-- Unified HTTP transport: `runHttp()` with Streamable HTTP (sessions + SSE) as default and `stateless = true` opt-in (#26, #27, #28)
-
-### Changed (breaking)
-- **Jackson 3 migration** (#31): dropped `jackson-databind 2.x` and `jackson-module-scala` / `jackson-datatype-jdk8` / `jackson-datatype-jsr310` for `tools.jackson 3.0.3` (native Scala and `java.time` support). Custom `JacksonConverter` implementations now receive a `JacksonConversionContext` instead of raw `JsonMapper` + `ClassTagExtensions`. Java MCP SDK binding switched from `mcp-json-jackson2` to `mcp-json-jackson3`.
-- **Removed deprecated annotations**: `@ToolParam`, `@ResourceParam`, `@PromptParam` — use `@Param` (deprecated in 0.2.1; scheduled for removal in 0.3.0).
-- Module layout: `fast-mcp-scala/shared/src/` and `fast-mcp-scala/js/src/` are new source roots; consumers wiring the project as a git submodule or with custom build logic may need to update paths.
-- Scala 3.8.1 → 3.8.3, WartRemover 3.5.5 → 3.5.6 (#33).
-- Java MCP SDK `0.17.2` → `1.1.1` (`mcp-core` + `mcp-json-jackson3`).
-
-### Migration
-Two places most users will feel the upgrade:
-
-1. **`@Param` only**: replace any remaining `@ToolParam` / `@ResourceParam` / `@PromptParam` with `@Param` (deprecated since 0.2.1; removed in 0.3.0).
-2. **Custom Jackson converters**: if you defined a `given JacksonConverter[T]` that accessed `JsonMapper` directly, switch to the `JacksonConversionContext` argument — see `docs/jackson-converter-enhancements.md`.
-
-The annotation-driven path (`@Tool` + `scanAnnotations`) and the default decoders require no changes.
 
 ## [0.2.3] - Bug Fix Release (2026-02-16)
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Built on **ZIO 2**, **Tapir**-derived schemas, **Jackson 3** (JVM) / **zio-json*
 
 ```scala 3 ignore
 // JVM — Java SDK-backed runtime with annotations, derived schemas, HTTP + stdio transports.
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.0-rc4"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.0"
 
 // Scala.js — TS SDK-backed runtime on Bun/Node + the same annotation and typed-contract APIs.
-libraryDependencies += "com.tjclp" %%% "fast-mcp-scala" % "0.3.0-rc4"
+libraryDependencies += "com.tjclp" %%% "fast-mcp-scala" % "0.3.0"
 ```
 
 Built against Scala 3.8.3. JVM requires JDK 17+. Scala.js artifact is published for `sjs1_3` (Scala.js 1.x); runs on Bun (first-class) and Node 18+.
@@ -53,7 +53,7 @@ A single-file server with one tool — the same code lives in [`HelloWorld.scala
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc4
+//> using dep com.tjclp::fast-mcp-scala:0.3.0
 //> using options "-Xcheck-macros" "-experimental"
 
 import com.tjclp.fastmcp.{*, given}
@@ -300,7 +300,7 @@ Proof: the conformance suite at [`JsServerConformanceTest.scala`](fast-mcp-scala
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala_sjs1:0.3.0-rc4
+//> using dep com.tjclp::fast-mcp-scala_sjs1:0.3.0
 
 import com.tjclp.fastmcp.{*, given}
 
@@ -377,7 +377,7 @@ Add to `claude_desktop_config.json`:
       "command": "scala-cli",
       "args": [
         "-e",
-        "//> using dep com.tjclp::fast-mcp-scala:0.3.0-rc4",
+        "//> using dep com.tjclp::fast-mcp-scala:0.3.0",
         "--main-class",
         "com.tjclp.fastmcp.examples.AnnotatedServer"
       ]


### PR DESCRIPTION
## Summary

- **CHANGELOG**: promote `[Unreleased]` → `[0.3.0] - 2026-04-22`; keep the `[0.3.0-rc4]` section intact as the cumulative rc1..rc4 notes; delete the stale `[0.3.0] - Cross-Platform Contracts & Jackson 3 (2026-04-16)` header (it was written pre-RC-cycle and is superseded by rc4).
- **README**: bump the five user-facing install snippets from `0.3.0-rc4` → `0.3.0` (L42, L45, L56, L303, L380). The two "Developing locally" snippets referencing `0.3.0-SNAPSHOT` (L418, L425) stay as-is and will bump to `0.4.0-SNAPSHOT` in the post-release follow-up.
- **No code changes.** `build.mill` default remains `0.3.0-SNAPSHOT`; the release workflow (`.github/workflows/release.yml`) sets `PUBLISH_VERSION` from the `v0.3.0` tag.

## Release sequence after merge

1. Merge this PR to `main`.
2. Tag the merge commit on `main`: `git tag -a v0.3.0 -m "v0.3.0" && git push origin v0.3.0`.
3. Release workflow publishes `com.tjclp:fast-mcp-scala_3:0.3.0` and `com.tjclp:fast-mcp-scala_sjs1_3:0.3.0` to Maven Central and creates a non-prerelease GitHub release (auto-flagged as `Latest` because the tag has no `-qualifier`).

## Deferred to follow-up

- `@deprecated("Use McpServerSettings", since = "0.3.0-rc2")` on `FastMcpServerSettings` type/val alias at `fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServerSettings.scala:27-32` stays in 0.3.x — CHANGELOG explicitly promised "one release cycle." Removal target is 0.4.0.

## Test plan

- [x] `./mill fast-mcp-scala.checkFormat` — 0 violations
- [x] `./mill fast-mcp-scala.test` — 39/39 passing (JVM + Bun conformance + shared contract surface)
- [ ] CI green on this PR (JDK 17, 21, 24)
- [ ] After merge: `v0.3.0` tag triggers Sonatype Central publish
- [ ] Verify `https://central.sonatype.com/artifact/com.tjclp/fast-mcp-scala_3/0.3.0` shows the new artifact
- [ ] (Optional) Build an example against `0.3.0` with `mill.javalib.NativeImageModule` to validate the GraalVM reachability metadata end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)