### PR TITLE
fix: Option tool params decode via zio-json, not a Mirror sum decoder (#64)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,7 +298,7 @@ rm -rf out/fast-mcp-scala && ./mill fast-mcp-scala.compile
 ./mill -i __.publishLocal
 ```
 
-Then in your project use version `1.0.0-RC1`.
+Then in your project use version `1.0.0-RC2-SNAPSHOT`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -479,14 +479,14 @@ For architectural detail, see [`docs/architecture.md`](docs/architecture.md).
 After `publishLocal`:
 
 ```scala 3 ignore
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "1.0.0-RC1"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "1.0.0-RC2-SNAPSHOT"
 ```
 
 Or with Mill:
 
 ```scala 3 ignore
 def ivyDeps = Agg(
-  ivy"com.tjclp::fast-mcp-scala:1.0.0-RC1"
+  ivy"com.tjclp::fast-mcp-scala:1.0.0-RC2-SNAPSHOT"
 )
 ```
 

--- a/build.mill
+++ b/build.mill
@@ -91,7 +91,7 @@ trait FastMCPPublishingBase extends PublishModule {
 
   /** Version derived from PUBLISH_VERSION env var (set by CI), or SNAPSHOT for local dev */
   override def publishVersion: T[String] =
-    sys.env.getOrElse("PUBLISH_VERSION", "1.0.0-RC1")
+    sys.env.getOrElse("PUBLISH_VERSION", "1.0.0-RC2-SNAPSHOT")
 
   override def pomSettings: T[PomSettings] = PomSettings(
     description = artifactDescription,

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/surface/RootImportSurfaceTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/surface/RootImportSurfaceTest.scala
@@ -7,6 +7,7 @@ import zio.json.*
 
 import com.tjclp.fastmcp.{given, *}
 import com.tjclp.fastmcp.codec.DefaultDecodeContext
+import com.tjclp.fastmcp.macros.MapToFunctionMacro
 
 class RootImportSurfaceTest extends AnyFunSuite {
 
@@ -85,5 +86,26 @@ class RootImportSurfaceTest extends AnyFunSuite {
       DefaultDecodeContext.default
     )
     assert(tagged == TaggedId("abc"))
+  }
+
+  // Regression for #64: at ROOT-IMPORT call sites `export McpDecoders.given` flattens the
+  // low-priority Mirror fallback to the same precedence as the JsonDecoder-based given, and
+  // Option[T] (a sum type with a Mirror) used to resolve to a derived sum decoder that expects
+  // `{"Some": ...}` — rejecting bare values AND `null`. Must resolve via zio-json's Option decoder.
+  test("root import decodes Option params from bare values, null, and absence (#64)") {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    val jsonNull: Any = null
+
+    val decoder = summon[McpDecoder[Option[String]]]
+    assert(decoder.decode("p", "main", DefaultDecodeContext.default) == Some("main"))
+    assert(decoder.decode("p", jsonNull, DefaultDecodeContext.default) == None)
+
+    def search(query: String, drive: Option[String], limit: Option[Int]): String =
+      s"$query/${drive.getOrElse("all")}/${limit.getOrElse(10)}"
+
+    val fn = MapToFunctionMacro.callByMap(search).asInstanceOf[Map[String, Any] => Any]
+    assert(fn(Map("query" -> "q", "drive" -> "main", "limit" -> 3)) == "q/main/3")
+    assert(fn(Map("query" -> "q", "drive" -> jsonNull, "limit" -> jsonNull)) == "q/all/10")
+    assert(fn(Map("query" -> "q")) == "q/all/10")
   }
 }

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/codec/DefaultDecodeContext.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/codec/DefaultDecodeContext.scala
@@ -59,8 +59,12 @@ object DefaultDecodeContext:
     * [[parseJsonObject]]/[[parseJsonArray]], primitives, byte arrays (base64), and `Option`. Falls
     * back to a string rendering for anything else (rare; matches the old JS behavior).
     */
+  @SuppressWarnings(Array("org.wartremover.warts.Null"))
   def toJsonAst(value: Any): Json =
     value match
+      // Raw null can reach us from direct in-process calls and JS interop (wire null arrives
+      // as None via fromJsonAst); rendering it as Json.Null instead of NPE-ing on toString
+      case null => Json.Null
       case j: Json => j
       case s: String => Json.Str(s)
       case b: Boolean => Json.Bool(b)

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/codec/McpDecoders.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/codec/McpDecoders.scala
@@ -24,7 +24,16 @@ import com.tjclp.fastmcp.server.McpContext
   */
 trait McpDecodersLowPriority:
 
-  inline given derivedZioJsonDecoder[T](using Mirror.Of[T]): McpDecoder[T] =
+  /** Mirror-derived fallback for case classes WITHOUT an explicit `JsonDecoder`.
+    *
+    * Deliberately constrained to `Mirror.ProductOf` (not `Mirror.Of`): sum types like `Option[T]`
+    * and `Either[A, B]` also have mirrors, and `export McpDecoders.given` flattens this
+    * low-priority given to the same precedence as `zioJsonDecoder` at root-import call sites — so
+    * `McpDecoder[Option[String]]` used to resolve HERE, deriving a sum decoder that expects
+    * `{"Some": ...}` and rejects bare values (#64). With the product constraint, sum types with
+    * zio-json built-ins (Option, Either, collections) resolve uniquely through `zioJsonDecoder`.
+    */
+  inline given derivedZioJsonDecoder[T](using Mirror.ProductOf[T]): McpDecoder[T] =
     new McpDecoder[T]:
       def decode(name: String, rawValue: Any, context: McpDecodeContext): T =
         val json = context.writeValueAsString(rawValue)


### PR DESCRIPTION
Fixes #64.

## Root cause

`Option[T]` (and any sum type) has a `Mirror`, so the low-priority `derivedZioJsonDecoder[T](using Mirror.Of[T])` was eligible for it — and at **root-import call sites** (`import com.tjclp.fastmcp.{*, given}`), `export McpDecoders.given` flattens the low-priority trait member to the same precedence as `zioJsonDecoder`, and resolution picks the Mirror candidate. The derived decoder for `Option` is a **sum decoder** expecting `{"Some": ...}` / `{"None": {}}`, so it rejects bare values (`(expected '{' got '"')`) — and `null` NPE'd separately in `toJsonAst`.

Net effect in 1.0.0-RC1: `@Tool` methods with `Option` params were unusable over the wire on both platforms (absent, null, and provided all failed). The existing `MapToFunctionMacroTest` Option test passes only because that file doesn't use the root import — the resolution is scope-dependent.

## Fix

1. **`McpDecoders.derivedZioJsonDecoder`: `Mirror.Of` → `Mirror.ProductOf`.** The fallback exists for case classes without an explicit `JsonDecoder`; sum types with zio-json built-ins (Option, Either, collections) now resolve uniquely via `zioJsonDecoder`. Sum ADTs as raw tool params now require an explicit `JsonDecoder` — which they effectively already did, since the derived sum decoder never matched wire shapes.
2. **`DefaultDecodeContext.toJsonAst`: raw `null` → `Json.Null`** instead of NPE on `toString` (wire null arrives as `None`, but direct in-process calls and JS interop can pass real `null`).

## Verification

- New regression test in `RootImportSurfaceTest` (the scope where the bug lives): bare/null/absent × `Option[String]`/`Option[Int]`, via direct summon and `MapToFunctionMacro.callByMap`.
- Full JVM (16 suites) and JS (40 tests) suites pass.
- External repro (loom MCP server, Scala.js/Bun on Databricks Apps) verified against a `1.0.0-RC2-SNAPSHOT` publishLocal: all three cases decode correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)