### PR TITLE
chore: bump dev default to 0.3.3-SNAPSHOT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ rm -rf out/fast-mcp-scala && ./mill fast-mcp-scala.compile
 ./mill -i __.publishLocal
 ```
 
-Then in your project use version `0.3.2`.
+Then in your project use version `0.3.3-SNAPSHOT`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -451,14 +451,14 @@ For architectural detail, see [`docs/architecture.md`](docs/architecture.md).
 After `publishLocal`:
 
 ```scala 3 ignore
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.2"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.3-SNAPSHOT"
 ```
 
 Or with Mill:
 
 ```scala 3 ignore
 def ivyDeps = Agg(
-  ivy"com.tjclp::fast-mcp-scala:0.3.2"
+  ivy"com.tjclp::fast-mcp-scala:0.3.3-SNAPSHOT"
 )
 ```
 

--- a/build.mill
+++ b/build.mill
@@ -93,7 +93,7 @@ trait FastMCPPublishingBase extends PublishModule {
 
   /** Version derived from PUBLISH_VERSION env var (set by CI), or SNAPSHOT for local dev */
   override def publishVersion: T[String] =
-    sys.env.getOrElse("PUBLISH_VERSION", "0.3.2")
+    sys.env.getOrElse("PUBLISH_VERSION", "0.3.3-SNAPSHOT")
 
   override def pomSettings: T[PomSettings] = PomSettings(
     description = artifactDescription,


### PR DESCRIPTION
## Summary
- Bump `build.mill` `publishVersion` default from `0.3.2` → `0.3.3-SNAPSHOT` so local `publishLocal` artifacts are clearly distinguishable from the released `0.3.2` on Maven Central. CI release workflow still overrides via `PUBLISH_VERSION` from the tag, so this only affects local dev.
- Update README "Consuming a local build" and `CLAUDE.md` publishLocal references to track `0.3.3-SNAPSHOT`. Quickstart / install snippets stay at `0.3.2` (the latest published release on Maven Central).

This re-introduces the `-SNAPSHOT` suffix that was used pre-v0.3.1; v0.3.1 and v0.3.2 had bare versions in the default. The SNAPSHOT form makes the dev-vs-released distinction obvious in `~/.ivy2/local`.

## Test plan
- [ ] `./mill fast-mcp-scala.show.jvm.publishVersion` reports `0.3.3-SNAPSHOT` locally
- [ ] `./mill fast-mcp-scala.show.js.publishVersion` reports `0.3.3-SNAPSHOT` locally
- [ ] CI green (compile + test on JDK 17/21/24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)