### PR TITLE
chore: bump dev default to 1.0.0-RC4-SNAPSHOT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,7 +298,7 @@ rm -rf out/fast-mcp-scala && ./mill fast-mcp-scala.compile
 ./mill -i __.publishLocal
 ```
 
-Then in your project use version `1.0.0-RC3`.
+Then in your project use version `1.0.0-RC4-SNAPSHOT`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -506,14 +506,14 @@ For architectural detail, see [`docs/architecture.md`](docs/architecture.md).
 After `publishLocal`:
 
 ```scala 3 ignore
-libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "1.0.0-RC3"
+libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "1.0.0-RC4-SNAPSHOT"
 ```
 
 Or with Mill:
 
 ```scala 3 ignore
 def ivyDeps = Agg(
-  ivy"com.tjclp::fast-mcp-scala:1.0.0-RC3"
+  ivy"com.tjclp::fast-mcp-scala:1.0.0-RC4-SNAPSHOT"
 )
 ```
 

--- a/build.mill
+++ b/build.mill
@@ -90,7 +90,7 @@ trait FastMCPPublishingBase extends PublishModule {
 
   /** Version derived from PUBLISH_VERSION env var (set by CI), or SNAPSHOT for local dev */
   override def publishVersion: T[String] =
-    sys.env.getOrElse("PUBLISH_VERSION", "1.0.0-RC3")
+    sys.env.getOrElse("PUBLISH_VERSION", "1.0.0-RC4-SNAPSHOT")
 
   override def pomSettings: T[PomSettings] = PomSettings(
     description = artifactDescription,


### PR DESCRIPTION
Post-release bump after [v1.0.0-RC3](https://github.com/TJC-LP/fast-mcp-scala/releases/tag/v1.0.0-RC3) per the release convention (cf. #63): `build.mill` dev default and the README/CLAUDE.md publishLocal sections move to `1.0.0-RC4-SNAPSHOT` so local builds are obviously dev artifacts. Quickstart refs stay at the released `1.0.0-RC3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)