### PR TITLE
feat: GraalVM native-image support — stdio + HTTP (TJC-2114, 2/2)

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Cache Mill
         uses: actions/cache@v4
         with:
-          path: ~/.mill
+          path: ~/.cache/mill
           key: ${{ runner.os }}-mill-native-${{ hashFiles('**/build.mill') }}
           restore-keys: |
             ${{ runner.os }}-mill-native-

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Cache Mill
         uses: actions/cache@v4
         with:
-          path: ~/.mill
+          path: ~/.cache/mill
           key: ${{ runner.os }}-mill-native-${{ hashFiles('**/build.mill') }}
           restore-keys: |
             ${{ runner.os }}-mill-native-
@@ -95,8 +95,15 @@ jobs:
 
       # The official MCP conformance suite against the native binary, held to the SAME
       # (empty) baseline as the JVM: any divergence is a native-image bug, never a new baseline.
+      # Distinct ports per step so a lingering listener can never satisfy the next readiness poll
+      # (the script also refuses to start if its port is taken).
       - name: Conformance (active suite)
         run: ./scripts/conformance.sh native 8077 active
 
-      - name: Conformance (2026-07-28 requirements)
-        run: ./scripts/conformance.sh native 8077 2026
+      # Scenario-level parity on the 2026 requirements run: the native binary must produce the
+      # SAME normalized scenario results as the JVM server, not merely a passing exit code.
+      - name: Conformance parity (2026 requirements, JVM vs native)
+        run: |
+          ./scripts/conformance.sh jvm 8078 2026 | sed 's/\x1b\[[0-9;]*m//g' | grep -E '^(✓|✗|Total:)' > jvm-2026.txt
+          ./scripts/conformance.sh native 8079 2026 | sed 's/\x1b\[[0-9;]*m//g' | grep -E '^(✓|✗|Total:)' > native-2026.txt
+          diff -u jvm-2026.txt native-2026.txt

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -54,3 +54,49 @@ jobs:
 
       - name: Exercise binary over stdio JSON-RPC
         run: ./scripts/native-smoke.sh
+
+  native-http:
+    name: native-image HTTP conformance (linux-x64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK (Mill runner only)
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:21
+
+      - name: Set up Bun (conformance harness)
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Cache Coursier (incl. GraalVM archive)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier
+            ~/.ivy2/cache
+          key: ${{ runner.os }}-coursier-native-${{ hashFiles('**/build.mill') }}
+          restore-keys: |
+            ${{ runner.os }}-coursier-native-
+
+      - name: Cache Mill
+        uses: actions/cache@v4
+        with:
+          path: ~/.mill
+          key: ${{ runner.os }}-mill-native-${{ hashFiles('**/build.mill') }}
+          restore-keys: |
+            ${{ runner.os }}-mill-native-
+
+      - name: Build native HTTP conformance binary
+        run: ./mill fast-mcp-scala.nativeSmoke.http.nativeImage
+
+      # The official MCP conformance suite against the native binary, held to the SAME
+      # (empty) baseline as the JVM: any divergence is a native-image bug, never a new baseline.
+      - name: Conformance (active suite)
+        run: ./scripts/conformance.sh native 8077 active
+
+      - name: Conformance (2026-07-28 requirements)
+        run: ./scripts/conformance.sh native 8077 2026

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -1,0 +1,56 @@
+name: Native Image
+
+# Builds the stdio smoke binary with GraalVM and drives it over JSON-RPC
+# (scripts/native-smoke.sh) so the native-image story (GH #66 / TJC-2114) can
+# never rot silently: any dependency bump that introduces a reflection need or
+# re-couples the transport seam turns this red on the PR that does it.
+#
+# No JDK matrix: temurin:21 only runs Mill itself — GraalVM is provisioned by
+# Mill via the coursier JVM index (`jvmVersion` on the nativeSmoke modules).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  native-smoke:
+    name: native-image stdio smoke (linux-x64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK (Mill runner only)
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:21
+
+      # Separate cache key from ci.yml so the ~350MB GraalVM archive doesn't
+      # bloat the main build's cache.
+      - name: Cache Coursier (incl. GraalVM archive)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier
+            ~/.ivy2/cache
+          key: ${{ runner.os }}-coursier-native-${{ hashFiles('**/build.mill') }}
+          restore-keys: |
+            ${{ runner.os }}-coursier-native-
+
+      - name: Cache Mill
+        uses: actions/cache@v4
+        with:
+          path: ~/.mill
+          key: ${{ runner.os }}-mill-native-${{ hashFiles('**/build.mill') }}
+          restore-keys: |
+            ${{ runner.os }}-mill-native-
+
+      - name: Build native stdio smoke binary
+        run: ./mill fast-mcp-scala.nativeSmoke.stdio.nativeImage
+
+      - name: Exercise binary over stdio JSON-RPC
+        run: ./scripts/native-smoke.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **GraalVM native-image support for stdio servers** (TJC-2114, #66): the
+  non-published `nativeSmoke.stdio` Mill module builds `examples.AnnotatedServer`
+  into a native binary (GraalVM 25, `--no-fallback`) with **zero hand-written
+  reachability metadata**, and `scripts/native-smoke.sh` drives the full MCP
+  handshake against it — including the runtime tapir→circe schema path — plus a
+  netty-shed assertion (`io.netty`/`zio.http` string counts ≈ 0). A new
+  PR-blocking `native.yml` workflow runs both on linux-x64 so the metadata
+  story can't rot. Downstream recipe and audit loop in `docs/native-image.md`.
+
 ### Changed
 
 - **BREAKING (binary): the transport seam is split in two** (TJC-2114, #66).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   story can't rot. Downstream recipe and audit loop in `docs/native-image.md`.
 - **GraalVM native-image support for HTTP servers** (TJC-2114, #66): the
   `nativeSmoke.http` module compiles the conformance server (zio-http/netty)
-  to a native binary with two flags — `--install-exit-handlers` and
+  to a native binary with a four-flag recipe: `--install-exit-handlers`,
   `--initialize-at-run-time=io.netty` (countering netty-codec-http's blanket
-  build-time-init rule, which is incompatible with GraalVM on JDK 25).
+  build-time-init rule, incompatible with GraalVM on JDK 25), and
+  `-H:+UnlockExperimentalVMOptions -H:+SharedArenaSupport` (netty's JDK-25
+  direct-buffer cleaner allocates via `Arena.ofShared` at runtime; without it
+  event-loop threads die one by one and SIGTERM shutdown hangs).
   `scripts/conformance.sh native` runs the official MCP conformance suite
   against the binary: identical results to the JVM in both `active` (empty
   baseline) and `2026` modes, CI-gated in `native.yml`. Netty runs on NIO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   netty-shed assertion (`io.netty`/`zio.http` string counts ≈ 0). A new
   PR-blocking `native.yml` workflow runs both on linux-x64 so the metadata
   story can't rot. Downstream recipe and audit loop in `docs/native-image.md`.
+- **GraalVM native-image support for HTTP servers** (TJC-2114, #66): the
+  `nativeSmoke.http` module compiles the conformance server (zio-http/netty)
+  to a native binary with two flags — `--install-exit-handlers` and
+  `--initialize-at-run-time=io.netty` (countering netty-codec-http's blanket
+  build-time-init rule, which is incompatible with GraalVM on JDK 25).
+  `scripts/conformance.sh native` runs the official MCP conformance suite
+  against the binary: identical results to the JVM in both `active` (empty
+  baseline) and `2026` modes, CI-gated in `native.yml`. Netty runs on NIO
+  inside images (auto-detected; `-Dfastmcp.http.channelType` overrides).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -258,9 +258,12 @@ object server extends ScalaModule with mill.javalib.NativeImageModule {
 }
 ```
 
-CI builds and exercises a native `AnnotatedServer` on every PR (`scripts/native-smoke.sh`).
-HTTP-transport native images are in progress. Full recipe, caveats, and the metadata audit loop:
-[docs/native-image.md](docs/native-image.md).
+HTTP servers compile too (keep the zio-http dep, add `--install-exit-handlers` and
+`--initialize-at-run-time=io.netty`): the official MCP conformance suite passes against the
+native binary with results identical to the JVM. CI exercises both a native `AnnotatedServer`
+over stdio (`scripts/native-smoke.sh`) and the native conformance server over HTTP
+(`scripts/conformance.sh native`) on every PR. Full recipes, caveats, and the metadata audit
+loop: [docs/native-image.md](docs/native-image.md).
 
 ## Tasks (experimental, off by default)
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Built on **ZIO 2**, **Tapir**-derived schemas, and **zio-json** on both platform
 - [Prompts](#prompts)
 - [Context (`McpContext`)](#context-mcpcontext)
 - [Transports](#transports)
+- [Native image (GraalVM)](#native-image-graalvm)
 - [Customizing decoding (zio-json)](#customizing-decoding-zio-json)
 - [One core, two transports](#one-core-two-transports)
 - [Spec coverage](#spec-coverage)
@@ -238,6 +239,27 @@ Need lower-level control? Skip the sugar trait and construct directly — `val s
 | `resourcesSubscribe` | `false` | Enable legacy `resources/subscribe`; modern clients use `subscriptions/listen` |
 
 Modern POST requests must include `Content-Type: application/json`, an `Accept` header listing both JSON and SSE, `MCP-Protocol-Version: 2026-07-28`, and `Mcp-Method`; tool calls, resource reads, and prompt gets also require `Mcp-Name`. The protocol version and client capabilities are repeated in every request's `params._meta`. Header/body mismatches return HTTP 400 with `-32020`; unsupported versions return `-32022`; unknown request methods return HTTP 404 with `-32601`. The complete wire-behavior and review matrix is in the [2026-07-28 upgrade guide](docs/2026-07-28-upgrade.md).
+
+## Native image (GraalVM)
+
+Stdio servers compile to self-contained native binaries with **zero hand-written reachability
+metadata** — registration and schema derivation are compile-time macros, so there is nothing for
+closed-world analysis to miss, and the transport-seam split keeps zio-http/netty out of
+stdio-only images entirely (~35 MB, instant startup, no JVM in the container):
+
+```scala
+object server extends ScalaModule with mill.javalib.NativeImageModule {
+  def mvnDeps = Seq(mvn"com.tjclp::fast-mcp-scala:<version>".exclude("dev.zio" -> "zio-http_3"))
+  def mainClass = Some("com.example.MyServer")
+  override def jvmVersion = Task { "graalvm-community:25.0.2" }
+  override def nativeImageOptions = Task { super.nativeImageOptions() ++ Seq("--no-fallback") }
+  // + two one-line overrides to neutralize stale netty metadata; see the guide
+}
+```
+
+CI builds and exercises a native `AnnotatedServer` on every PR (`scripts/native-smoke.sh`).
+HTTP-transport native images are in progress. Full recipe, caveats, and the metadata audit loop:
+[docs/native-image.md](docs/native-image.md).
 
 ## Tasks (experimental, off by default)
 

--- a/README.md
+++ b/README.md
@@ -249,11 +249,12 @@ stdio-only images entirely (~35 MB, instant startup, no JVM in the container):
 
 ```scala
 object server extends ScalaModule with mill.javalib.NativeImageModule {
+  def scalaVersion = "3.8.3"
+  def scalacOptions = Seq("-experimental")   // the annotation macros require it
   def mvnDeps = Seq(mvn"com.tjclp::fast-mcp-scala:<version>".exclude("dev.zio" -> "zio-http_3"))
   def mainClass = Some("com.example.MyServer")
   override def jvmVersion = Task { "graalvm-community:25.0.2" }
   override def nativeImageOptions = Task { super.nativeImageOptions() ++ Seq("--no-fallback") }
-  // + two one-line overrides to neutralize stale netty metadata; see the guide
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -258,9 +258,10 @@ object server extends ScalaModule with mill.javalib.NativeImageModule {
 }
 ```
 
-HTTP servers compile too (keep the zio-http dep, add `--install-exit-handlers` and
-`--initialize-at-run-time=io.netty`): the official MCP conformance suite passes against the
-native binary with results identical to the JVM. CI exercises both a native `AnnotatedServer`
+HTTP servers compile too (keep the zio-http dep; add `--install-exit-handlers`,
+`--initialize-at-run-time=io.netty`, and `-H:+UnlockExperimentalVMOptions
+-H:+SharedArenaSupport` — see the guide for the full recipe): the official MCP conformance suite
+passes against the native binary with scenario-level parity to the JVM, enforced in CI. CI exercises both a native `AnnotatedServer`
 over stdio (`scripts/native-smoke.sh`) and the native conformance server over HTTP
 (`scripts/conformance.sh native`) on every PR. Full recipes, caveats, and the metadata audit
 loop: [docs/native-image.md](docs/native-image.md).

--- a/build.mill
+++ b/build.mill
@@ -329,6 +329,13 @@ object `fast-mcp-scala` extends Module {
     object http extends NativeSmokeModule {
       override def mainClass = Some("com.tjclp.fastmcp.examples.conformance.ConformanceServerJvm")
 
+      // Netty-scoped counter to the stale GraalVM-metadata-repo entries: the repo marks netty
+      // `override: true` but its newest netty configs are 4.1.x-era (predating netty 4.2's
+      // module renames). With the latest-config fallback off, the untested 4.2.3 gets no repo
+      // config and no `--exclude-config` stripping of its own (correct) in-jar metadata — while
+      // every other dependency keeps Mill's default repo-metadata behavior.
+      override def nativeUseLatestConfigWhenVersionIsUntested = Task { false }
+
       override def nativeImageOptions = Task {
         super.nativeImageOptions() ++ Seq(
           // SIGINT/SIGTERM must terminate a long-running server binary.

--- a/build.mill
+++ b/build.mill
@@ -281,14 +281,6 @@ object `fast-mcp-scala` extends Module {
       // JVM index; pinned exactly (bump deliberately, in step with docs/native-image.md).
       override def jvmVersion: T[String] = Task { "graalvm-community:25.0.2" }
 
-      // Neutralize Mill's GraalVM-reachability-metadata-repo integration. Left enabled it would
-      // `--exclude-config` netty's own in-jar metadata (the repo marks netty `override: true`)
-      // and substitute stale 4.1.x-era configs that predate netty 4.2's module renames. We want
-      // exactly the in-jar metadata that libraries ship (zio and netty both do).
-      override def nativeMetadataConfigurations =
-        Task { Set.empty[mill.javalib.graalvm.MetadataResult] }
-      override def nativeExcludedConfigJars = Task { Seq.empty[PathRef] }
-
       override def nativeImageOptions = Task {
         super.nativeImageOptions() ++ Seq(
           "--no-fallback" // fail the build rather than emit a JVM-hosted fallback image
@@ -302,6 +294,16 @@ object `fast-mcp-scala` extends Module {
       */
     object stdio extends NativeSmokeModule {
       override def mainClass = Some("com.tjclp.fastmcp.examples.AnnotatedServer")
+
+      // Neutralize Mill's GraalVM-reachability-metadata-repo integration FOR THIS MODULE: netty
+      // stays in the resolved deps (moduleDeps can't exclude it the way a downstream dependency
+      // exclusion does, only the classpath filter below), so Mill would otherwise inject stale
+      // 4.1.x-era netty repo configs referencing classes this image doesn't carry. A downstream
+      // stdio build that excludes zio-http needs NEITHER override — Mill's defaults are correct
+      // there (and other dependencies keep their repo metadata).
+      override def nativeMetadataConfigurations =
+        Task { Set.empty[mill.javalib.graalvm.MetadataResult] }
+      override def nativeExcludedConfigJars = Task { Seq.empty[PathRef] }
 
       // A stdio-only server has no reachable path into the HTTP stack (the transport-seam split),
       // so drop zio-http/netty from the image classpath — the same shape as a downstream

--- a/build.mill
+++ b/build.mill
@@ -321,8 +321,27 @@ object `fast-mcp-scala` extends Module {
       }
     }
 
-    // object http — added by the HTTP native-image stage (TJC-2114 PR 3/3):
-    //   mainClass = ConformanceServerJvm; netty init flags layer in as overrides there.
+    /** HTTP smoke: the conformance server over streamable HTTP — the strongest possible check
+      * (the official MCP conformance suite runs against the native binary; see
+      * `scripts/conformance.sh native`). Netty stays on the classpath here, so this module owns
+      * the netty-under-native-image flags.
+      */
+    object http extends NativeSmokeModule {
+      override def mainClass = Some("com.tjclp.fastmcp.examples.conformance.ConformanceServerJvm")
+
+      override def nativeImageOptions = Task {
+        super.nativeImageOptions() ++ Seq(
+          // SIGINT/SIGTERM must terminate a long-running server binary.
+          "--install-exit-handlers",
+          // netty-codec-http ships a blanket `--initialize-at-build-time=io.netty`, which is
+          // incompatible with GraalVM on JDK 25: buffer/handler <clinit>s allocate native memory
+          // (FFM Arena via CleanerJava25) and bake response objects into the image heap. Equal
+          // specificity + later rule wins, so this CLI arg re-defaults the whole netty tree to
+          // run-time init (netty's own class-specific run-time entries are unaffected).
+          "--initialize-at-run-time=io.netty"
+        )
+      }
+    }
   }
 }
 // Run all tests: ./mill fast-mcp-scala.jvm.test + fast-mcp-scala.js.test.bunTest

--- a/build.mill
+++ b/build.mill
@@ -338,7 +338,13 @@ object `fast-mcp-scala` extends Module {
           // (FFM Arena via CleanerJava25) and bake response objects into the image heap. Equal
           // specificity + later rule wins, so this CLI arg re-defaults the whole netty tree to
           // run-time init (netty's own class-specific run-time entries are unaffected).
-          "--initialize-at-run-time=io.netty"
+          "--initialize-at-run-time=io.netty",
+          // netty's JDK-25 direct-buffer cleaner allocates via Arena.ofShared at RUNTIME; without
+          // this, the first cleaner allocation throws UnsupportedFeatureError, killing event-loop
+          // threads one by one (service limps along on the survivors) and deadlocking SIGTERM
+          // shutdown. Found by dogfooding; the conformance gate now greps the server log for it.
+          "-H:+UnlockExperimentalVMOptions",
+          "-H:+SharedArenaSupport"
         )
       }
     }

--- a/build.mill
+++ b/build.mill
@@ -262,5 +262,65 @@ object `fast-mcp-scala` extends Module {
       }
     }
   }
+
+  /** GraalVM native-image smoke binaries (NOT published — verify with `resolve __.publishArtifacts`).
+    *
+    * These exist so CI proves that a downstream `NativeImageModule` build against fast-mcp-scala
+    * needs zero hand-written reachability config (GH #66 / TJC-2114). One object per binary,
+    * because `NativeImageModule` builds from `finalMainClass`. Exercised by
+    * `scripts/native-smoke.sh` and `.github/workflows/native.yml`.
+    */
+  object nativeSmoke extends Module {
+
+    trait NativeSmokeModule extends ScalaModule with mill.javalib.NativeImageModule {
+      override def scalaVersion: T[String] = scala3Version
+      override def moduleDeps = Seq(jvm)
+
+      // GraalVM scoped to the smoke modules ONLY — setting jvmVersion on the published jvm
+      // module would silently change its compile/test JVM. Provisioned by Mill via the coursier
+      // JVM index; pinned exactly (bump deliberately, in step with docs/native-image.md).
+      override def jvmVersion: T[String] = Task { "graalvm-community:25.0.2" }
+
+      // Neutralize Mill's GraalVM-reachability-metadata-repo integration. Left enabled it would
+      // `--exclude-config` netty's own in-jar metadata (the repo marks netty `override: true`)
+      // and substitute stale 4.1.x-era configs that predate netty 4.2's module renames. We want
+      // exactly the in-jar metadata that libraries ship (zio and netty both do).
+      override def nativeMetadataConfigurations =
+        Task { Set.empty[mill.javalib.graalvm.MetadataResult] }
+      override def nativeExcludedConfigJars = Task { Seq.empty[PathRef] }
+
+      override def nativeImageOptions = Task {
+        super.nativeImageOptions() ++ Seq(
+          "--no-fallback" // fail the build rather than emit a JVM-hosted fallback image
+        )
+      }
+    }
+
+    /** Stdio smoke: AnnotatedServer covers the full surface a downstream stdio server hits at
+      * runtime — macro-registered tools/prompts/resources AND the genuine runtime tapir→circe
+      * JSON-schema rendering path (materialized at registration/tools-list time).
+      */
+    object stdio extends NativeSmokeModule {
+      override def mainClass = Some("com.tjclp.fastmcp.examples.AnnotatedServer")
+
+      // A stdio-only server has no reachable path into the HTTP stack (the transport-seam split),
+      // so drop zio-http/netty from the image classpath — the same shape as a downstream
+      // stdio-only build that excludes the zio-http dependency. This isn't just size hygiene:
+      // netty's own in-jar reflect-config unconditionally registers methods whose signatures
+      // mention netty buffer types, forcing them reachable, and netty's
+      // `--initialize-at-build-time=io.netty` then allocates a native MemorySegment in
+      // EmptyByteBuf.<clinit> on JDK 25 — an image-heap error. Reachability truth is proven by
+      // the smoke run: any seam leak resurfaces as a linking/runtime failure.
+      override def nativeImageClasspath = Task {
+        super.nativeImageClasspath().filterNot { ref =>
+          val name = ref.path.last
+          name.startsWith("netty-") || name.startsWith("zio-http")
+        }
+      }
+    }
+
+    // object http — added by the HTTP native-image stage (TJC-2114 PR 3/3):
+    //   mainClass = ConformanceServerJvm; netty init flags layer in as overrides there.
+  }
 }
 // Run all tests: ./mill fast-mcp-scala.jvm.test + fast-mcp-scala.js.test.bunTest

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -114,7 +114,8 @@ CI. To re-audit (e.g. after a major dependency bump):
 
 ## Building an HTTP server
 
-HTTP native images keep zio-http/netty and need exactly two extra flags:
+HTTP native images keep zio-http/netty; relative to the stdio recipe they need one netty-scoped
+build override and four extra flags:
 
 ```scala
 object server extends ScalaModule with mill.javalib.NativeImageModule {
@@ -124,9 +125,12 @@ object server extends ScalaModule with mill.javalib.NativeImageModule {
   def mvnDeps = Seq(mvn"com.tjclp::fast-mcp-scala:<version>")   // zio-http stays
 
   override def jvmVersion = Task { "graalvm-community:25.0.2" }
-  override def nativeMetadataConfigurations =
-    Task { Set.empty[mill.javalib.graalvm.MetadataResult] }
-  override def nativeExcludedConfigJars = Task { Seq.empty[PathRef] }
+
+  // The GraalVM metadata repo marks netty `override: true` with stale 4.1.x-era configs that
+  // predate netty 4.2's module renames; with the latest-config fallback off, untested netty
+  // versions get no repo config and keep their own (correct) in-jar metadata, while every other
+  // dependency keeps Mill's default repo-metadata behavior.
+  override def nativeUseLatestConfigWhenVersionIsUntested = Task { false }
 
   override def nativeImageOptions = Task {
     super.nativeImageOptions() ++ Seq(
@@ -159,5 +163,7 @@ Runtime behavior baked into `JvmHttpBackend`:
 
 The in-repo proof: `fast-mcp-scala.nativeSmoke.http` builds the conformance server, and
 `scripts/conformance.sh native [port] [active|2026]` runs the **official MCP conformance suite**
-against the native binary, held to the unchanged (empty) JVM baseline — measured identical to the
-JVM in both modes. CI runs both on every PR.
+against the native binary, held to the unchanged (empty) JVM baseline. CI runs the active suite,
+enforces scenario-level JVM/native parity on the 2026 requirements run, requires a clean server
+log (no `UnsupportedFeatureError`), and requires the binary to exit within 15s of SIGTERM — on
+every PR.

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -7,7 +7,7 @@ Databricks Apps). Tracking issue: [#66](https://github.com/TJC-LP/fast-mcp-scala
 | Transport | Status |
 |---|---|
 | **stdio** (`McpServerApp[Stdio]`, `runStdio()`) | ✅ Supported, CI-gated (`.github/workflows/native.yml`), **zero hand-written reachability metadata** |
-| **HTTP** (`McpServerApp[Http]`, `runHttp()`) | 🚧 In progress (TJC-2114 stage 3): zio-http/netty under native-image |
+| **HTTP** (`McpServerApp[Http]`, `runHttp()`) | ✅ Supported, CI-gated: the official MCP conformance suite runs against the native binary (identical results to the JVM in both `active` and `2026` modes) |
 
 ## Why zero metadata works
 
@@ -63,10 +63,10 @@ This is not just size hygiene: netty's own in-jar reflect-config unconditionally
 methods whose signatures mention netty buffer types, forcing them reachable, and netty's
 `--initialize-at-build-time=io.netty` directive then allocates a native `MemorySegment` in
 `EmptyByteBuf.<clinit>` on JDK 25 — failing the build with "Detected a native MemorySegment in
-the image heap". With the dependency excluded, none of that metadata is on the image classpath — and Mill's
-GraalVM-reachability-metadata-repo integration can stay at its defaults, so any OTHER dependency
-you add keeps its repo metadata. (Making netty itself work under native-image is the HTTP stage
-of TJC-2114.)
+the image heap". With the dependency excluded, none of that metadata is on the image classpath —
+and Mill's GraalVM-reachability-metadata-repo integration can stay at its defaults, so any OTHER
+dependency you add keeps its repo metadata. (HTTP builds keep netty and counter the stale-repo
+problem with a scoped override — see the HTTP section below.)
 
 The in-repo proof: `fast-mcp-scala.nativeSmoke.stdio` builds
 `examples.AnnotatedServer` with exactly this shape (it filters netty/zio-http from
@@ -111,3 +111,48 @@ CI. To re-audit (e.g. after a major dependency bump):
    `fast-mcp-scala/jvm/resources/META-INF/native-image/com.tjclp/fast-mcp-scala_3/reachability-metadata.json`
    (the modern single-file format). Mill's default `resources` ships it inside the published jar,
    so downstream builds stay zero-config.
+
+## Building an HTTP server
+
+HTTP native images keep zio-http/netty and need exactly two extra flags:
+
+```scala
+object server extends ScalaModule with mill.javalib.NativeImageModule {
+  def scalaVersion = "3.8.3"
+  def mainClass = Some("com.example.MyHttpServer")
+  def mvnDeps = Seq(mvn"com.tjclp::fast-mcp-scala:<version>")   // zio-http stays
+
+  override def jvmVersion = Task { "graalvm-community:25.0.2" }
+  override def nativeMetadataConfigurations =
+    Task { Set.empty[mill.javalib.graalvm.MetadataResult] }
+  override def nativeExcludedConfigJars = Task { Seq.empty[PathRef] }
+
+  override def nativeImageOptions = Task {
+    super.nativeImageOptions() ++ Seq(
+      "--no-fallback",
+      // SIGINT/SIGTERM must terminate a long-running server binary.
+      "--install-exit-handlers",
+      // netty-codec-http ships a blanket `--initialize-at-build-time=io.netty`, which is
+      // incompatible with GraalVM on JDK 25 (buffer/handler <clinit>s allocate native memory via
+      // the FFM CleanerJava25 and bake response objects into the image heap). Equal specificity +
+      // later rule wins, so this re-defaults the whole netty tree to run-time init; netty's own
+      // class-specific run-time entries are unaffected.
+      "--initialize-at-run-time=io.netty"
+    )
+  }
+}
+```
+
+Runtime behavior baked into `JvmHttpBackend`:
+
+- **Netty channel type**: `AUTO` (epoll/kqueue) on a normal JVM, **`NIO` inside a native image**
+  (detected via the `org.graalvm.nativeimage.imagecode` property — `AUTO`'s runtime transport
+  probing is exactly what closed-world analysis can't tolerate). Override with
+  `-Dfastmcp.http.channelType=nio|epoll|kqueue|auto` if you know what you're doing.
+- **Container binding**: the default host is `127.0.0.1`; set
+  `McpServerSettings(host = "0.0.0.0")` for containerized deployments (Databricks Apps included).
+
+The in-repo proof: `fast-mcp-scala.nativeSmoke.http` builds the conformance server, and
+`scripts/conformance.sh native [port] [active|2026]` runs the **official MCP conformance suite**
+against the native binary, held to the unchanged (empty) JVM baseline — measured identical to the
+JVM in both modes. CI runs both on every PR.

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -37,13 +37,6 @@ object server extends ScalaModule with mill.javalib.NativeImageModule {
   // GraalVM provisioned by Mill via the coursier JVM index — no GRAALVM_HOME, no setup-graalvm.
   override def jvmVersion = Task { "graalvm-community:25.0.2" }
 
-  // Neutralize Mill's GraalVM-reachability-metadata-repo integration: the repo marks netty
-  // `override: true` with stale 4.1.x-era configs, and Mill would strip netty's own (fresher)
-  // in-jar metadata in favor of them. Rely on in-jar metadata instead.
-  override def nativeMetadataConfigurations =
-    Task { Set.empty[mill.javalib.graalvm.MetadataResult] }
-  override def nativeExcludedConfigJars = Task { Seq.empty[PathRef] }
-
   override def nativeImageOptions = Task {
     // Always call super — the default wires resource inclusion and config directories.
     super.nativeImageOptions() ++ Seq("--no-fallback")
@@ -70,8 +63,10 @@ This is not just size hygiene: netty's own in-jar reflect-config unconditionally
 methods whose signatures mention netty buffer types, forcing them reachable, and netty's
 `--initialize-at-build-time=io.netty` directive then allocates a native `MemorySegment` in
 `EmptyByteBuf.<clinit>` on JDK 25 — failing the build with "Detected a native MemorySegment in
-the image heap". With the dependency excluded, none of that metadata is on the image classpath.
-(Making netty itself work under native-image is the HTTP stage of TJC-2114.)
+the image heap". With the dependency excluded, none of that metadata is on the image classpath — and Mill's
+GraalVM-reachability-metadata-repo integration can stay at its defaults, so any OTHER dependency
+you add keeps its repo metadata. (Making netty itself work under native-image is the HTTP stage
+of TJC-2114.)
 
 The in-repo proof: `fast-mcp-scala.nativeSmoke.stdio` builds
 `examples.AnnotatedServer` with exactly this shape (it filters netty/zio-http from

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -119,6 +119,7 @@ HTTP native images keep zio-http/netty and need exactly two extra flags:
 ```scala
 object server extends ScalaModule with mill.javalib.NativeImageModule {
   def scalaVersion = "3.8.3"
+  def scalacOptions = Seq("-experimental")                      // annotation macros require it
   def mainClass = Some("com.example.MyHttpServer")
   def mvnDeps = Seq(mvn"com.tjclp::fast-mcp-scala:<version>")   // zio-http stays
 
@@ -137,7 +138,11 @@ object server extends ScalaModule with mill.javalib.NativeImageModule {
       // the FFM CleanerJava25 and bake response objects into the image heap). Equal specificity +
       // later rule wins, so this re-defaults the whole netty tree to run-time init; netty's own
       // class-specific run-time entries are unaffected.
-      "--initialize-at-run-time=io.netty"
+      "--initialize-at-run-time=io.netty",
+      // netty's JDK-25 direct-buffer cleaner allocates via Arena.ofShared at runtime; without
+      // this, cleaner allocations throw and kill event-loop threads (and SIGTERM shutdown hangs).
+      "-H:+UnlockExperimentalVMOptions",
+      "-H:+SharedArenaSupport"
     )
   }
 }

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -1,0 +1,115 @@
+# GraalVM native-image
+
+fast-mcp-scala servers compile to self-contained native binaries with GraalVM `native-image` —
+instant startup, no JVM in the deployment container (the motivating case: MCP servers on
+Databricks Apps). Tracking issue: [#66](https://github.com/TJC-LP/fast-mcp-scala/issues/66).
+
+| Transport | Status |
+|---|---|
+| **stdio** (`McpServerApp[Stdio]`, `runStdio()`) | ✅ Supported, CI-gated (`.github/workflows/native.yml`), **zero hand-written reachability metadata** |
+| **HTTP** (`McpServerApp[Http]`, `runHttp()`) | 🚧 In progress (TJC-2114 stage 3): zio-http/netty under native-image |
+
+## Why zero metadata works
+
+The library's registration and schema machinery is compile-time (Scala 3 macros, zio-json inline
+derivation); the only runtime work is plain ADT transformation (tapir → circe schema rendering),
+which uses no reflection. ZIO ships its own native-image metadata in its jar. The
+`native-smoke.sh` CI gate is the rot protection — if a future dependency bump introduces a
+reflection need, the smoke goes red on the PR that introduces it, and only then does a
+`META-INF/native-image/com.tjclp/fast-mcp-scala_3/reachability-metadata.json` entry get added.
+
+## Building a stdio server (downstream recipe, Mill)
+
+```scala
+object server extends ScalaModule with mill.javalib.NativeImageModule {
+  def scalaVersion = "3.8.3"
+  def mainClass = Some("com.example.MyServer")
+
+  def mvnDeps = Seq(
+    // stdio-only: exclude the HTTP stack — see "The stdio/HTTP split" below
+    mvn"com.tjclp::fast-mcp-scala:<version>"
+      .exclude("dev.zio" -> "zio-http_3")
+  )
+
+  // GraalVM provisioned by Mill via the coursier JVM index — no GRAALVM_HOME, no setup-graalvm.
+  override def jvmVersion = Task { "graalvm-community:25.0.2" }
+
+  // Neutralize Mill's GraalVM-reachability-metadata-repo integration: the repo marks netty
+  // `override: true` with stale 4.1.x-era configs, and Mill would strip netty's own (fresher)
+  // in-jar metadata in favor of them. Rely on in-jar metadata instead.
+  override def nativeMetadataConfigurations =
+    Task { Set.empty[mill.javalib.graalvm.MetadataResult] }
+  override def nativeExcludedConfigJars = Task { Seq.empty[PathRef] }
+
+  override def nativeImageOptions = Task {
+    // Always call super — the default wires resource inclusion and config directories.
+    super.nativeImageOptions() ++ Seq("--no-fallback")
+  }
+}
+```
+
+`./mill server.nativeImage` → `out/server/nativeImage.dest/native-executable` (~35 MB for a
+small annotated server). Point Claude Desktop (or any MCP client) straight at it:
+
+```json
+{ "mcpServers": { "my-server": { "command": "/path/to/native-executable" } } }
+```
+
+## The stdio/HTTP split
+
+Since the transport-seam split (TJC-2114), `runStdio()` has no reachable call path into the HTTP
+stack: `serveHttp` lives on the separate `HttpTransportBackend` trait, `runHttp()` takes it as a
+`using` parameter, and the `TransportRunner[Http]` given is conditional. Closed-world analysis
+therefore drops zio-http and netty from stdio-only binaries entirely.
+
+**Stdio-only builds should also exclude the `zio-http` dependency** (as in the recipe above).
+This is not just size hygiene: netty's own in-jar reflect-config unconditionally registers
+methods whose signatures mention netty buffer types, forcing them reachable, and netty's
+`--initialize-at-build-time=io.netty` directive then allocates a native `MemorySegment` in
+`EmptyByteBuf.<clinit>` on JDK 25 — failing the build with "Detected a native MemorySegment in
+the image heap". With the dependency excluded, none of that metadata is on the image classpath.
+(Making netty itself work under native-image is the HTTP stage of TJC-2114.)
+
+The in-repo proof: `fast-mcp-scala.nativeSmoke.stdio` builds
+`examples.AnnotatedServer` with exactly this shape (it filters netty/zio-http from
+`nativeImageClasspath`, which is the moduleDeps equivalent of the dependency exclusion), and
+`scripts/native-smoke.sh` asserts both the full MCP handshake and that the binary contains no
+`io.netty` / `zio.http` strings.
+
+## Notes and troubleshooting
+
+- **Signal handling**: ZIO's `sun.misc.Signal` hooks are unavailable in a native image; ZIO logs
+  a warning and falls back to no-op signal handling (fiber dumps are affected, serving is not).
+  For long-running server binaries add `--install-exit-handlers` so SIGINT/SIGTERM terminate the
+  process cleanly.
+- **`MissingRegistrationError` at runtime**: a dependency started using reflection. Reproduce on
+  the JVM under the tracing agent (below), and add only the missing entries.
+- **Linker errors on self-hosted runners**: `native-image` needs a C toolchain (`gcc`,
+  `zlib1g-dev` on Debian/Ubuntu; preinstalled on GitHub-hosted runners).
+- **Build memory**: small servers build in well under 4 GB; pass `-J-Xmx6g` in
+  `nativeImageOptions` if the builder OOMs on a constrained runner.
+
+## Regenerating / auditing reachability metadata
+
+The library currently ships **no** metadata because none is needed — verified continuously by
+CI. To re-audit (e.g. after a major dependency bump):
+
+1. Build with diagnostics: add `--exact-reachability-metadata` to `nativeImageOptions`, run the
+   binary with `-XX:MissingRegistrationReportingMode=Warn`, and exercise it
+   (`scripts/native-smoke.sh <binary>`); every near-miss is reported. Treat the output as
+   advisory — never bake `--exact-reachability-metadata` into CI (it turns benign try/catch
+   `Class.forName` probes inside the JDK into hard errors).
+2. If something genuinely needs registration, capture it with the agent, driving the JVM with
+   the same smoke requests:
+
+   ```bash
+   GRAAL_JAVA="$(./mill show fast-mcp-scala.nativeSmoke.stdio.javaHome | ... )/bin/java"
+   CP="$(./mill show fast-mcp-scala.jvm.runClasspath | ...)"
+   NATIVE_SMOKE_CMD="$GRAAL_JAVA -agentlib:native-image-agent=config-output-dir=/tmp/ni-config \
+     -cp '$CP' com.tjclp.fastmcp.examples.AnnotatedServer" ./scripts/native-smoke.sh
+   ```
+
+3. Hand-distill the delta (never wholesale-copy the agent output — it over-captures) into
+   `fast-mcp-scala/jvm/resources/META-INF/native-image/com.tjclp/fast-mcp-scala_3/reachability-metadata.json`
+   (the modern single-file format). Mill's default `resources` ships it inside the published jar,
+   so downstream builds stay zero-config.

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -23,6 +23,9 @@ reflection need, the smoke goes red on the PR that introduces it, and only then 
 ```scala
 object server extends ScalaModule with mill.javalib.NativeImageModule {
   def scalaVersion = "3.8.3"
+  // fast-mcp-scala's annotation macros are @experimental; consumers compile with -experimental
+  // (same requirement as the scala-cli quickstart in the README)
+  def scalacOptions = Seq("-experimental")
   def mainClass = Some("com.example.MyServer")
 
   def mvnDeps = Seq(

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -2,7 +2,7 @@
 #
 # Run the official MCP conformance server suites against fast-mcp-scala.
 #
-#   scripts/conformance.sh [jvm|js] [port] [active|2026]
+#   scripts/conformance.sh [jvm|js|native] [port] [active|2026]
 #
 # Boots the cross-platform ConformanceServer (com.tjclp.fastmcp.examples.conformance.*) over
 # streamable HTTP, then drives it with the official harness via `bunx`. Exit code follows the harness
@@ -13,6 +13,11 @@
 # frozen at its release (extension/pending scenarios are reported but not scored by the harness).
 #
 # Requires: a JDK (jvm), bun (both). No vendored conformance checkout — the engine is fetched by bunx.
+#
+# "native" runs the SAME conformance server compiled to a GraalVM native image
+# (fast-mcp-scala.nativeSmoke.http.nativeImage; override with FAST_MCP_NATIVE_BIN) against the
+# UNCHANGED jvm baseline — the binary is behaviorally the same server, so any divergence is a
+# native-image bug to fix, never a new baseline.
 set -euo pipefail
 
 PLATFORM="${1:-jvm}"
@@ -23,6 +28,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 URL="http://127.0.0.1:${PORT}/mcp"
 BASELINE="$ROOT/conformance/baseline-${PLATFORM}.yml"
+[ "$PLATFORM" = "native" ] && BASELINE="$ROOT/conformance/baseline-jvm.yml"
 LOG="$(mktemp -t fmcp-conf-log.XXXXXX)"
 SRV_PID=""
 ENTRY=""
@@ -58,10 +64,25 @@ start_js() {
   SRV_PID=$!
 }
 
+start_native() {
+  local bin="${FAST_MCP_NATIVE_BIN:-}"
+  if [ -z "$bin" ]; then
+    echo "→ building native ConformanceServer (GraalVM)" >&2
+    ./mill --no-server fast-mcp-scala.nativeSmoke.http.nativeImage >/dev/null 2>&1
+    bin="$(./mill --no-server show fast-mcp-scala.nativeSmoke.http.nativeImage 2>/dev/null |
+      python3 -c "import sys,json,re; print(re.sub(r'^q?ref:v\\d+:[0-9a-f]+:','',json.load(sys.stdin)))")"
+  fi
+  [ -x "$bin" ] || { echo "native binary not found/executable: $bin" >&2; exit 1; }
+  echo "→ launching native ConformanceServer on :$PORT ($bin)" >&2
+  "$bin" "$PORT" >"$LOG" 2>&1 &
+  SRV_PID=$!
+}
+
 case "$PLATFORM" in
   jvm) start_jvm ;;
   js) start_js ;;
-  *) echo "usage: $0 [jvm|js] [port]" >&2; exit 2 ;;
+  native) start_native ;;
+  *) echo "usage: $0 [jvm|js|native] [port]" >&2; exit 2 ;;
 esac
 
 echo "→ waiting for $URL" >&2
@@ -83,7 +104,7 @@ case "$MODE" in
     bunx "@modelcontextprotocol/conformance@${CONF_VERSION}" \
       server --url "$URL" --requirements 2026-07-28
     ;;
-  *) echo "usage: $0 [jvm|js] [port] [active|2026]" >&2; exit 2 ;;
+  *) echo "usage: $0 [jvm|js|native] [port] [active|2026]" >&2; exit 2 ;;
 esac
 RC=$?
 set -e

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -109,4 +109,11 @@ esac
 RC=$?
 set -e
 echo "→ server log: $LOG" >&2
+# Native binaries can shed threads on GraalVM UnsupportedFeatureError while the suite still
+# passes on the surviving event loops — treat any such error as a failure.
+if [ "$PLATFORM" = "native" ] && grep -q "UnsupportedFeatureError" "$LOG"; then
+  echo "native FAIL: UnsupportedFeatureError in server log (suite verdict: $RC)" >&2
+  grep -m1 -A3 "UnsupportedFeatureError" "$LOG" >&2
+  exit 1
+fi
 exit "$RC"

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -31,13 +31,40 @@ BASELINE="$ROOT/conformance/baseline-${PLATFORM}.yml"
 [ "$PLATFORM" = "native" ] && BASELINE="$ROOT/conformance/baseline-jvm.yml"
 LOG="$(mktemp -t fmcp-conf-log.XXXXXX)"
 SRV_PID=""
+SRV_STOPPED=""
 ENTRY=""
 
+# Terminate the launched server and record HOW it died: "clean" (exited within 15s of SIGTERM)
+# or "hang" (needed SIGKILL). Idempotent; used both on the normal path (so the completed log can
+# be inspected afterwards) and from the EXIT trap.
+stop_server() {
+  [ -n "$SRV_PID" ] || return 0
+  kill -TERM "$SRV_PID" 2>/dev/null || true
+  for _ in $(seq 1 30); do
+    kill -0 "$SRV_PID" 2>/dev/null || { SRV_STOPPED="clean"; break; }
+    sleep 0.5
+  done
+  if [ "$SRV_STOPPED" != "clean" ]; then
+    SRV_STOPPED="hang"
+    kill -9 "$SRV_PID" 2>/dev/null || true
+  fi
+  wait "$SRV_PID" 2>/dev/null || true
+  SRV_PID=""
+}
+
 cleanup() {
-  [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null || true
+  stop_server
   [ -n "$ENTRY" ] && rm -f "$ENTRY" 2>/dev/null || true
 }
 trap cleanup EXIT
+
+# Refuse to run if ANYTHING already listens on the port — the readiness poll below would
+# otherwise happily bless a foreign server and the suite would test the wrong process.
+if (exec 3<>"/dev/tcp/127.0.0.1/$PORT") 2>/dev/null; then
+  exec 3>&- 3<&- 2>/dev/null || true
+  echo "port $PORT is already in use — refusing to test an unknown server" >&2
+  exit 2
+fi
 
 jvm_classpath() {
   ./mill --no-server show fast-mcp-scala.jvm.runClasspath 2>/dev/null |
@@ -87,6 +114,11 @@ esac
 
 echo "→ waiting for $URL" >&2
 for i in $(seq 1 90); do
+  # The child must still be alive AND answering — a dead child with a lingering listener (or a
+  # foreign process) must never pass readiness.
+  if ! kill -0 "$SRV_PID" 2>/dev/null; then
+    echo "server process died during startup; log:" >&2; cat "$LOG" >&2; exit 1
+  fi
   curl -s -o /dev/null "$URL" 2>/dev/null && break
   if [ "$i" -eq 90 ]; then echo "server failed to start; log:" >&2; cat "$LOG" >&2; exit 1; fi
   sleep 0.5
@@ -108,12 +140,22 @@ case "$MODE" in
 esac
 RC=$?
 set -e
+# Terminate BEFORE inspecting the log, so teardown-time failures are gated too.
+stop_server
 echo "→ server log: $LOG" >&2
-# Native binaries can shed threads on GraalVM UnsupportedFeatureError while the suite still
-# passes on the surviving event loops — treat any such error as a failure.
-if [ "$PLATFORM" = "native" ] && grep -q "UnsupportedFeatureError" "$LOG"; then
-  echo "native FAIL: UnsupportedFeatureError in server log (suite verdict: $RC)" >&2
-  grep -m1 -A3 "UnsupportedFeatureError" "$LOG" >&2
-  exit 1
+if [ "$PLATFORM" = "native" ]; then
+  # --install-exit-handlers must actually work: a binary that survives 15s of SIGTERM is a bug
+  # (dead event loops deadlocking shutdown was exactly the failure SharedArenaSupport fixed).
+  if [ "$SRV_STOPPED" = "hang" ]; then
+    echo "native FAIL: server did not exit within 15s of SIGTERM (suite verdict: $RC)" >&2
+    exit 1
+  fi
+  # Native binaries can shed threads on GraalVM UnsupportedFeatureError while the suite still
+  # passes on the surviving event loops — treat any such error as a failure.
+  if grep -q "UnsupportedFeatureError" "$LOG"; then
+    echo "native FAIL: UnsupportedFeatureError in server log (suite verdict: $RC)" >&2
+    grep -m1 -A3 "UnsupportedFeatureError" "$LOG" >&2
+    exit 1
+  fi
 fi
 exit "$RC"

--- a/scripts/native-smoke.sh
+++ b/scripts/native-smoke.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Drive a fast-mcp-scala stdio MCP binary end-to-end over raw JSON-RPC (NDJSON) and assert the
+# replies with jq. Proves that a GraalVM native image of an annotated stdio server works with
+# ZERO hand-written reachability metadata (GH #66 / TJC-2114), and that the transport-seam split
+# keeps netty/zio-http out of the binary entirely.
+#
+# Usage:
+#   scripts/native-smoke.sh [path-to-binary]
+#
+# With no argument, resolves (and if needed builds) the
+# `fast-mcp-scala.nativeSmoke.stdio.nativeImage` output via mill.
+#
+# NATIVE_SMOKE_CMD overrides the server command entirely — e.g. a JVM run under
+# `-agentlib:native-image-agent` when regenerating metadata (see docs/native-image.md). The
+# binary-only checks (netty-shed) are skipped in that mode.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+command -v jq >/dev/null 2>&1 || { echo "native-smoke: jq is required" >&2; exit 1; }
+
+BIN="${1:-}"
+if [ -z "${NATIVE_SMOKE_CMD:-}" ] && [ -z "$BIN" ]; then
+  echo "→ resolving native binary via mill" >&2
+  BIN="$(./mill --no-server show fast-mcp-scala.nativeSmoke.stdio.nativeImage 2>/dev/null |
+    python3 -c "import sys,json,re; print(re.sub(r'^q?ref:v\d+:[0-9a-f]+:','',json.load(sys.stdin)))")"
+fi
+if [ -z "${NATIVE_SMOKE_CMD:-}" ]; then
+  [ -x "$BIN" ] || { echo "native-smoke: binary not found/executable: $BIN" >&2; exit 1; }
+fi
+
+WORK="$(mktemp -d -t fmcp-native.XXXXXX)"
+OUT="$WORK/out"
+ERR="$WORK/err"
+SRV_PID=""
+cleanup() {
+  exec 3>&- 2>/dev/null || true
+  [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "native-smoke FAIL: $1" >&2
+  echo "--- stdout ---" >&2; cat "$OUT" >&2
+  echo "--- stderr ---" >&2; cat "$ERR" >&2
+  exit 1
+}
+
+# True once the reply for $1 has landed in $OUT (tolerates a partially-written last line).
+has_id() {
+  jq -es --argjson id "$1" 'map(select(.id == $id)) | length >= 1' <"$OUT" >/dev/null 2>&1
+}
+
+await_id() {
+  for _ in $(seq 1 120); do
+    has_id "$1" && return 0
+    sleep 0.5
+  done
+  fail "timed out waiting for reply id=$1"
+}
+
+# Requests are fed through a FIFO in two phases: the stdio loop dispatches each frame in its own
+# fiber, so post-handshake requests must not be written until the initialize reply has landed
+# (otherwise they race the handshake and get -32600 "Server not initialized").
+mkfifo "$WORK/in"
+echo "→ driving server over stdio" >&2
+if [ -n "${NATIVE_SMOKE_CMD:-}" ]; then
+  bash -c "$NATIVE_SMOKE_CMD" <"$WORK/in" >"$OUT" 2>"$ERR" &
+else
+  "$BIN" <"$WORK/in" >"$OUT" 2>"$ERR" &
+fi
+SRV_PID=$!
+exec 3>"$WORK/in"
+
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"native-smoke","version":"0.0.0"}}}' >&3
+await_id 1
+printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized"}' >&3
+
+# One exercise of every registration kind on AnnotatedServer. tools/list is the load-bearing
+# check: its inputSchema payloads are produced by the genuine RUNTIME tapir→circe
+# schema-rendering path, exactly where closed-world analysis would break if reachability
+# metadata were missing.
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"add","arguments":{"a":2,"b":3}}}' \
+  '{"jsonrpc":"2.0","id":4,"method":"prompts/list"}' \
+  '{"jsonrpc":"2.0","id":5,"method":"prompts/get","params":{"name":"hello_prompt","arguments":{}}}' \
+  '{"jsonrpc":"2.0","id":6,"method":"resources/list"}' \
+  '{"jsonrpc":"2.0","id":7,"method":"resources/read","params":{"uri":"static://welcome"}}' >&3
+
+for id in 2 3 4 5 6 7; do await_id "$id"; done
+
+# Close stdin → EOF ends the stdio loop; give the process a moment to exit on its own.
+exec 3>&-
+for _ in $(seq 1 20); do
+  kill -0 "$SRV_PID" 2>/dev/null || break
+  sleep 0.25
+done
+kill "$SRV_PID" 2>/dev/null || true
+wait "$SRV_PID" 2>/dev/null || true
+SRV_PID=""
+
+# Replies may arrive out of order (each frame dispatches in its own fiber), so slurp and select.
+for id in 1 2 3 4 5 6 7; do
+  jq -es --argjson id "$id" \
+    'map(select(.id == $id)) | length == 1 and (.[0] | has("result"))' \
+    <"$OUT" >/dev/null 2>&1 || fail "no clean result for id=$id"
+done
+
+jq -es 'map(select(.id == 2))[0].result.tools | map(.name) | (index("add") != null) and (index("calculator") != null)' \
+  <"$OUT" >/dev/null || fail "tools/list is missing add/calculator"
+jq -es 'map(select(.id == 2))[0].result.tools[] | select(.name == "add") | .inputSchema.properties.a.type == "integer"' \
+  <"$OUT" >/dev/null || fail "add inputSchema lost its runtime-derived properties"
+jq -es 'map(select(.id == 3))[0].result.content[0].text == "5"' \
+  <"$OUT" >/dev/null || fail "tools/call add(2,3) != 5"
+jq -es 'map(select(.id == 4))[0].result.prompts | length > 0' \
+  <"$OUT" >/dev/null || fail "prompts/list empty"
+jq -es 'map(select(.id == 5))[0].result.messages | length > 0' \
+  <"$OUT" >/dev/null || fail "prompts/get hello_prompt empty"
+jq -es 'map(select(.id == 6))[0].result.resources | length > 0' \
+  <"$OUT" >/dev/null || fail "resources/list empty"
+jq -es 'map(select(.id == 7))[0].result.contents[0].text | length > 0' \
+  <"$OUT" >/dev/null || fail "resources/read static://welcome unreadable"
+
+# The seam-split regression guard: a stdio binary must not contain the HTTP stack. A handful of
+# stray matches is tolerated for robustness across GraalVM versions; a re-coupled seam shows up
+# as thousands (embedded class metadata).
+if [ -z "${NATIVE_SMOKE_CMD:-}" ] && command -v strings >/dev/null 2>&1; then
+  NETTY_COUNT="$(strings "$BIN" | grep -c 'io\.netty' || true)"
+  ZIOHTTP_COUNT="$(strings "$BIN" | grep -c 'zio\.http' || true)"
+  if [ "$NETTY_COUNT" -gt 5 ] || [ "$ZIOHTTP_COUNT" -gt 5 ]; then
+    fail "HTTP stack leaked into the stdio binary (io.netty: $NETTY_COUNT, zio.http: $ZIOHTTP_COUNT strings)"
+  fi
+  echo "→ netty-shed check ok (io.netty: $NETTY_COUNT, zio.http: $ZIOHTTP_COUNT strings)" >&2
+fi
+
+echo "native stdio smoke: OK${BIN:+ ($BIN)}"

--- a/scripts/native-smoke.sh
+++ b/scripts/native-smoke.sh
@@ -93,15 +93,22 @@ printf '%s\n' \
 
 for id in 2 3 4 5 6 7; do await_id "$id"; done
 
-# Close stdin → EOF ends the stdio loop; give the process a moment to exit on its own.
+# Close stdin → EOF must end the stdio loop and the process must exit 0 on its own; a hang or a
+# nonzero status is a real defect (forced TERM/KILL would mask it), so both fail the smoke.
 exec 3>&-
-for _ in $(seq 1 20); do
-  kill -0 "$SRV_PID" 2>/dev/null || break
+EXITED=""
+for _ in $(seq 1 40); do
+  kill -0 "$SRV_PID" 2>/dev/null || { EXITED=1; break; }
   sleep 0.25
 done
-kill "$SRV_PID" 2>/dev/null || true
-wait "$SRV_PID" 2>/dev/null || true
+if [ -z "$EXITED" ]; then
+  kill -9 "$SRV_PID" 2>/dev/null || true
+  fail "server did not exit on stdin EOF within 10s"
+fi
+SRV_RC=0
+wait "$SRV_PID" || SRV_RC=$?
 SRV_PID=""
+[ "$SRV_RC" -eq 0 ] || fail "server exited with status $SRV_RC (expected 0 on clean EOF)"
 
 # Replies may arrive out of order (each frame dispatches in its own fiber), so slurp and select.
 for id in 1 2 3 4 5 6 7; do


### PR DESCRIPTION
## Summary

The remainder of GraalVM native-image support (#66, Linear TJC-2114), following the merged seam split (#67). Combines the previously-stacked stdio (#72) and HTTP (#73) stages into one PR — stacked PRs + squash-merge required an O(stack) repair on every bottom merge, so the two remaining stages (which merge together regardless) are folded. **Six commits, unchanged from the reviewed stack, cleanly separated per stage** — per-stage detail in the closed #72/#73 descriptions.

### Stdio (commits 1–3)
- Non-published `nativeSmoke.stdio` Mill module: `AnnotatedServer` → 35MB binary, GraalVM 25 via `jvmVersion`, **zero hand-written reachability metadata**.
- `scripts/native-smoke.sh`: FIFO-phased NDJSON driver; asserts runtime tapir→circe schemas, tool calls, prompts, resources, **exit-0-on-EOF within 10s** (forced kills fail the smoke), and the netty-shed guard (0 `io.netty`/`zio.http` strings — the #67 split, proven).
- PR-blocking `.github/workflows/native.yml`; `docs/native-image.md` + README recipes (with `-experimental`, validated by dogfooding the published artifact downstream).

### HTTP (commits 4–6)
- `nativeSmoke.http`: the conformance server → 64MB binary. Full netty recipe: `--install-exit-handlers`, `--initialize-at-run-time=io.netty` (counters netty-codec-http's blanket build-time rule, incompatible with GraalVM on JDK 25), `-H:+SharedArenaSupport` (netty's JDK-25 FFM buffer cleaner; without it event-loop threads die silently and SIGTERM hangs). Netty-scoped `nativeUseLatestConfigWhenVersionIsUntested = false` (in-jar metadata survives; other deps keep repo metadata).
- `scripts/conformance.sh native`: hardened harness — refuses occupied ports, requires child liveness, explicit SIGTERM + bounded-wait before log inspection, fails on any `UnsupportedFeatureError`.
- CI: official conformance active suite vs the **unchanged empty jvm baseline** + **scenario-level JVM/native 2026 parity diff** (verified byte-identical, 51 scenario lines).

### Review status
All six findings + nits from the stack review are addressed in these commits (findings 1–3 reproduced-then-fixed; 4–6 plus `Locale.ROOT`/boss-group test/architecture docs/cache paths included).

## Test plan
- [x] linux-x64 CI: stdio smoke + HTTP conformance (both jobs in this PR's `native.yml`)
- [x] Local: full JVM+JS suites, checkFormat, publish surface unchanged
- [x] Downstream dogfood against the published 1.0.0-RC2-SNAPSHOT (stdio recipe with Mill metadata defaults; HTTP recipe incl. SIGTERM exit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)