### PR TITLE
chore: prepare v0.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to fast-mcp-scala will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-04-28
+
+### Added
+
+- **Experimental MCP Tasks API exported at the top level.** The 2025-11-25 Tasks surface is now available from the root package exports.
+
+### Fixed
+
+- **Effectful annotation handlers now execute their returned effects.** `@Tool`, `@Resource`, and `@Prompt` macro-generated handlers now run returned `ZIO`, `Try`, and `Either` values instead of treating them as plain return payloads.
+
 ## [0.3.1] - 2026-04-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ rm -rf out/fast-mcp-scala && ./mill fast-mcp-scala.compile
 ./mill -i __.publishLocal
 ```
 
-Then in your project use version `0.3.1`.
+Then in your project use version `0.3.2`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Built on **ZIO 2**, **Tapir**-derived schemas, **Jackson 3** (JVM) / **zio-json*
 
 ```scala 3 ignore
 // JVM — Java SDK-backed runtime with annotations, derived schemas, HTTP + stdio transports.
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.1"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.2"
 
 // Scala.js — TS SDK-backed runtime on Bun/Node + the same annotation and typed-contract APIs.
-libraryDependencies += "com.tjclp" %%% "fast-mcp-scala" % "0.3.1"
+libraryDependencies += "com.tjclp" %%% "fast-mcp-scala" % "0.3.2"
 ```
 
 Built against Scala 3.8.3. JVM requires JDK 17+. Scala.js artifact is published for `sjs1_3` (Scala.js 1.x); runs on Bun (first-class) and Node 18+.
@@ -53,7 +53,7 @@ A single-file server with one tool — the same code lives in [`HelloWorld.scala
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala:0.3.1
+//> using dep com.tjclp::fast-mcp-scala:0.3.2
 //> using options "-Xcheck-macros" "-experimental"
 
 import com.tjclp.fastmcp.{*, given}
@@ -336,7 +336,7 @@ Proof: the conformance suite at [`JsServerConformanceTest.scala`](fast-mcp-scala
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala_sjs1:0.3.1
+//> using dep com.tjclp::fast-mcp-scala_sjs1:0.3.2
 
 import com.tjclp.fastmcp.{*, given}
 
@@ -413,7 +413,7 @@ Add to `claude_desktop_config.json`:
       "command": "scala-cli",
       "args": [
         "-e",
-        "//> using dep com.tjclp::fast-mcp-scala:0.3.1",
+        "//> using dep com.tjclp::fast-mcp-scala:0.3.2",
         "--main-class",
         "com.tjclp.fastmcp.examples.AnnotatedServer"
       ]
@@ -451,14 +451,14 @@ For architectural detail, see [`docs/architecture.md`](docs/architecture.md).
 After `publishLocal`:
 
 ```scala 3 ignore
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.1"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.2"
 ```
 
 Or with Mill:
 
 ```scala 3 ignore
 def ivyDeps = Agg(
-  ivy"com.tjclp::fast-mcp-scala:0.3.1"
+  ivy"com.tjclp::fast-mcp-scala:0.3.2"
 )
 ```
 

--- a/build.mill
+++ b/build.mill
@@ -93,7 +93,7 @@ trait FastMCPPublishingBase extends PublishModule {
 
   /** Version derived from PUBLISH_VERSION env var (set by CI), or SNAPSHOT for local dev */
   override def publishVersion: T[String] =
-    sys.env.getOrElse("PUBLISH_VERSION", "0.3.1")
+    sys.env.getOrElse("PUBLISH_VERSION", "0.3.2")
 
   override def pomSettings: T[PomSettings] = PomSettings(
     description = artifactDescription,


### PR DESCRIPTION
## Summary

Prepare the `v0.3.2` release branch.

Changes:
- Bump the default publish version from `0.3.1` to `0.3.2`.
- Add `0.3.2` changelog notes for the experimental MCP Tasks root export and effectful annotation handler fix.
- Refresh README and CLAUDE dependency/version references to `0.3.2`.

## Validation

- `./mill --no-server fast-mcp-scala.test`

## Release flow

After this PR merges, tag `main` as `v0.3.2` to trigger the release workflow.