### PR TITLE
chore: prepare v1.0.0-RC3 — native-image release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to fast-mcp-scala will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0-RC3] - 2026-08-31
 
 ### Added
 
@@ -55,6 +55,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never existed) and the unused zio-schema dependencies
   (`zio-schema`/`-json`/`-derivation` had zero usages; schema derivation is
   tapir-based).
+
+## [1.0.0-RC2] - 2026-08-28
+
+### Fixed
+
+- `Option` tool parameters decode via zio-json instead of a `Mirror` sum
+  decoder (#64, #65).
 
 ## [1.0.0-RC1] - 2026-08-17
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,7 +298,7 @@ rm -rf out/fast-mcp-scala && ./mill fast-mcp-scala.compile
 ./mill -i __.publishLocal
 ```
 
-Then in your project use version `1.0.0-RC2-SNAPSHOT`.
+Then in your project use version `1.0.0-RC3`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Built on **ZIO 2**, **Tapir**-derived schemas, and **zio-json** on both platform
 
 ```scala 3 ignore
 // JVM — native Scala MCP core with annotations, derived schemas, HTTP + stdio transports.
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "1.0.0-RC1"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "1.0.0-RC3"
 
 // Scala.js — the same native core on Bun (Bun.serve + Node stdio), same annotation and typed-contract APIs.
-libraryDependencies += "com.tjclp" %%% "fast-mcp-scala" % "1.0.0-RC1"
+libraryDependencies += "com.tjclp" %%% "fast-mcp-scala" % "1.0.0-RC3"
 ```
 
 Built against Scala 3.8.3. JVM requires JDK 17+. Scala.js artifact is published for `sjs1_3` (Scala.js 1.x); runs on Bun (first-class) and Node 18+.
@@ -54,7 +54,7 @@ A single-file server with one tool — the same code lives in [`HelloWorld.scala
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala:1.0.0-RC1
+//> using dep com.tjclp::fast-mcp-scala:1.0.0-RC3
 //> using options "-Xcheck-macros" "-experimental"
 
 import com.tjclp.fastmcp.{*, given}
@@ -251,7 +251,7 @@ stdio-only images entirely (~35 MB, instant startup, no JVM in the container):
 object server extends ScalaModule with mill.javalib.NativeImageModule {
   def scalaVersion = "3.8.3"
   def scalacOptions = Seq("-experimental")   // the annotation macros require it
-  def mvnDeps = Seq(mvn"com.tjclp::fast-mcp-scala:<version>".exclude("dev.zio" -> "zio-http_3"))
+  def mvnDeps = Seq(mvn"com.tjclp::fast-mcp-scala:1.0.0-RC3".exclude("dev.zio" -> "zio-http_3"))
   def mainClass = Some("com.example.MyServer")
   override def jvmVersion = Task { "graalvm-community:25.0.2" }
   override def nativeImageOptions = Task { super.nativeImageOptions() ++ Seq("--no-fallback") }
@@ -383,7 +383,7 @@ Proof: the official **MCP conformance suite** runs against both platforms in CI 
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::fast-mcp-scala_sjs1:1.0.0-RC1
+//> using dep com.tjclp::fast-mcp-scala_sjs1:1.0.0-RC3
 
 import com.tjclp.fastmcp.{*, given}
 
@@ -468,7 +468,7 @@ Add to `claude_desktop_config.json`:
       "command": "scala-cli",
       "args": [
         "-e",
-        "//> using dep com.tjclp::fast-mcp-scala:1.0.0-RC1",
+        "//> using dep com.tjclp::fast-mcp-scala:1.0.0-RC3",
         "--main-class",
         "com.tjclp.fastmcp.examples.AnnotatedServer"
       ]
@@ -506,14 +506,14 @@ For architectural detail, see [`docs/architecture.md`](docs/architecture.md).
 After `publishLocal`:
 
 ```scala 3 ignore
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "1.0.0-RC2-SNAPSHOT"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "1.0.0-RC3"
 ```
 
 Or with Mill:
 
 ```scala 3 ignore
 def ivyDeps = Agg(
-  ivy"com.tjclp::fast-mcp-scala:1.0.0-RC2-SNAPSHOT"
+  ivy"com.tjclp::fast-mcp-scala:1.0.0-RC3"
 )
 ```
 

--- a/build.mill
+++ b/build.mill
@@ -90,7 +90,7 @@ trait FastMCPPublishingBase extends PublishModule {
 
   /** Version derived from PUBLISH_VERSION env var (set by CI), or SNAPSHOT for local dev */
   override def publishVersion: T[String] =
-    sys.env.getOrElse("PUBLISH_VERSION", "1.0.0-RC2-SNAPSHOT")
+    sys.env.getOrElse("PUBLISH_VERSION", "1.0.0-RC3")
 
   override def pomSettings: T[PomSettings] = PomSettings(
     description = artifactDescription,

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -30,7 +30,7 @@ object server extends ScalaModule with mill.javalib.NativeImageModule {
 
   def mvnDeps = Seq(
     // stdio-only: exclude the HTTP stack — see "The stdio/HTTP split" below
-    mvn"com.tjclp::fast-mcp-scala:<version>"
+    mvn"com.tjclp::fast-mcp-scala:1.0.0-RC3"
       .exclude("dev.zio" -> "zio-http_3")
   )
 
@@ -122,7 +122,7 @@ object server extends ScalaModule with mill.javalib.NativeImageModule {
   def scalaVersion = "3.8.3"
   def scalacOptions = Seq("-experimental")                      // annotation macros require it
   def mainClass = Some("com.example.MyHttpServer")
-  def mvnDeps = Seq(mvn"com.tjclp::fast-mcp-scala:<version>")   // zio-http stays
+  def mvnDeps = Seq(mvn"com.tjclp::fast-mcp-scala:1.0.0-RC3")   // zio-http stays
 
   override def jvmVersion = Task { "graalvm-community:25.0.2" }
 


### PR DESCRIPTION
Release-prep for **v1.0.0-RC3**, the first release with GraalVM native-image support (#66 / TJC-2114, merged in #67 + #75).

- `build.mill` dev default → bare `1.0.0-RC3` (the tag points at this commit; post-release bump PR to `1.0.0-RC4-SNAPSHOT` follows per convention)
- CHANGELOG stamped `[1.0.0-RC3] - 2026-08-31`; backfilled the missing `[1.0.0-RC2]` section (the #64 Option-decode fix released 2026-08-28)
- README quickstart/publishLocal refs (stale at RC1/RC2-SNAPSHOT) → RC3; native-image recipes in README + `docs/native-image.md` pinned to RC3 — the first version those recipes actually work against
- `CLAUDE.md` publishLocal note updated

After merge: `git tag -a v1.0.0-RC3 && git push origin v1.0.0-RC3` → release.yml publishes `fast-mcp-scala_3` + `_sjs1_3` to Maven Central and cuts the prerelease.

🤖 Generated with [Claude Code](https://claude.com/claude-code)