### PR TITLE
chore: bump dev default to 1.0.0-RC2-SNAPSHOT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,7 +298,7 @@ rm -rf out/fast-mcp-scala && ./mill fast-mcp-scala.compile
 ./mill -i __.publishLocal
 ```
 
-Then in your project use version `1.0.0-RC1`.
+Then in your project use version `1.0.0-RC2-SNAPSHOT`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -479,14 +479,14 @@ For architectural detail, see [`docs/architecture.md`](docs/architecture.md).
 After `publishLocal`:
 
 ```scala 3 ignore
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "1.0.0-RC1"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "1.0.0-RC2-SNAPSHOT"
 ```
 
 Or with Mill:
 
 ```scala 3 ignore
 def ivyDeps = Agg(
-  ivy"com.tjclp::fast-mcp-scala:1.0.0-RC1"
+  ivy"com.tjclp::fast-mcp-scala:1.0.0-RC2-SNAPSHOT"
 )
 ```
 

--- a/build.mill
+++ b/build.mill
@@ -91,7 +91,7 @@ trait FastMCPPublishingBase extends PublishModule {
 
   /** Version derived from PUBLISH_VERSION env var (set by CI), or SNAPSHOT for local dev */
   override def publishVersion: T[String] =
-    sys.env.getOrElse("PUBLISH_VERSION", "1.0.0-RC1")
+    sys.env.getOrElse("PUBLISH_VERSION", "1.0.0-RC2-SNAPSHOT")
 
   override def pomSettings: T[PomSettings] = PomSettings(
     description = artifactDescription,


### PR DESCRIPTION
Post-release dev-default bump after v1.0.0-RC1, per the release convention: `build.mill` default moves to `1.0.0-RC2-SNAPSHOT`, README/CLAUDE.md publishLocal sections track it, quickstart snippets keep the released `1.0.0-RC1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)