### PR TITLE
feat: GraalVM native-image HTTP — official conformance against the native binary (TJC-2114, 3/3)

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Cache Mill
         uses: actions/cache@v4
         with:
-          path: ~/.mill
+          path: ~/.cache/mill
           key: ${{ runner.os }}-mill-native-${{ hashFiles('**/build.mill') }}
           restore-keys: |
             ${{ runner.os }}-mill-native-
@@ -95,8 +95,15 @@ jobs:
 
       # The official MCP conformance suite against the native binary, held to the SAME
       # (empty) baseline as the JVM: any divergence is a native-image bug, never a new baseline.
+      # Distinct ports per step so a lingering listener can never satisfy the next readiness poll
+      # (the script also refuses to start if its port is taken).
       - name: Conformance (active suite)
         run: ./scripts/conformance.sh native 8077 active
 
-      - name: Conformance (2026-07-28 requirements)
-        run: ./scripts/conformance.sh native 8077 2026
+      # Scenario-level parity on the 2026 requirements run: the native binary must produce the
+      # SAME normalized scenario results as the JVM server, not merely a passing exit code.
+      - name: Conformance parity (2026 requirements, JVM vs native)
+        run: |
+          ./scripts/conformance.sh jvm 8078 2026 | sed 's/\x1b\[[0-9;]*m//g' | grep -E '^(✓|✗|Total:)' > jvm-2026.txt
+          ./scripts/conformance.sh native 8079 2026 | sed 's/\x1b\[[0-9;]*m//g' | grep -E '^(✓|✗|Total:)' > native-2026.txt
+          diff -u jvm-2026.txt native-2026.txt

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -54,3 +54,49 @@ jobs:
 
       - name: Exercise binary over stdio JSON-RPC
         run: ./scripts/native-smoke.sh
+
+  native-http:
+    name: native-image HTTP conformance (linux-x64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK (Mill runner only)
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:21
+
+      - name: Set up Bun (conformance harness)
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Cache Coursier (incl. GraalVM archive)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier
+            ~/.ivy2/cache
+          key: ${{ runner.os }}-coursier-native-${{ hashFiles('**/build.mill') }}
+          restore-keys: |
+            ${{ runner.os }}-coursier-native-
+
+      - name: Cache Mill
+        uses: actions/cache@v4
+        with:
+          path: ~/.mill
+          key: ${{ runner.os }}-mill-native-${{ hashFiles('**/build.mill') }}
+          restore-keys: |
+            ${{ runner.os }}-mill-native-
+
+      - name: Build native HTTP conformance binary
+        run: ./mill fast-mcp-scala.nativeSmoke.http.nativeImage
+
+      # The official MCP conformance suite against the native binary, held to the SAME
+      # (empty) baseline as the JVM: any divergence is a native-image bug, never a new baseline.
+      - name: Conformance (active suite)
+        run: ./scripts/conformance.sh native 8077 active
+
+      - name: Conformance (2026-07-28 requirements)
+        run: ./scripts/conformance.sh native 8077 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   story can't rot. Downstream recipe and audit loop in `docs/native-image.md`.
 - **GraalVM native-image support for HTTP servers** (TJC-2114, #66): the
   `nativeSmoke.http` module compiles the conformance server (zio-http/netty)
-  to a native binary with two flags — `--install-exit-handlers` and
+  to a native binary with a four-flag recipe: `--install-exit-handlers`,
   `--initialize-at-run-time=io.netty` (countering netty-codec-http's blanket
-  build-time-init rule, which is incompatible with GraalVM on JDK 25).
+  build-time-init rule, incompatible with GraalVM on JDK 25), and
+  `-H:+UnlockExperimentalVMOptions -H:+SharedArenaSupport` (netty's JDK-25
+  direct-buffer cleaner allocates via `Arena.ofShared` at runtime; without it
+  event-loop threads die one by one and SIGTERM shutdown hangs).
   `scripts/conformance.sh native` runs the official MCP conformance suite
   against the binary: identical results to the JVM in both `active` (empty
   baseline) and `2026` modes, CI-gated in `native.yml`. Netty runs on NIO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   netty-shed assertion (`io.netty`/`zio.http` string counts ≈ 0). A new
   PR-blocking `native.yml` workflow runs both on linux-x64 so the metadata
   story can't rot. Downstream recipe and audit loop in `docs/native-image.md`.
+- **GraalVM native-image support for HTTP servers** (TJC-2114, #66): the
+  `nativeSmoke.http` module compiles the conformance server (zio-http/netty)
+  to a native binary with two flags — `--install-exit-handlers` and
+  `--initialize-at-run-time=io.netty` (countering netty-codec-http's blanket
+  build-time-init rule, which is incompatible with GraalVM on JDK 25).
+  `scripts/conformance.sh native` runs the official MCP conformance suite
+  against the binary: identical results to the JVM in both `active` (empty
+  baseline) and `2026` modes, CI-gated in `native.yml`. Netty runs on NIO
+  inside images (auto-detected; `-Dfastmcp.http.channelType` overrides).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -258,9 +258,12 @@ object server extends ScalaModule with mill.javalib.NativeImageModule {
 }
 ```
 
-CI builds and exercises a native `AnnotatedServer` on every PR (`scripts/native-smoke.sh`).
-HTTP-transport native images are in progress. Full recipe, caveats, and the metadata audit loop:
-[docs/native-image.md](docs/native-image.md).
+HTTP servers compile too (keep the zio-http dep, add `--install-exit-handlers` and
+`--initialize-at-run-time=io.netty`): the official MCP conformance suite passes against the
+native binary with results identical to the JVM. CI exercises both a native `AnnotatedServer`
+over stdio (`scripts/native-smoke.sh`) and the native conformance server over HTTP
+(`scripts/conformance.sh native`) on every PR. Full recipes, caveats, and the metadata audit
+loop: [docs/native-image.md](docs/native-image.md).
 
 ## Tasks (experimental, off by default)
 

--- a/README.md
+++ b/README.md
@@ -258,9 +258,10 @@ object server extends ScalaModule with mill.javalib.NativeImageModule {
 }
 ```
 
-HTTP servers compile too (keep the zio-http dep, add `--install-exit-handlers` and
-`--initialize-at-run-time=io.netty`): the official MCP conformance suite passes against the
-native binary with results identical to the JVM. CI exercises both a native `AnnotatedServer`
+HTTP servers compile too (keep the zio-http dep; add `--install-exit-handlers`,
+`--initialize-at-run-time=io.netty`, and `-H:+UnlockExperimentalVMOptions
+-H:+SharedArenaSupport` — see the guide for the full recipe): the official MCP conformance suite
+passes against the native binary with scenario-level parity to the JVM, enforced in CI. CI exercises both a native `AnnotatedServer`
 over stdio (`scripts/native-smoke.sh`) and the native conformance server over HTTP
 (`scripts/conformance.sh native`) on every PR. Full recipes, caveats, and the metadata audit
 loop: [docs/native-image.md](docs/native-image.md).

--- a/build.mill
+++ b/build.mill
@@ -329,6 +329,13 @@ object `fast-mcp-scala` extends Module {
     object http extends NativeSmokeModule {
       override def mainClass = Some("com.tjclp.fastmcp.examples.conformance.ConformanceServerJvm")
 
+      // Netty-scoped counter to the stale GraalVM-metadata-repo entries: the repo marks netty
+      // `override: true` but its newest netty configs are 4.1.x-era (predating netty 4.2's
+      // module renames). With the latest-config fallback off, the untested 4.2.3 gets no repo
+      // config and no `--exclude-config` stripping of its own (correct) in-jar metadata — while
+      // every other dependency keeps Mill's default repo-metadata behavior.
+      override def nativeUseLatestConfigWhenVersionIsUntested = Task { false }
+
       override def nativeImageOptions = Task {
         super.nativeImageOptions() ++ Seq(
           // SIGINT/SIGTERM must terminate a long-running server binary.

--- a/build.mill
+++ b/build.mill
@@ -321,8 +321,27 @@ object `fast-mcp-scala` extends Module {
       }
     }
 
-    // object http — added by the HTTP native-image stage (TJC-2114 PR 3/3):
-    //   mainClass = ConformanceServerJvm; netty init flags layer in as overrides there.
+    /** HTTP smoke: the conformance server over streamable HTTP — the strongest possible check
+      * (the official MCP conformance suite runs against the native binary; see
+      * `scripts/conformance.sh native`). Netty stays on the classpath here, so this module owns
+      * the netty-under-native-image flags.
+      */
+    object http extends NativeSmokeModule {
+      override def mainClass = Some("com.tjclp.fastmcp.examples.conformance.ConformanceServerJvm")
+
+      override def nativeImageOptions = Task {
+        super.nativeImageOptions() ++ Seq(
+          // SIGINT/SIGTERM must terminate a long-running server binary.
+          "--install-exit-handlers",
+          // netty-codec-http ships a blanket `--initialize-at-build-time=io.netty`, which is
+          // incompatible with GraalVM on JDK 25: buffer/handler <clinit>s allocate native memory
+          // (FFM Arena via CleanerJava25) and bake response objects into the image heap. Equal
+          // specificity + later rule wins, so this CLI arg re-defaults the whole netty tree to
+          // run-time init (netty's own class-specific run-time entries are unaffected).
+          "--initialize-at-run-time=io.netty"
+        )
+      }
+    }
   }
 }
 // Run all tests: ./mill fast-mcp-scala.jvm.test + fast-mcp-scala.js.test.bunTest

--- a/build.mill
+++ b/build.mill
@@ -338,7 +338,13 @@ object `fast-mcp-scala` extends Module {
           // (FFM Arena via CleanerJava25) and bake response objects into the image heap. Equal
           // specificity + later rule wins, so this CLI arg re-defaults the whole netty tree to
           // run-time init (netty's own class-specific run-time entries are unaffected).
-          "--initialize-at-run-time=io.netty"
+          "--initialize-at-run-time=io.netty",
+          // netty's JDK-25 direct-buffer cleaner allocates via Arena.ofShared at RUNTIME; without
+          // this, the first cleaner allocation throws UnsupportedFeatureError, killing event-loop
+          // threads one by one (service limps along on the survivors) and deadlocking SIGTERM
+          // shutdown. Found by dogfooding; the conformance gate now greps the server log for it.
+          "-H:+UnlockExperimentalVMOptions",
+          "-H:+SharedArenaSupport"
         )
       }
     }

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -114,7 +114,8 @@ CI. To re-audit (e.g. after a major dependency bump):
 
 ## Building an HTTP server
 
-HTTP native images keep zio-http/netty and need exactly two extra flags:
+HTTP native images keep zio-http/netty; relative to the stdio recipe they need one netty-scoped
+build override and four extra flags:
 
 ```scala
 object server extends ScalaModule with mill.javalib.NativeImageModule {
@@ -124,9 +125,12 @@ object server extends ScalaModule with mill.javalib.NativeImageModule {
   def mvnDeps = Seq(mvn"com.tjclp::fast-mcp-scala:<version>")   // zio-http stays
 
   override def jvmVersion = Task { "graalvm-community:25.0.2" }
-  override def nativeMetadataConfigurations =
-    Task { Set.empty[mill.javalib.graalvm.MetadataResult] }
-  override def nativeExcludedConfigJars = Task { Seq.empty[PathRef] }
+
+  // The GraalVM metadata repo marks netty `override: true` with stale 4.1.x-era configs that
+  // predate netty 4.2's module renames; with the latest-config fallback off, untested netty
+  // versions get no repo config and keep their own (correct) in-jar metadata, while every other
+  // dependency keeps Mill's default repo-metadata behavior.
+  override def nativeUseLatestConfigWhenVersionIsUntested = Task { false }
 
   override def nativeImageOptions = Task {
     super.nativeImageOptions() ++ Seq(
@@ -159,5 +163,7 @@ Runtime behavior baked into `JvmHttpBackend`:
 
 The in-repo proof: `fast-mcp-scala.nativeSmoke.http` builds the conformance server, and
 `scripts/conformance.sh native [port] [active|2026]` runs the **official MCP conformance suite**
-against the native binary, held to the unchanged (empty) JVM baseline — measured identical to the
-JVM in both modes. CI runs both on every PR.
+against the native binary, held to the unchanged (empty) JVM baseline. CI runs the active suite,
+enforces scenario-level JVM/native parity on the 2026 requirements run, requires a clean server
+log (no `UnsupportedFeatureError`), and requires the binary to exit within 15s of SIGTERM — on
+every PR.

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -7,7 +7,7 @@ Databricks Apps). Tracking issue: [#66](https://github.com/TJC-LP/fast-mcp-scala
 | Transport | Status |
 |---|---|
 | **stdio** (`McpServerApp[Stdio]`, `runStdio()`) | ✅ Supported, CI-gated (`.github/workflows/native.yml`), **zero hand-written reachability metadata** |
-| **HTTP** (`McpServerApp[Http]`, `runHttp()`) | 🚧 In progress (TJC-2114 stage 3): zio-http/netty under native-image |
+| **HTTP** (`McpServerApp[Http]`, `runHttp()`) | ✅ Supported, CI-gated: the official MCP conformance suite runs against the native binary (identical results to the JVM in both `active` and `2026` modes) |
 
 ## Why zero metadata works
 
@@ -63,10 +63,10 @@ This is not just size hygiene: netty's own in-jar reflect-config unconditionally
 methods whose signatures mention netty buffer types, forcing them reachable, and netty's
 `--initialize-at-build-time=io.netty` directive then allocates a native `MemorySegment` in
 `EmptyByteBuf.<clinit>` on JDK 25 — failing the build with "Detected a native MemorySegment in
-the image heap". With the dependency excluded, none of that metadata is on the image classpath — and Mill's
-GraalVM-reachability-metadata-repo integration can stay at its defaults, so any OTHER dependency
-you add keeps its repo metadata. (Making netty itself work under native-image is the HTTP stage
-of TJC-2114.)
+the image heap". With the dependency excluded, none of that metadata is on the image classpath —
+and Mill's GraalVM-reachability-metadata-repo integration can stay at its defaults, so any OTHER
+dependency you add keeps its repo metadata. (HTTP builds keep netty and counter the stale-repo
+problem with a scoped override — see the HTTP section below.)
 
 The in-repo proof: `fast-mcp-scala.nativeSmoke.stdio` builds
 `examples.AnnotatedServer` with exactly this shape (it filters netty/zio-http from
@@ -111,3 +111,48 @@ CI. To re-audit (e.g. after a major dependency bump):
    `fast-mcp-scala/jvm/resources/META-INF/native-image/com.tjclp/fast-mcp-scala_3/reachability-metadata.json`
    (the modern single-file format). Mill's default `resources` ships it inside the published jar,
    so downstream builds stay zero-config.
+
+## Building an HTTP server
+
+HTTP native images keep zio-http/netty and need exactly two extra flags:
+
+```scala
+object server extends ScalaModule with mill.javalib.NativeImageModule {
+  def scalaVersion = "3.8.3"
+  def mainClass = Some("com.example.MyHttpServer")
+  def mvnDeps = Seq(mvn"com.tjclp::fast-mcp-scala:<version>")   // zio-http stays
+
+  override def jvmVersion = Task { "graalvm-community:25.0.2" }
+  override def nativeMetadataConfigurations =
+    Task { Set.empty[mill.javalib.graalvm.MetadataResult] }
+  override def nativeExcludedConfigJars = Task { Seq.empty[PathRef] }
+
+  override def nativeImageOptions = Task {
+    super.nativeImageOptions() ++ Seq(
+      "--no-fallback",
+      // SIGINT/SIGTERM must terminate a long-running server binary.
+      "--install-exit-handlers",
+      // netty-codec-http ships a blanket `--initialize-at-build-time=io.netty`, which is
+      // incompatible with GraalVM on JDK 25 (buffer/handler <clinit>s allocate native memory via
+      // the FFM CleanerJava25 and bake response objects into the image heap). Equal specificity +
+      // later rule wins, so this re-defaults the whole netty tree to run-time init; netty's own
+      // class-specific run-time entries are unaffected.
+      "--initialize-at-run-time=io.netty"
+    )
+  }
+}
+```
+
+Runtime behavior baked into `JvmHttpBackend`:
+
+- **Netty channel type**: `AUTO` (epoll/kqueue) on a normal JVM, **`NIO` inside a native image**
+  (detected via the `org.graalvm.nativeimage.imagecode` property — `AUTO`'s runtime transport
+  probing is exactly what closed-world analysis can't tolerate). Override with
+  `-Dfastmcp.http.channelType=nio|epoll|kqueue|auto` if you know what you're doing.
+- **Container binding**: the default host is `127.0.0.1`; set
+  `McpServerSettings(host = "0.0.0.0")` for containerized deployments (Databricks Apps included).
+
+The in-repo proof: `fast-mcp-scala.nativeSmoke.http` builds the conformance server, and
+`scripts/conformance.sh native [port] [active|2026]` runs the **official MCP conformance suite**
+against the native binary, held to the unchanged (empty) JVM baseline — measured identical to the
+JVM in both modes. CI runs both on every PR.

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -119,6 +119,7 @@ HTTP native images keep zio-http/netty and need exactly two extra flags:
 ```scala
 object server extends ScalaModule with mill.javalib.NativeImageModule {
   def scalaVersion = "3.8.3"
+  def scalacOptions = Seq("-experimental")                      // annotation macros require it
   def mainClass = Some("com.example.MyHttpServer")
   def mvnDeps = Seq(mvn"com.tjclp::fast-mcp-scala:<version>")   // zio-http stays
 
@@ -137,7 +138,11 @@ object server extends ScalaModule with mill.javalib.NativeImageModule {
       // the FFM CleanerJava25 and bake response objects into the image heap). Equal specificity +
       // later rule wins, so this re-defaults the whole netty tree to run-time init; netty's own
       // class-specific run-time entries are unaffected.
-      "--initialize-at-run-time=io.netty"
+      "--initialize-at-run-time=io.netty",
+      // netty's JDK-25 direct-buffer cleaner allocates via Arena.ofShared at runtime; without
+      // this, cleaner allocations throw and kill event-loop threads (and SIGTERM shutdown hangs).
+      "-H:+UnlockExperimentalVMOptions",
+      "-H:+SharedArenaSupport"
     )
   }
 }

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -2,7 +2,7 @@
 #
 # Run the official MCP conformance server suites against fast-mcp-scala.
 #
-#   scripts/conformance.sh [jvm|js] [port] [active|2026]
+#   scripts/conformance.sh [jvm|js|native] [port] [active|2026]
 #
 # Boots the cross-platform ConformanceServer (com.tjclp.fastmcp.examples.conformance.*) over
 # streamable HTTP, then drives it with the official harness via `bunx`. Exit code follows the harness
@@ -13,6 +13,11 @@
 # frozen at its release (extension/pending scenarios are reported but not scored by the harness).
 #
 # Requires: a JDK (jvm), bun (both). No vendored conformance checkout — the engine is fetched by bunx.
+#
+# "native" runs the SAME conformance server compiled to a GraalVM native image
+# (fast-mcp-scala.nativeSmoke.http.nativeImage; override with FAST_MCP_NATIVE_BIN) against the
+# UNCHANGED jvm baseline — the binary is behaviorally the same server, so any divergence is a
+# native-image bug to fix, never a new baseline.
 set -euo pipefail
 
 PLATFORM="${1:-jvm}"
@@ -23,6 +28,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 URL="http://127.0.0.1:${PORT}/mcp"
 BASELINE="$ROOT/conformance/baseline-${PLATFORM}.yml"
+[ "$PLATFORM" = "native" ] && BASELINE="$ROOT/conformance/baseline-jvm.yml"
 LOG="$(mktemp -t fmcp-conf-log.XXXXXX)"
 SRV_PID=""
 ENTRY=""
@@ -58,10 +64,25 @@ start_js() {
   SRV_PID=$!
 }
 
+start_native() {
+  local bin="${FAST_MCP_NATIVE_BIN:-}"
+  if [ -z "$bin" ]; then
+    echo "→ building native ConformanceServer (GraalVM)" >&2
+    ./mill --no-server fast-mcp-scala.nativeSmoke.http.nativeImage >/dev/null 2>&1
+    bin="$(./mill --no-server show fast-mcp-scala.nativeSmoke.http.nativeImage 2>/dev/null |
+      python3 -c "import sys,json,re; print(re.sub(r'^q?ref:v\\d+:[0-9a-f]+:','',json.load(sys.stdin)))")"
+  fi
+  [ -x "$bin" ] || { echo "native binary not found/executable: $bin" >&2; exit 1; }
+  echo "→ launching native ConformanceServer on :$PORT ($bin)" >&2
+  "$bin" "$PORT" >"$LOG" 2>&1 &
+  SRV_PID=$!
+}
+
 case "$PLATFORM" in
   jvm) start_jvm ;;
   js) start_js ;;
-  *) echo "usage: $0 [jvm|js] [port]" >&2; exit 2 ;;
+  native) start_native ;;
+  *) echo "usage: $0 [jvm|js|native] [port]" >&2; exit 2 ;;
 esac
 
 echo "→ waiting for $URL" >&2
@@ -83,7 +104,7 @@ case "$MODE" in
     bunx "@modelcontextprotocol/conformance@${CONF_VERSION}" \
       server --url "$URL" --requirements 2026-07-28
     ;;
-  *) echo "usage: $0 [jvm|js] [port] [active|2026]" >&2; exit 2 ;;
+  *) echo "usage: $0 [jvm|js|native] [port] [active|2026]" >&2; exit 2 ;;
 esac
 RC=$?
 set -e

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -109,4 +109,11 @@ esac
 RC=$?
 set -e
 echo "→ server log: $LOG" >&2
+# Native binaries can shed threads on GraalVM UnsupportedFeatureError while the suite still
+# passes on the surviving event loops — treat any such error as a failure.
+if [ "$PLATFORM" = "native" ] && grep -q "UnsupportedFeatureError" "$LOG"; then
+  echo "native FAIL: UnsupportedFeatureError in server log (suite verdict: $RC)" >&2
+  grep -m1 -A3 "UnsupportedFeatureError" "$LOG" >&2
+  exit 1
+fi
 exit "$RC"

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -31,13 +31,40 @@ BASELINE="$ROOT/conformance/baseline-${PLATFORM}.yml"
 [ "$PLATFORM" = "native" ] && BASELINE="$ROOT/conformance/baseline-jvm.yml"
 LOG="$(mktemp -t fmcp-conf-log.XXXXXX)"
 SRV_PID=""
+SRV_STOPPED=""
 ENTRY=""
 
+# Terminate the launched server and record HOW it died: "clean" (exited within 15s of SIGTERM)
+# or "hang" (needed SIGKILL). Idempotent; used both on the normal path (so the completed log can
+# be inspected afterwards) and from the EXIT trap.
+stop_server() {
+  [ -n "$SRV_PID" ] || return 0
+  kill -TERM "$SRV_PID" 2>/dev/null || true
+  for _ in $(seq 1 30); do
+    kill -0 "$SRV_PID" 2>/dev/null || { SRV_STOPPED="clean"; break; }
+    sleep 0.5
+  done
+  if [ "$SRV_STOPPED" != "clean" ]; then
+    SRV_STOPPED="hang"
+    kill -9 "$SRV_PID" 2>/dev/null || true
+  fi
+  wait "$SRV_PID" 2>/dev/null || true
+  SRV_PID=""
+}
+
 cleanup() {
-  [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null || true
+  stop_server
   [ -n "$ENTRY" ] && rm -f "$ENTRY" 2>/dev/null || true
 }
 trap cleanup EXIT
+
+# Refuse to run if ANYTHING already listens on the port — the readiness poll below would
+# otherwise happily bless a foreign server and the suite would test the wrong process.
+if (exec 3<>"/dev/tcp/127.0.0.1/$PORT") 2>/dev/null; then
+  exec 3>&- 3<&- 2>/dev/null || true
+  echo "port $PORT is already in use — refusing to test an unknown server" >&2
+  exit 2
+fi
 
 jvm_classpath() {
   ./mill --no-server show fast-mcp-scala.jvm.runClasspath 2>/dev/null |
@@ -87,6 +114,11 @@ esac
 
 echo "→ waiting for $URL" >&2
 for i in $(seq 1 90); do
+  # The child must still be alive AND answering — a dead child with a lingering listener (or a
+  # foreign process) must never pass readiness.
+  if ! kill -0 "$SRV_PID" 2>/dev/null; then
+    echo "server process died during startup; log:" >&2; cat "$LOG" >&2; exit 1
+  fi
   curl -s -o /dev/null "$URL" 2>/dev/null && break
   if [ "$i" -eq 90 ]; then echo "server failed to start; log:" >&2; cat "$LOG" >&2; exit 1; fi
   sleep 0.5
@@ -108,12 +140,22 @@ case "$MODE" in
 esac
 RC=$?
 set -e
+# Terminate BEFORE inspecting the log, so teardown-time failures are gated too.
+stop_server
 echo "→ server log: $LOG" >&2
-# Native binaries can shed threads on GraalVM UnsupportedFeatureError while the suite still
-# passes on the surviving event loops — treat any such error as a failure.
-if [ "$PLATFORM" = "native" ] && grep -q "UnsupportedFeatureError" "$LOG"; then
-  echo "native FAIL: UnsupportedFeatureError in server log (suite verdict: $RC)" >&2
-  grep -m1 -A3 "UnsupportedFeatureError" "$LOG" >&2
-  exit 1
+if [ "$PLATFORM" = "native" ]; then
+  # --install-exit-handlers must actually work: a binary that survives 15s of SIGTERM is a bug
+  # (dead event loops deadlocking shutdown was exactly the failure SharedArenaSupport fixed).
+  if [ "$SRV_STOPPED" = "hang" ]; then
+    echo "native FAIL: server did not exit within 15s of SIGTERM (suite verdict: $RC)" >&2
+    exit 1
+  fi
+  # Native binaries can shed threads on GraalVM UnsupportedFeatureError while the suite still
+  # passes on the surviving event loops — treat any such error as a failure.
+  if grep -q "UnsupportedFeatureError" "$LOG"; then
+    echo "native FAIL: UnsupportedFeatureError in server log (suite verdict: $RC)" >&2
+    grep -m1 -A3 "UnsupportedFeatureError" "$LOG" >&2
+    exit 1
+  fi
 fi
 exit "$RC"


### PR DESCRIPTION
## Summary

PR **3 of 3** (stacked on #72 ← #67-merged). Replaces #69, whose stack metadata wedged (mergeability stuck UNKNOWN, CI not triggering) after the stage-1 squash-merge + branch deletion; identical content, same branch. for GraalVM native-image support (#66, Linear TJC-2114). Delivers issue #66's request 2: a supported native-image story for `McpServerApp[Http]` — and the primary path (zio-http/netty under native-image) worked, no JDK-HttpServer fallback needed.

### The whole netty fix is one flag

`--initialize-at-run-time=io.netty` (plus `--install-exit-handlers` for SIGTERM). netty-codec-http ships a blanket `--initialize-at-build-time=io.netty` in its jar, which is incompatible with GraalVM on JDK 25: buffer/handler class initializers allocate native memory via the FFM `CleanerJava25` (`EmptyByteBuf`, `UnpooledByteBufAllocator`) and bake `DefaultFullHttpResponse` statics into the image heap (`HttpServerExpectContinueHandler`, `HttpObjectAggregator`) — each a fatal image-heap error, chased with `--trace-object-instantiation`. Equal specificity + later-rule-wins means one CLI package rule re-defaults the whole netty tree to run-time init while netty's own class-specific run-time entries stand. The #67 channel-type pin engages automatically in-image (NIO via `org.graalvm.nativeimage.imagecode`) — verified serving on a machine where AUTO would have picked kqueue.

### What's here

- **`nativeSmoke.http`** Mill module: `ConformanceServerJvm` → native binary (64MB).
- **`scripts/conformance.sh native [port] [active|2026]`**: builds/launches the native binary and runs the **official MCP conformance suite** against it, held to the **unchanged empty jvm baseline** — divergence is a native bug by policy, never a new baseline.
- **`native.yml`**: second linux-x64 job runs both conformance modes on every PR.
- **`docs/native-image.md`** HTTP recipe + README/CHANGELOG updates.

### Measured (macOS arm64, side-by-side on this branch)

| Mode | Native binary | JVM |
|---|---|---|
| `active` suite | baseline check passed (73/73) | baseline check passed (73/73) |
| `2026` requirements | exit 0, 146 passed / 36 unscored-failed | exit 0, **identical totals** |

(One debugging war story for reviewers: the first native conformance run appeared to pass 73/73 — against a months-old stale ConformanceServer squatting on :8077 from an old worktree. The readiness poll now-obviously curls whatever owns the port; killed it, re-ran everything for real.)

## Merge order

Merge #72 first (do NOT delete its branch until this PR is retargeted/recreated onto main), then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
