### PR TITLE
fix: execute ZIO/Try/Either returns in @Tool/@Resource/@Prompt macros (#50)

### DIFF
--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/macros/MacroUtils.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/macros/MacroUtils.scala
@@ -498,6 +498,43 @@ private[macros] object MacroUtils:
   def invokeFunctionWithArgs(function: Any, args: List[Any]): Any =
     RefResolver.invokeFunctionWithArgs(function, args)
 
+  /** Effect shape detected on an annotated method's dealiased return type.
+    *
+    * Drives whether the macro-generated handler treats the method result as a pure value (wrap in
+    * `ZIO.attempt`) or as an effect that must be flattened (`ZIO`, `Try`, `Either[Throwable, _]`).
+    * Mirrors the typed-contract `ToHandlerEffect` typeclass.
+    */
+  private[macros] enum EffectShape:
+    case Pure, Zio, TryEffect, EitherThrowable
+
+  /** Classify the return type of a `@Tool` / `@Resource` / `@Prompt` method.
+    *
+    * Aborts at macro time if the method returns a `ZIO` with a non-`Any` environment, since the
+    * shared handler signature `(args, ctx) => ZIO[Any, Throwable, Any]` cannot satisfy an
+    * environment requirement.
+    */
+  private[macros] def detectEffectShape(using quotes: Quotes)(
+      methodSym: quotes.reflect.Symbol
+  ): EffectShape =
+    import quotes.reflect.*
+
+    val resType = (methodSym.info match
+      case mt: MethodType => mt.resType
+      case other => other
+    ).dealias
+
+    if resType <:< TypeRepr.of[zio.ZIO[Any, Any, Any]] then EffectShape.Zio
+    else if resType <:< TypeRepr.of[zio.ZIO[Nothing, Any, Any]] then
+      report.errorAndAbort(
+        s"Annotated method '${methodSym.name}' returns ${resType.show}; " +
+          "annotation-based handlers must return ZIO with environment Any. " +
+          "Provide the environment via ZIO.provide(...) inside the method body, " +
+          "or use a typed contract (McpTool.derived) for environment-dependent effects."
+      )
+    else if resType <:< TypeRepr.of[scala.util.Try[Any]] then EffectShape.TryEffect
+    else if resType <:< TypeRepr.of[Either[Throwable, Any]] then EffectShape.EitherThrowable
+    else EffectShape.Pure
+
   /** Takes a JSON schema potentially containing `$defs` and `$ref` and returns a new JSON schema
     * where all references are resolved and inlined.
     */

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/EffectReturnTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/EffectReturnTest.scala
@@ -1,0 +1,168 @@
+package com.tjclp.fastmcp
+package macros
+
+import scala.util.{Failure, Success, Try}
+
+import org.scalatest.funsuite.AnyFunSuite
+import zio.*
+
+import com.tjclp.fastmcp.core.*
+import com.tjclp.fastmcp.macros.JacksonConverter.given
+import com.tjclp.fastmcp.macros.RegistrationMacro.scanAnnotations
+import com.tjclp.fastmcp.server.*
+
+/** Verifies that `@Tool` / `@Resource` / `@Prompt` macros honor effect-shaped return types (ZIO,
+  * Try, Either[Throwable, _]) instead of stringifying the unexecuted effect — issue #50.
+  */
+class EffectReturnTest extends AnyFunSuite:
+
+  private def runTool(server: FastMcpServer, name: String, args: Map[String, Any]): Any =
+    Unsafe.unsafe { implicit unsafe =>
+      Runtime.default.unsafe
+        .run(server.toolManager.callTool(name, args, None))
+        .getOrThrowFiberFailure()
+    }
+
+  private def runToolExit(
+      server: FastMcpServer,
+      name: String,
+      args: Map[String, Any]
+  ): Exit[Throwable, Any] =
+    Unsafe.unsafe { implicit unsafe =>
+      Runtime.default.unsafe.run(server.toolManager.callTool(name, args, None))
+    }
+
+  test("@Tool returning UIO[Int] executes the effect (issue #50 repro)") {
+    val server = new FastMcpServer("EffectReturnUio", "0.1.0")
+    server.scanAnnotations[EffectReturnTest.type]
+
+    val result = runTool(server, "addZio", Map("a" -> 3, "b" -> 4))
+    assert(result == 7)
+    assert(!result.toString.contains("ZIO"), s"Result should not be a ZIO toString: $result")
+  }
+
+  test("@Tool returning Task[String] executes and returns the value") {
+    val server = new FastMcpServer("EffectReturnTask", "0.1.0")
+    server.scanAnnotations[EffectReturnTest.type]
+
+    val result = runTool(server, "shoutZio", Map("text" -> "hello"))
+    assert(result == "HELLO")
+  }
+
+  test("@Tool returning failed Task surfaces the Throwable") {
+    val server = new FastMcpServer("EffectReturnTaskFail", "0.1.0")
+    server.scanAnnotations[EffectReturnTest.type]
+
+    val exit = runToolExit(server, "boomZio", Map.empty)
+    assert(exit.isFailure, s"Expected failure exit, got: $exit")
+    val cause = exit.causeOption.get
+    val defects = cause.failures ++ cause.defects
+    assert(
+      defects.exists(_.getMessage.contains("kaboom")),
+      s"Expected Throwable with 'kaboom', got: $defects"
+    )
+  }
+
+  test("@Tool returning IO[String, Int] wraps non-Throwable failures in RuntimeException") {
+    val server = new FastMcpServer("EffectReturnIo", "0.1.0")
+    server.scanAnnotations[EffectReturnTest.type]
+
+    val exit = runToolExit(server, "divideIo", Map("a" -> 10, "b" -> 0))
+    assert(exit.isFailure)
+    val cause = exit.causeOption.get
+    val failures = cause.failures
+    assert(failures.exists(t => t.isInstanceOf[RuntimeException] && t.getMessage.contains("divide by zero")))
+  }
+
+  test("@Tool returning Try[Int] success returns the value") {
+    val server = new FastMcpServer("EffectReturnTry", "0.1.0")
+    server.scanAnnotations[EffectReturnTest.type]
+
+    val result = runTool(server, "addTry", Map("a" -> 2, "b" -> 5))
+    assert(result == 7)
+  }
+
+  test("@Tool returning Try[Int] failure surfaces the Throwable") {
+    val server = new FastMcpServer("EffectReturnTryFail", "0.1.0")
+    server.scanAnnotations[EffectReturnTest.type]
+
+    val exit = runToolExit(server, "addTry", Map("a" -> -1, "b" -> 0))
+    assert(exit.isFailure)
+    val cause = exit.causeOption.get
+    assert(cause.failures.exists(_.getMessage.contains("negative")))
+  }
+
+  test("@Tool returning Either[Throwable, Int] success returns the value") {
+    val server = new FastMcpServer("EffectReturnEither", "0.1.0")
+    server.scanAnnotations[EffectReturnTest.type]
+
+    val result = runTool(server, "addEither", Map("a" -> 8, "b" -> 9))
+    assert(result == 17)
+  }
+
+  test("@Tool returning Either[Throwable, Int] Left surfaces the Throwable") {
+    val server = new FastMcpServer("EffectReturnEitherFail", "0.1.0")
+    server.scanAnnotations[EffectReturnTest.type]
+
+    val exit = runToolExit(server, "addEither", Map("a" -> -1, "b" -> -1))
+    assert(exit.isFailure)
+    val cause = exit.causeOption.get
+    assert(cause.failures.exists(_.getMessage.contains("both negative")))
+  }
+
+  test("@Resource returning UIO[String] executes the effect") {
+    val server = new FastMcpServer("EffectReturnResource", "0.1.0")
+    server.scanAnnotations[EffectReturnTest.type]
+
+    val result = Unsafe.unsafe { implicit unsafe =>
+      Runtime.default.unsafe
+        .run(server.resourceManager.readResource("greeting://zio", None))
+        .getOrThrowFiberFailure()
+    }
+    assert(result == "hello-from-zio", s"Expected unwrapped string, got: $result")
+  }
+
+  test("@Prompt returning UIO[List[Message]] executes the effect") {
+    val server = new FastMcpServer("EffectReturnPrompt", "0.1.0")
+    server.scanAnnotations[EffectReturnTest.type]
+
+    val result = Unsafe.unsafe { implicit unsafe =>
+      Runtime.default.unsafe
+        .run(server.promptManager.getPrompt("zio-prompt", Map("topic" -> "scala"), None))
+        .getOrThrowFiberFailure()
+    }
+    val texts = result.map(_.content).collect { case t: TextContent => t.text }
+    assert(texts.exists(_.contains("scala")), s"Expected message containing 'scala', got: $texts")
+  }
+
+object EffectReturnTest:
+
+  @Tool(name = Some("addZio"), description = Some("Add via UIO"))
+  def addZio(@Param("a") a: Int, @Param("b") b: Int): UIO[Int] = ZIO.succeed(a + b)
+
+  @Tool(name = Some("shoutZio"), description = Some("Uppercase via Task"))
+  def shoutZio(@Param("text") text: String): Task[String] = ZIO.attempt(text.toUpperCase)
+
+  @Tool(name = Some("boomZio"), description = Some("Always fails"))
+  def boomZio(): Task[Int] = ZIO.fail(new RuntimeException("kaboom"))
+
+  @Tool(name = Some("divideIo"), description = Some("Divide with non-Throwable error"))
+  def divideIo(@Param("a") a: Int, @Param("b") b: Int): IO[String, Int] =
+    if b == 0 then ZIO.fail("divide by zero") else ZIO.succeed(a / b)
+
+  @Tool(name = Some("addTry"), description = Some("Add via Try"))
+  def addTry(@Param("a") a: Int, @Param("b") b: Int): Try[Int] =
+    if a < 0 then Failure(new IllegalArgumentException("negative input"))
+    else Success(a + b)
+
+  @Tool(name = Some("addEither"), description = Some("Add via Either[Throwable, Int]"))
+  def addEither(@Param("a") a: Int, @Param("b") b: Int): Either[Throwable, Int] =
+    if a < 0 && b < 0 then Left(new IllegalArgumentException("both negative"))
+    else Right(a + b)
+
+  @Resource(uri = "greeting://zio", description = Some("Greeting via UIO"))
+  def greetingZio(): UIO[String] = ZIO.succeed("hello-from-zio")
+
+  @Prompt(name = Some("zio-prompt"), description = Some("Prompt via UIO"))
+  def zioPrompt(@Param("topic") topic: String): UIO[List[Message]] =
+    ZIO.succeed(List(Message(role = Role.User, content = TextContent(s"talk about $topic"))))

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/PromptProcessor.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/PromptProcessor.scala
@@ -40,25 +40,73 @@ private[macros] object PromptProcessor extends AnnotationProcessorBase:
 
     val methodRefExpr = methodRef(ownerSym, methodSym)
 
+    val coerceMessages: Expr[Any => List[Message]] = '{ (anyResult: Any) =>
+      anyResult match
+        case msgs: List[?] if msgs.nonEmpty && msgs.head.isInstanceOf[Message] =>
+          msgs.asInstanceOf[List[Message]]
+        case s: String =>
+          List(Message(role = Role.User, content = TextContent(s)))
+        case other =>
+          List(Message(role = Role.User, content = TextContent(other.toString)))
+    }
+
+    val handler: Expr[Map[String, Any] => ZIO[Any, Throwable, List[Message]]] =
+      MacroUtils.detectEffectShape(methodSym) match
+        case MacroUtils.EffectShape.Pure =>
+          '{ (args: Map[String, Any]) =>
+            ZIO.attempt {
+              val result = MapToFunctionMacro
+                .callByMap($methodRefExpr)
+                .asInstanceOf[Map[String, Any] => Any](args)
+              $coerceMessages(result)
+            }
+          }
+        case MacroUtils.EffectShape.Zio =>
+          '{ (args: Map[String, Any]) =>
+            ZIO
+              .suspend {
+                MapToFunctionMacro
+                  .callByMap($methodRefExpr)
+                  .asInstanceOf[Map[String, Any] => Any](args)
+                  .asInstanceOf[ZIO[Any, Any, Any]]
+                  .mapError {
+                    case t: Throwable => t
+                    case other => new RuntimeException(s"Prompt error: $other")
+                  }
+              }
+              .map($coerceMessages)
+          }
+        case MacroUtils.EffectShape.TryEffect =>
+          '{ (args: Map[String, Any]) =>
+            ZIO
+              .suspend {
+                val result = MapToFunctionMacro
+                  .callByMap($methodRefExpr)
+                  .asInstanceOf[Map[String, Any] => Any](args)
+                  .asInstanceOf[scala.util.Try[Any]]
+                ZIO.fromTry(result)
+              }
+              .map($coerceMessages)
+          }
+        case MacroUtils.EffectShape.EitherThrowable =>
+          '{ (args: Map[String, Any]) =>
+            ZIO
+              .suspend {
+                val result = MapToFunctionMacro
+                  .callByMap($methodRefExpr)
+                  .asInstanceOf[Map[String, Any] => Any](args)
+                  .asInstanceOf[Either[Throwable, Any]]
+                ZIO.fromEither(result)
+              }
+              .map($coerceMessages)
+          }
+
     val registration: Expr[ZIO[Any, Throwable, McpServerCore]] = '{
       $server.prompt(
         name = ${ Expr(finalName) },
         description = ${ Expr(finalDesc) },
         arguments = $maybeArgs,
-        handler = (args: Map[String, Any]) =>
-          ZIO.attempt {
-            val result = MapToFunctionMacro
-              .callByMap($methodRefExpr)
-              .asInstanceOf[Map[String, Any] => Any](args)
-
-            result match
-              case msgs: List[?] if msgs.nonEmpty && msgs.head.isInstanceOf[Message] =>
-                msgs.asInstanceOf[List[Message]]
-              case s: String =>
-                List(Message(role = Role.User, content = TextContent(s)))
-              case other =>
-                List(Message(role = Role.User, content = TextContent(other.toString)))
-          }
+        handler = $handler
       )
     }
 

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ResourceProcessor.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ResourceProcessor.scala
@@ -75,23 +75,123 @@ private[macros] object ResourceProcessor extends AnnotationProcessorBase:
 
     val methodRefExpr = methodRef(ownerSym, methodSym)
 
+    val coerceBody: Expr[Any => String | Array[Byte]] = '{ (anyResult: Any) =>
+      anyResult match
+        case s: String => s
+        case b: Array[Byte] => b
+        case other => other.toString
+    }
+
+    val effectShape = MacroUtils.detectEffectShape(methodSym)
+
+    val templateHandler: Expr[Map[String, String] => ZIO[Any, Throwable, String | Array[Byte]]] =
+      effectShape match
+        case MacroUtils.EffectShape.Pure =>
+          '{ (params: Map[String, String]) =>
+            ZIO.attempt {
+              val anyResult = MapToFunctionMacro
+                .callByMap($methodRefExpr)
+                .asInstanceOf[Map[String, Any] => Any](params.asInstanceOf[Map[String, Any]])
+              $coerceBody(anyResult)
+            }
+          }
+        case MacroUtils.EffectShape.Zio =>
+          '{ (params: Map[String, String]) =>
+            ZIO
+              .suspend {
+                MapToFunctionMacro
+                  .callByMap($methodRefExpr)
+                  .asInstanceOf[Map[String, Any] => Any](params.asInstanceOf[Map[String, Any]])
+                  .asInstanceOf[ZIO[Any, Any, Any]]
+                  .mapError {
+                    case t: Throwable => t
+                    case other => new RuntimeException(s"Resource error: $other")
+                  }
+              }
+              .map($coerceBody)
+          }
+        case MacroUtils.EffectShape.TryEffect =>
+          '{ (params: Map[String, String]) =>
+            ZIO
+              .suspend {
+                val result = MapToFunctionMacro
+                  .callByMap($methodRefExpr)
+                  .asInstanceOf[Map[String, Any] => Any](params.asInstanceOf[Map[String, Any]])
+                  .asInstanceOf[scala.util.Try[Any]]
+                ZIO.fromTry(result)
+              }
+              .map($coerceBody)
+          }
+        case MacroUtils.EffectShape.EitherThrowable =>
+          '{ (params: Map[String, String]) =>
+            ZIO
+              .suspend {
+                val result = MapToFunctionMacro
+                  .callByMap($methodRefExpr)
+                  .asInstanceOf[Map[String, Any] => Any](params.asInstanceOf[Map[String, Any]])
+                  .asInstanceOf[Either[Throwable, Any]]
+                ZIO.fromEither(result)
+              }
+              .map($coerceBody)
+          }
+
+    val staticHandler: Expr[() => ZIO[Any, Throwable, String | Array[Byte]]] =
+      effectShape match
+        case MacroUtils.EffectShape.Pure =>
+          '{ () =>
+            ZIO.attempt {
+              val anyResult = MapToFunctionMacro
+                .callByMap($methodRefExpr)
+                .asInstanceOf[Map[String, Any] => Any](Map.empty)
+              $coerceBody(anyResult)
+            }
+          }
+        case MacroUtils.EffectShape.Zio =>
+          '{ () =>
+            ZIO
+              .suspend {
+                MapToFunctionMacro
+                  .callByMap($methodRefExpr)
+                  .asInstanceOf[Map[String, Any] => Any](Map.empty)
+                  .asInstanceOf[ZIO[Any, Any, Any]]
+                  .mapError {
+                    case t: Throwable => t
+                    case other => new RuntimeException(s"Resource error: $other")
+                  }
+              }
+              .map($coerceBody)
+          }
+        case MacroUtils.EffectShape.TryEffect =>
+          '{ () =>
+            ZIO
+              .suspend {
+                val result = MapToFunctionMacro
+                  .callByMap($methodRefExpr)
+                  .asInstanceOf[Map[String, Any] => Any](Map.empty)
+                  .asInstanceOf[scala.util.Try[Any]]
+                ZIO.fromTry(result)
+              }
+              .map($coerceBody)
+          }
+        case MacroUtils.EffectShape.EitherThrowable =>
+          '{ () =>
+            ZIO
+              .suspend {
+                val result = MapToFunctionMacro
+                  .callByMap($methodRefExpr)
+                  .asInstanceOf[Map[String, Any] => Any](Map.empty)
+                  .asInstanceOf[Either[Throwable, Any]]
+                ZIO.fromEither(result)
+              }
+              .map($coerceBody)
+          }
+
     val registration: Expr[ZIO[Any, Throwable, McpServerCore]] =
       if isTemplate then
         '{
           $server.resourceTemplate(
             uriPattern = ${ Expr(uri) },
-            handler = (params: Map[String, String]) =>
-              ZIO.attempt {
-                val anyResult = MapToFunctionMacro
-                  .callByMap($methodRefExpr)
-                  .asInstanceOf[Map[String, Any] => Any](
-                    params.asInstanceOf[Map[String, Any]]
-                  )
-                anyResult match
-                  case s: String => s
-                  case b: Array[Byte] => b
-                  case other => other.toString
-              },
+            handler = $templateHandler,
             name = ${ Expr(finalName) },
             description = ${ Expr(finalDesc) },
             mimeType = ${ Expr(mimeTypeOpt) },
@@ -102,16 +202,7 @@ private[macros] object ResourceProcessor extends AnnotationProcessorBase:
         '{
           $server.resource(
             uri = ${ Expr(uri) },
-            handler = () =>
-              ZIO.attempt {
-                val anyResult = MapToFunctionMacro
-                  .callByMap($methodRefExpr)
-                  .asInstanceOf[Map[String, Any] => Any](Map.empty)
-                anyResult match
-                  case s: String => s
-                  case b: Array[Byte] => b
-                  case other => other.toString
-              },
+            handler = $staticHandler,
             name = ${ Expr(finalName) },
             description = ${ Expr(finalDesc) },
             mimeType = ${ Expr(mimeTypeOpt) }

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ToolProcessor.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ToolProcessor.scala
@@ -72,18 +72,66 @@ private[macros] object ToolProcessor extends AnnotationProcessorBase:
       p.name == "ctx" && p.info <:< TypeRepr.of[McpContext]
     })
 
-    val handler: Expr[ContextualToolHandler] = '{
-      (args: Map[String, Any], ctxOpt: Option[McpContext]) =>
-        ZIO.attempt {
-          val patchedArgs =
-            if ${ Expr(ctxParamPresent) } then args + ("ctx" -> ctxOpt.getOrElse(McpContext.empty))
-            else args
+    val ctxParamPresentExpr = Expr(ctxParamPresent)
 
-          MapToFunctionMacro
-            .callByMap($methodRefExpr)
-            .asInstanceOf[Map[String, Any] => Any](patchedArgs)
-        }
-    }
+    val handler: Expr[ContextualToolHandler] =
+      MacroUtils.detectEffectShape(methodSym) match
+        case MacroUtils.EffectShape.Pure =>
+          '{ (args: Map[String, Any], ctxOpt: Option[McpContext]) =>
+            ZIO.attempt {
+              val patchedArgs =
+                if $ctxParamPresentExpr then args + ("ctx" -> ctxOpt.getOrElse(McpContext.empty))
+                else args
+              MapToFunctionMacro
+                .callByMap($methodRefExpr)
+                .asInstanceOf[Map[String, Any] => Any](patchedArgs)
+            }
+          }
+
+        case MacroUtils.EffectShape.Zio =>
+          '{ (args: Map[String, Any], ctxOpt: Option[McpContext]) =>
+            ZIO.suspend {
+              val patchedArgs =
+                if $ctxParamPresentExpr then args + ("ctx" -> ctxOpt.getOrElse(McpContext.empty))
+                else args
+              MapToFunctionMacro
+                .callByMap($methodRefExpr)
+                .asInstanceOf[Map[String, Any] => Any](patchedArgs)
+                .asInstanceOf[ZIO[Any, Any, Any]]
+                .mapError {
+                  case t: Throwable => t
+                  case other => new RuntimeException(s"Tool error: $other")
+                }
+            }
+          }
+
+        case MacroUtils.EffectShape.TryEffect =>
+          '{ (args: Map[String, Any], ctxOpt: Option[McpContext]) =>
+            ZIO.suspend {
+              val patchedArgs =
+                if $ctxParamPresentExpr then args + ("ctx" -> ctxOpt.getOrElse(McpContext.empty))
+                else args
+              val result = MapToFunctionMacro
+                .callByMap($methodRefExpr)
+                .asInstanceOf[Map[String, Any] => Any](patchedArgs)
+                .asInstanceOf[scala.util.Try[Any]]
+              ZIO.fromTry(result)
+            }
+          }
+
+        case MacroUtils.EffectShape.EitherThrowable =>
+          '{ (args: Map[String, Any], ctxOpt: Option[McpContext]) =>
+            ZIO.suspend {
+              val patchedArgs =
+                if $ctxParamPresentExpr then args + ("ctx" -> ctxOpt.getOrElse(McpContext.empty))
+                else args
+              val result = MapToFunctionMacro
+                .callByMap($methodRefExpr)
+                .asInstanceOf[Map[String, Any] => Any](patchedArgs)
+                .asInstanceOf[Either[Throwable, Any]]
+              ZIO.fromEither(result)
+            }
+          }
 
     val rawSchema: Expr[io.circe.Json] = '{
       JsonSchemaMacro.schemaForFunctionArgs(


### PR DESCRIPTION
## Summary
- The annotation macros wrapped method invocation in `ZIO.attempt { method(...) }` unconditionally, so when an annotated method returned an effect (`UIO[Int]`, `Task[String]`, `IO[String, Int]`, `Try[A]`, `Either[Throwable, A]`) the synthesized handler ended up with a nested ZIO. The outer ZIO completed with the *inner effect as its value*, which `transformToolResult` then stringified — producing the warning reported in #50: `Tool handler for 'add' returned type zio.ZIO$Sync, using toString representation`.
- Detects the dealiased method return type at macro time and emits a flattening handler:
  - `ZIO[Any, E, A]` → `ZIO.suspend { ... }.mapError { non-Throwable -> RuntimeException }`
  - `Try[A]` → `ZIO.fromTry`
  - `Either[Throwable, A]` → `ZIO.fromEither`
  - everything else → existing `ZIO.attempt` path
- Aborts at macro time if a method returns `ZIO` with a non-`Any` environment, pointing users to `ZIO.provide` or the typed-contract path (`McpTool.derived`).
- Applies the same fix to `@Resource` and `@Prompt` so all three annotation processors are at parity with the typed-contract `ToHandlerEffect` typeclass.

Fixes #50.

## Test plan
- [x] `./mill fast-mcp-scala.jvm.test` — full JVM suite (138 cases, including 10 new `EffectReturnTest` cases covering UIO/Task/IO/Try/Either success+failure paths plus `@Resource` UIO and `@Prompt` UIO)
- [x] `./mill fast-mcp-scala.test` — JVM + Bun conformance (329 cases)
- [x] `./mill fast-mcp-scala.checkFormat`
- [x] Issue #50 minimal repro:
  ```scala
  @Tool(name = Some("add"))
  def add(@Param("a") a: Int, @Param("b") b: Int): UIO[Int] = ZIO.succeed(a + b)
  ```
  now returns `7` instead of `zio.ZIO$Sync@…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)