### PR TITLE
fix: stop advertising `logging` capability on stateless transport (#56)

### DIFF
--- a/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerConformanceTest.scala
+++ b/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerConformanceTest.scala
@@ -162,6 +162,13 @@ class JsServerConformanceTest extends AsyncFlatSpec with Matchers with BeforeAnd
     }
   }
 
+  it should "not advertise the logging capability (issue #56)" in {
+    ensureConnected().map { c =>
+      val caps = c.getServerCapabilities().toOption
+      caps.flatMap(_.logging.toOption).isDefined shouldBe false
+    }
+  }
+
   // --- Tools ---
 
   "tools/list" should "return registered typed contracts" in {

--- a/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/facades/McpClient.scala
+++ b/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/facades/McpClient.scala
@@ -80,6 +80,7 @@ trait ServerCapabilities extends js.Object:
   val tools: js.UndefOr[js.Object] = js.native
   val resources: js.UndefOr[js.Object] = js.native
   val prompts: js.UndefOr[js.Object] = js.native
+  val logging: js.UndefOr[js.Object] = js.native
 
 // --- Tool types ---
 

--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/FastMcpServer.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/FastMcpServer.scala
@@ -690,12 +690,18 @@ class FastMcpServer[R](
       if (promptManager.listDefinitions().nonEmpty)
         new McpSchema.ServerCapabilities.PromptCapabilities(true)
       else null
-    val loggingCapabilities = new McpSchema.ServerCapabilities.LoggingCapabilities()
 
+    // Pass null for logging — fast-mcp-scala exposes no logging API yet (issue #56).
+    // The stateless server respects this null. The stateful server (streamable HTTP,
+    // stdio) forces `.mutate().logging().build()` at McpAsyncServer.java:136,164, so
+    // it still advertises `logging: {}` — but it also auto-registers a no-op handler
+    // for `logging/setLevel` there, so clients don't see a "Missing handler" error.
+    // Resolving the cosmetic advertisement on stateful paths requires bypassing the
+    // Java SDK entirely (planned for a future rewrite).
     new McpSchema.ServerCapabilities(
       null,
       null, // experimental
-      loggingCapabilities,
+      null, // logging
       promptCapabilities,
       resourceCapabilities,
       toolCapabilities

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/ZioHttpStatelessTransportTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/ZioHttpStatelessTransportTest.scala
@@ -119,6 +119,15 @@ class ZioHttpStatelessTransportTest extends AnyFlatSpec with Matchers {
     body should include("\"protocolVersion\"")
   }
 
+  it should "not advertise the logging capability (issue #56)" in {
+    val (code, body) = post(
+      """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"""
+    )
+    code shouldBe 200
+    body should include("\"tools\"") // sanity: at least one capability still advertised
+    body should not include "\"logging\""
+  }
+
   "notifications/initialized" should "return 202" in {
     val (code, _) = post(
       """{"jsonrpc":"2.0","method":"notifications/initialized"}"""


### PR DESCRIPTION
## Summary

Closes #56.

The Java MCP SDK 1.1.1 stateless server does not register a default `logging/setLevel` handler, so advertising `LoggingCapabilities` in the initialize response causes MCP Inspector (and any spec-compliant client) to call `logging/setLevel` and receive HTTP 400 with `Missing handler for request type: logging/setLevel`.

- Pass `null` for the logging argument in `FastMcpServer.buildCapabilities()`. This matches the JS path, which already omits logging from capabilities.
- Add regression tests on the JVM stateless transport and on the JS conformance suite.

## Limitation (documented in the code)

The Java SDK's **stateful** path (streamable HTTP, stdio) forces `.mutate().logging().build()` at [`McpAsyncServer.java:136,164`](https://github.com/modelcontextprotocol/java-sdk/blob/v1.1.1/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java#L136-L164), so the stateful initialize response still contains `"logging": {}`. There the SDK also auto-registers a no-op handler for `logging/setLevel`, so clients do not see a 400.

Verified that this stateful override persists in v1.1.2, v1.1.3, and v2.0.0-M3 of the Java SDK — there is no upstream fix coming. Fully removing the cosmetic advertisement on stateful paths requires bypassing the Java SDK and is tracked separately for a future rewrite.

## Test plan

- [x] `./mill fast-mcp-scala.test` — all 329 tests pass
- [x] `./mill fast-mcp-scala.checkFormat` — clean
- [ ] Manual: run an example server with `stateless = true`, point `npx @modelcontextprotocol/inspector` at it, confirm no `"logging": {}` in initialize and no `Missing handler` error in Inspector logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)