### PR TITLE
Release v0.3.1: ship BunPublishModule for JS/TS dep propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to fast-mcp-scala will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.1] - 2026-04-22
+
+### Added
+
+- **`BunPublishModule` mixin on the Scala.js artifact.** `fast-mcp-scala_sjs1_3` now publishes with `META-INF/bun/bun-dependencies.json` embedded in the JAR, listing the runtime JS dependencies (`@modelcontextprotocol/sdk@1.29.0`, `zod@4.3.6`, `zod-to-json-schema@3.25.1`). Downstream Scala.js consumers that use `BunScalaJSModule` (from `mill-bun-plugin` 0.2.0+) pick these up automatically via `classpathBunManifests` — no need to redeclare the SDK in their own `bunDeps`. Manifest-only by default (cross-platform safe); set `bunPublishVendoredRuntime = true` to also embed a resolved `node_modules/` tree.
 
 ## [0.3.0] - 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to fast-mcp-scala will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.3.0] - 2026-04-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,7 @@ rm -rf out/fast-mcp-scala && ./mill fast-mcp-scala.compile
 ./mill -i __.publishLocal
 ```
 
-Then in your project use version `0.3.0-SNAPSHOT`.
+Then in your project use version `0.3.1-SNAPSHOT`.
 
 ## Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,7 @@ rm -rf out/fast-mcp-scala && ./mill fast-mcp-scala.compile
 ./mill -i __.publishLocal
 ```
 
-Then in your project use version `0.3.1-SNAPSHOT`.
+Then in your project use version `0.3.1`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Built on **ZIO 2**, **Tapir**-derived schemas, **Jackson 3** (JVM) / **zio-json*
 
 ```scala 3 ignore
 // JVM — Java SDK-backed runtime with annotations, derived schemas, HTTP + stdio transports.
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.0"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.1"
 
 // Scala.js — TS SDK-backed runtime on Bun/Node + the same annotation and typed-contract APIs.
-libraryDependencies += "com.tjclp" %%% "fast-mcp-scala" % "0.3.0"
+libraryDependencies += "com.tjclp" %%% "fast-mcp-scala" % "0.3.1"
 ```
 
 Built against Scala 3.8.3. JVM requires JDK 17+. Scala.js artifact is published for `sjs1_3` (Scala.js 1.x); runs on Bun (first-class) and Node 18+.
@@ -53,7 +53,7 @@ A single-file server with one tool — the same code lives in [`HelloWorld.scala
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala:0.3.0
+//> using dep com.tjclp::fast-mcp-scala:0.3.1
 //> using options "-Xcheck-macros" "-experimental"
 
 import com.tjclp.fastmcp.{*, given}
@@ -300,7 +300,7 @@ Proof: the conformance suite at [`JsServerConformanceTest.scala`](fast-mcp-scala
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala_sjs1:0.3.0
+//> using dep com.tjclp::fast-mcp-scala_sjs1:0.3.1
 
 import com.tjclp.fastmcp.{*, given}
 
@@ -377,7 +377,7 @@ Add to `claude_desktop_config.json`:
       "command": "scala-cli",
       "args": [
         "-e",
-        "//> using dep com.tjclp::fast-mcp-scala:0.3.0",
+        "//> using dep com.tjclp::fast-mcp-scala:0.3.1",
         "--main-class",
         "com.tjclp.fastmcp.examples.AnnotatedServer"
       ]
@@ -415,14 +415,14 @@ For architectural detail, see [`docs/architecture.md`](docs/architecture.md).
 After `publishLocal`:
 
 ```scala 3 ignore
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.1-SNAPSHOT"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.1"
 ```
 
 Or with Mill:
 
 ```scala 3 ignore
 def ivyDeps = Agg(
-  ivy"com.tjclp::fast-mcp-scala:0.3.1-SNAPSHOT"
+  ivy"com.tjclp::fast-mcp-scala:0.3.1"
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -415,14 +415,14 @@ For architectural detail, see [`docs/architecture.md`](docs/architecture.md).
 After `publishLocal`:
 
 ```scala 3 ignore
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.0-SNAPSHOT"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.1-SNAPSHOT"
 ```
 
 Or with Mill:
 
 ```scala 3 ignore
 def ivyDeps = Agg(
-  ivy"com.tjclp::fast-mcp-scala:0.3.0-SNAPSHOT"
+  ivy"com.tjclp::fast-mcp-scala:0.3.1-SNAPSHOT"
 )
 ```
 

--- a/build.mill
+++ b/build.mill
@@ -93,7 +93,7 @@ trait FastMCPPublishingBase extends PublishModule {
 
   /** Version derived from PUBLISH_VERSION env var (set by CI), or SNAPSHOT for local dev */
   override def publishVersion: T[String] =
-    sys.env.getOrElse("PUBLISH_VERSION", "0.3.0-SNAPSHOT")
+    sys.env.getOrElse("PUBLISH_VERSION", "0.3.1-SNAPSHOT")
 
   override def pomSettings: T[PomSettings] = PomSettings(
     description = artifactDescription,

--- a/build.mill
+++ b/build.mill
@@ -93,7 +93,7 @@ trait FastMCPPublishingBase extends PublishModule {
 
   /** Version derived from PUBLISH_VERSION env var (set by CI), or SNAPSHOT for local dev */
   override def publishVersion: T[String] =
-    sys.env.getOrElse("PUBLISH_VERSION", "0.3.1-SNAPSHOT")
+    sys.env.getOrElse("PUBLISH_VERSION", "0.3.1")
 
   override def pomSettings: T[PomSettings] = PomSettings(
     description = artifactDescription,
@@ -194,7 +194,7 @@ object `fast-mcp-scala` extends Module {
 
   // Scala.js backend — wraps the TS MCP SDK server on Bun to provide a real cross-platform
   // MCP server runtime. Cross-published to Maven Central as `com.tjclp:fast-mcp-scala_sjs1_3`.
-  object js extends BunScalaJSModule with ScalafmtModule with FastMCPPublishingBase {
+  object js extends BunScalaJSModule with BunPublishModule with ScalafmtModule with FastMCPPublishingBase {
     def scalaVersion = scala3Version
 
     override def moduleKind = Task { ModuleKind.ESModule }


### PR DESCRIPTION
## Summary

Going straight to **v0.3.1 release** (skipping the usual 0.X.Y-SNAPSHOT dev cycle) to ship one small additive feature on top of v0.3.0.

### Feature: BunPublishModule on the Scala.js artifact

`fast-mcp-scala_sjs1_3` now mixes in `BunPublishModule` from mill-bun-plugin (0.2.1). The published JAR carries `META-INF/bun/bun-dependencies.json` listing the runtime JS dependencies:

```json
{
  "dependencies": {
    "@modelcontextprotocol/sdk": "1.29.0",
    "zod": "4.3.6",
    "zod-to-json-schema": "3.25.1"
  },
  "devDependencies": {}
}
```

Downstream Scala.js consumers that use `BunScalaJSModule` (mill-bun-plugin 0.2.0+) pick these up automatically via `classpathBunManifests` — no need to redeclare the SDK in their own `bunDeps`. Manifest-only by default (cross-platform safe); set `bunPublishVendoredRuntime = true` to also embed a resolved `node_modules/` tree.

Verified by `unzip -p out/fast-mcp-scala/js/jar.dest/out.jar META-INF/bun/bun-dependencies.json` — manifest ships correctly.

### Version bumps

- `build.mill:96`: default `publishVersion` → `0.3.1` (deviates from the usual `-SNAPSHOT` default; user call)
- `build.mill:197`: `js` module picks up `with BunPublishModule`
- `README.md`: all install + publishLocal snippets → `0.3.1`
- `CLAUDE.md:223`: publishLocal reference → `0.3.1`
- `CHANGELOG.md`: new `[0.3.1] - 2026-04-22` section with feature bullet; `[Unreleased]` header removed

## Release sequence after merge

1. Merge this PR to `main`.
2. Tag the merge commit: `git tag -a v0.3.1 -m "v0.3.1" && git push origin v0.3.1`.
3. Release workflow publishes `com.tjclp:fast-mcp-scala_3:0.3.1` + `_sjs1_3:0.3.1` to Sonatype Central and creates a non-prerelease GitHub release.

## Test plan

- [x] `./mill fast-mcp-scala.checkFormat` — 0 violations
- [x] `./mill fast-mcp-scala.test` — 39/39 passing (JVM + Bun conformance + shared contract surface)
- [x] `unzip -p out/fast-mcp-scala/js/jar.dest/out.jar META-INF/bun/bun-dependencies.json` — manifest present with expected content
- [ ] CI green on this PR (JDK 17, 21, 24)
- [ ] After merge + tag: Sonatype Central shows `com.tjclp:fast-mcp-scala_sjs1_3:0.3.1` and the JAR contains the manifest
- [ ] (Optional) Consume `0.3.1` in a scratch `BunScalaJSModule` downstream, confirm `@modelcontextprotocol/sdk` resolves without explicit `bunDeps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)