### PR TITLE
chore: prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-27
+
+Highlights: a type-safety overhaul that threads the ZIO environment `R`
+through the entire server stack, plus a fix for issue #56.
+
 ### Added
 
-- **Annotation and typed-contract handlers may declare ZIO environment requirements.** `@Tool` /
-  `@Resource` / `@Prompt` methods can return `ZIO[R, E, A]` with `R ≠ Any`; provide the layer
-  once at `server.runHttp().provide(...)` instead of inside every method body. Construct the
-  server with `McpServer.typed[R]("name")` (or `FastMcpServer.typed[R]`) so `runHttp()` returns
-  `ZIO[R, Throwable, Unit]`. The macro emits a compile-time error if a handler's `R` isn't
-  satisfied by the server's type. Typed contract factories accept an explicit environment type
-  where needed (`McpTool[In, Out, R]`, `McpPrompt[In, R]`,
-  `McpTemplateResource[In, R]`; static resources use `McpStaticResource.withEnv[R]`). Existing
-  no-environment arities remain source-compatible (`McpTool[In, Out]`, `McpPrompt[In]`,
-  `McpStaticResource`, `McpTemplateResource[In]`). Closes #55.
+- **End-to-end ZIO environment threading for handlers (`R`-aware servers).**
+  `@Tool` / `@Resource` / `@Prompt` methods — and typed-contract handlers —
+  can now return `ZIO[R, E, A]` with `R ≠ Any`. Construct the server with
+  `McpServer.typed[R]("name")` (or `FastMcpServer.typed[R]`) and provide the
+  layer once at the boundary: `server.runHttp().provide(Client.default)`.
+  No more wrapping every method body in its own `.provide(...)`. Closes #55.
+- **Compile-time `R`-mismatch errors from the annotation macros.** If a
+  `@Tool` / `@Resource` / `@Prompt` method requires an `R` the server can't
+  satisfy, the macro now emits a targeted compile-time error pointing at the
+  offending handler, instead of failing at runtime when a missing layer is
+  encountered. Replaces the previous blanket `errorAndAbort` on any
+  `ZIO[R, ...]` return type.
+- **Typed contract factories accept an explicit environment type.**
+  `McpTool[In, Out, R]`, `McpPrompt[In, R]`, `McpTemplateResource[In, R]`,
+  and `McpStaticResource.withEnv[R]` cover the typed paths. Existing
+  no-environment arities (`McpTool[In, Out]`, `McpPrompt[In]`,
+  `McpStaticResource`, `McpTemplateResource[In]`) remain source-compatible.
 
 ### Changed
 
-- **`McpServerCore`, `FastMcpServer`, and `JsMcpServer` are now parameterized on `R`.** The
-  default `McpServer("name")` factory still returns the `R = Any` form; explicit type
-  application (`FastMcpServer[Client]("name")`) or `McpServer.typed[R]("name")` gives a typed
-  server. Existing code that wrote `FastMcpServer` or `JsMcpServer` as bare types needs
-  `FastMcpServer[Any]` / `JsMcpServer[Any]`.
+- **`McpServerCore`, `FastMcpServer`, `JsMcpServer`, the managers, and the
+  typed-contract handlers are now parameterized on `R`.** The default
+  `McpServer("name")` factory still returns the `R = Any` form for
+  back-compat; explicit type application (`FastMcpServer[Client]("name")`)
+  or `McpServer.typed[R]("name")` gives a typed server.
+  **Migration:** code that referenced `FastMcpServer` or `JsMcpServer` as
+  bare types now needs `FastMcpServer[Any]` / `JsMcpServer[Any]`.
+- **Handler dispatch captures `ZIO.runtime[R]` once at server entry and
+  runs every handler effect on that runtime.** This is how the user's
+  `.provide(layer)` at the server boundary reaches every handler
+  invocation, including forked daemon fibers used by `TaskDispatcher` (JVM)
+  and `TaskManager.create` (JS) — they inherit the surrounding runtime via
+  `forkDaemon`.
+
+### Fixed
+
+- **Stop advertising the `logging` capability on the stateless HTTP transport.** The Java MCP
+  SDK 1.1.1 stateless server never registers a `logging/setLevel` handler, so spec-compliant
+  clients (e.g. MCP Inspector) would call the advertised method and receive HTTP 400 with
+  `Missing handler for request type: logging/setLevel`. `FastMcpServer` now passes `null` for
+  the `logging` argument when building `ServerCapabilities`, matching the JS path which never
+  advertised it. The stateful HTTP and stdio paths still cosmetically advertise `logging:{}`
+  because the underlying Java SDK forces `.mutate().logging().build()` at
+  `McpAsyncServer.java:136,164`; there the SDK auto-registers a no-op handler so clients do
+  not see a 400. Closes #56.
 
 ## [0.3.2] - 2026-04-28
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,7 +279,7 @@ rm -rf out/fast-mcp-scala && ./mill fast-mcp-scala.compile
 ./mill -i __.publishLocal
 ```
 
-Then in your project use version `0.3.3-SNAPSHOT`.
+Then in your project use version `0.4.0`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Built on **ZIO 2**, **Tapir**-derived schemas, **Jackson 3** (JVM) / **zio-json*
 
 ```scala 3 ignore
 // JVM — Java SDK-backed runtime with annotations, derived schemas, HTTP + stdio transports.
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.2"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.4.0"
 
 // Scala.js — TS SDK-backed runtime on Bun/Node + the same annotation and typed-contract APIs.
-libraryDependencies += "com.tjclp" %%% "fast-mcp-scala" % "0.3.2"
+libraryDependencies += "com.tjclp" %%% "fast-mcp-scala" % "0.4.0"
 ```
 
 Built against Scala 3.8.3. JVM requires JDK 17+. Scala.js artifact is published for `sjs1_3` (Scala.js 1.x); runs on Bun (first-class) and Node 18+.
@@ -53,7 +53,7 @@ A single-file server with one tool — the same code lives in [`HelloWorld.scala
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala:0.3.2
+//> using dep com.tjclp::fast-mcp-scala:0.4.0
 //> using options "-Xcheck-macros" "-experimental"
 
 import com.tjclp.fastmcp.{*, given}
@@ -336,7 +336,7 @@ Proof: the conformance suite at [`JsServerConformanceTest.scala`](fast-mcp-scala
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala_sjs1:0.3.2
+//> using dep com.tjclp::fast-mcp-scala_sjs1:0.4.0
 
 import com.tjclp.fastmcp.{*, given}
 
@@ -413,7 +413,7 @@ Add to `claude_desktop_config.json`:
       "command": "scala-cli",
       "args": [
         "-e",
-        "//> using dep com.tjclp::fast-mcp-scala:0.3.2",
+        "//> using dep com.tjclp::fast-mcp-scala:0.4.0",
         "--main-class",
         "com.tjclp.fastmcp.examples.AnnotatedServer"
       ]
@@ -451,14 +451,14 @@ For architectural detail, see [`docs/architecture.md`](docs/architecture.md).
 After `publishLocal`:
 
 ```scala 3 ignore
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.3.3-SNAPSHOT"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "0.4.0"
 ```
 
 Or with Mill:
 
 ```scala 3 ignore
 def ivyDeps = Agg(
-  ivy"com.tjclp::fast-mcp-scala:0.3.3-SNAPSHOT"
+  ivy"com.tjclp::fast-mcp-scala:0.4.0"
 )
 ```
 

--- a/build.mill
+++ b/build.mill
@@ -93,7 +93,7 @@ trait FastMCPPublishingBase extends PublishModule {
 
   /** Version derived from PUBLISH_VERSION env var (set by CI), or SNAPSHOT for local dev */
   override def publishVersion: T[String] =
-    sys.env.getOrElse("PUBLISH_VERSION", "0.3.3-SNAPSHOT")
+    sys.env.getOrElse("PUBLISH_VERSION", "0.4.0")
 
   override def pomSettings: T[PomSettings] = PomSettings(
     description = artifactDescription,


### PR DESCRIPTION
## Summary

Cut **v0.4.0**. The headline is a type-safety overhaul (PR #57) plus the issue #56 logging-capability fix (PR #58).

### Highlights

- **End-to-end ZIO environment threading.** `@Tool` / `@Resource` / `@Prompt` methods (and typed-contract handlers) can return `ZIO[R, E, A]` with `R ≠ Any`. Construct the server with `McpServer.typed[R]("name")` and provide the layer once at the boundary: `server.runHttp().provide(Client.default)`. No more wrapping every method body.
- **Compile-time `R`-mismatch errors** from the annotation macros — handlers requiring an `R` the server can't satisfy now fail at compile time with a targeted message, not at runtime when a missing layer is encountered.
- **`McpServerCore`, `FastMcpServer`, `JsMcpServer`, the managers, and typed contracts are parameterized on `R`.** Default `McpServer("name")` factory still returns `R = Any` for back-compat. **Migration:** bare-type references like `FastMcpServer` need `FastMcpServer[Any]`.
- **Fixed:** stop advertising the `logging` capability on the stateless HTTP transport (#56). Stateful HTTP and stdio still cosmetically advertise `logging:{}` because the Java SDK forces `.mutate().logging().build()` at `McpAsyncServer.java:136,164` — there it also auto-registers a no-op handler so clients do not see a 400. Fully eliminating the cosmetic advertisement on stateful paths is tracked separately (TJC-1131 — native Scala MCP core rewrite).

### Files changed

- `CHANGELOG.md` — promote `[Unreleased]` → `[0.4.0] - 2026-05-27`; reframe the ZIO env work as a type-safety overhaul; add the #56 fix entry.
- `build.mill` — `publishVersion` fallback `0.3.3-SNAPSHOT` → `0.4.0` so local `publishLocal` artifacts match the release coordinate.
- `CLAUDE.md` — publishLocal reference bumped to `0.4.0`.
- `README.md` — all install snippets and Consuming-a-local-build references updated to `0.4.0`.

### Test plan

- [x] `./mill fast-mcp-scala.test` — all 329 tests pass.
- [x] `./mill fast-mcp-scala.checkFormat` — clean.
- [ ] After merge: push `v0.4.0` tag to trigger the release workflow.
- [ ] After publish: follow-up PR bumps `publishVersion` fallback to the next dev SNAPSHOT (matches the v0.3.2 → v0.3.3 pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)