### PR TITLE
feat: zero-boilerplate Scala 3 enum support in typed contracts (TJC-2167, closes #78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to fast-mcp-scala will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Zero-boilerplate Scala 3 enum support in typed contracts** (TJC-2167, #78):
+  `McpTool[In, Out]` with enum fields now derives string-enum JSON schemas
+  (`{"type":"string","enum":[...]}`) and string-based zio-json codecs with no
+  user-supplied givens — at any nesting depth, including through `Option`,
+  collections, and nested case classes. The annotation path gains the same
+  for enums nested inside case-class params (previously coproducts of empty
+  objects / decode failures). User-defined `JsonDecoder`/`JsonEncoder`/tapir
+  `Schema` instances always win: the fix is macro-side (summon-first, local
+  givens planted only where the call-site search finds nothing), never
+  exported givens that could shadow companions. Parameterized-case enums
+  intentionally keep coproduct schemas and wrapper-object codecs.
+
+### Added
+
+- **Mirror-based `McpEncoder` fallback**: `Out` case classes without any
+  `JsonEncoder` in scope now encode (text + `structuredContent`)
+  automatically; guarded by `NotGiven[JsonEncoder[A]]` so every existing
+  explicit-encoder call site resolves exactly as before.
+
 ## [1.0.0-RC3] - 2026-08-31
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,8 @@ server.tool(addTool)
 - `McpTemplateResource[In]` / `McpTemplateResource[In, R](...)` - Typed resource template
 - `McpDecoder[T]` / `McpEncoder[A]` - Platform-neutral codecs
 - `ToolSchemaProvider[A]` - Auto-derives `inputSchema` from `@Param`-annotated case classes on both JVM and JS
-- `McpEncoder` falls back to `JsonEncoder[A]` → `TextContent(a.toJson)` via ZIO JSON
+- `McpEncoder` falls back to `JsonEncoder[A]` → `TextContent(a.toJson)` via ZIO JSON; case classes without any `JsonEncoder` derive one automatically (Mirror-based, `NotGiven`-guarded)
+- Scala 3 enums and nested case classes in `In`/`Out` need no user-supplied givens (GH #78): schemas render string enums, codecs derive string-based; user-defined instances always win (macro-side summon-first, never exported givens). Machinery: `shared/.../macros/EnumTypeCollector.scala` + `ZioJsonEnumDerivation.scala`
 
 ### Transports
 

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Task IDs come from the platform CSPRNG, a task that outlives its TTL is interrup
 
 ## Customizing decoding (zio-json)
 
-fast-mcp-scala decodes raw JSON-RPC arguments into Scala values with **zio-json** on both platforms (`codec/McpDecoders.scala` over the shared `DefaultDecodeContext`). Primitives, Scala 3 enums, case classes, `Option`, `List`, and `Map` work out of the box.
+fast-mcp-scala decodes raw JSON-RPC arguments into Scala values with **zio-json** on both platforms (`codec/McpDecoders.scala` over the shared `DefaultDecodeContext`). Primitives, Scala 3 enums, case classes (nested included), `Option`, `List`, and `Map` work out of the box — on the annotation path *and* in typed contracts. An enum field derives a string-enum JSON schema (`{"type":"string","enum":[...]}`) and a string-based codec with zero user-supplied givens; a hand-written `given JsonDecoder`/`JsonEncoder` for the enum — custom naming and all — always wins over the derived one. Result (`Out`) case classes likewise need no hand-written `JsonEncoder`. Enums with parameterized cases keep zio-json's wrapper-object encoding and tapir's coproduct schema (override per field with `@Param(schema = ...)` if needed).
 
 For anything else — including `java.time` types, which no longer decode for free now that Jackson is gone — supply a `given JsonDecoder[T]`; the shared derivation turns it into the `McpDecoder[T]` the contract layer needs:
 

--- a/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/contracts/SharedContractSurfaceTest.scala
+++ b/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/contracts/SharedContractSurfaceTest.scala
@@ -53,3 +53,31 @@ class SharedContractSurfaceTest extends AnyFunSuite:
     assert(staticResource.definition.uri == "static://welcome")
     assert(templateResource.definition.isTemplate)
   }
+
+// GH #78: zero-boilerplate enum support must hold on Scala.js too (macro expansion runs at JS
+// compile). Top-level fixtures: no hand-written givens anywhere.
+enum JsMood:
+  case bright, dim
+
+case class JsMoodArgs(mood: JsMood, label: Option[String])
+
+class EnumContractSurfaceJsTest extends AnyFunSuite:
+
+  test("enum-field contract derives decoder and schema with zero user givens on JS") {
+    import sttp.tapir.generic.auto.*
+    val schemaJson = ToolInputSchema.derived[JsMoodArgs].toJsonString
+    assert(schemaJson.contains("\"enum\""), s"missing enum constraint: $schemaJson")
+    assert(schemaJson.contains("bright"), s"missing enum value: $schemaJson")
+
+    val decoder = summon[McpDecoder[JsMoodArgs]]
+    val decoded = decoder.decode(
+      "args",
+      Map[String, Any]("mood" -> "dim"),
+      com.tjclp.fastmcp.codec.DefaultDecodeContext.default
+    )
+    assert(decoded == JsMoodArgs(JsMood.dim, None))
+
+    val encoder = summon[McpEncoder[JsMoodArgs]]
+    val structured = encoder.encodeStructured(JsMoodArgs(JsMood.bright, Some("x"))).map(_.toString)
+    assert(structured.exists(_.contains("bright")), s"structured: $structured")
+  }

--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/macros/schema/SchemaExtractor.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/macros/schema/SchemaExtractor.scala
@@ -63,7 +63,30 @@ object SchemaExtractor:
         // carries string-based enum schemas: the block-local givens win over the imported
         // generic.auto candidates when the derivation's per-field summons run (GH #78). The
         // macro-time summon is kept purely for its friendly missing-import diagnostic.
-        val nestedEnums = com.tjclp.fastmcp.macros.EnumTypeCollector.collectSingletonEnums(tpeRepr)
+        //
+        // User schemas always win: a local is planted only when the macro-time summon for the
+        // enum finds nothing, or finds tapir's AUTO-derivation bridge (LowPrioritySchema
+        // .derivedSchema over generic.auto's Derived) — a plain `.isEmpty` filter would disable
+        // the fix entirely under generic.auto, whose bridge satisfies every Schema summon.
+        def isAutoDerivedSchema(term: Term): Boolean =
+          def fnSymbol(t: Term): Symbol = t match
+            case Apply(fn, _) => fnSymbol(fn)
+            case TypeApply(fn, _) => fnSymbol(fn)
+            case Inlined(_, _, body) => fnSymbol(body)
+            case Block(_, expr) => fnSymbol(expr)
+            case other => other.symbol
+          val fullName = fnSymbol(term).fullName
+          fullName.startsWith("sttp.tapir.generic.auto") ||
+          fullName.endsWith("LowPrioritySchema.derivedSchema")
+        val nestedEnums = com.tjclp.fastmcp.macros.EnumTypeCollector
+          .collectSingletonEnums(tpeRepr)
+          .filter { e =>
+            e.asType match
+              case '[et] =>
+                Expr.summon[Schema[et]] match
+                  case None => true
+                  case Some(existing) => isAutoDerivedSchema(existing.asTerm)
+          }
         val rawSchemaExpr: Expr[Schema[T]] =
           if nestedEnums.isEmpty then summonOrAbort
           else

--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/macros/schema/SchemaExtractor.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/macros/schema/SchemaExtractor.scala
@@ -49,18 +49,36 @@ object SchemaExtractor:
             s"Cannot derive enum schema for ${Type.show[T]}: Missing Mirror.SumOf[T]. Ensure it's a standard Scala 3 enum."
           )
         }
-        report.info(
-          s"Detected enum type ${Type.show[T]}, using derivedEnumeration."
-        ) // Optional debug info
         '{ Schema.derivedEnumeration[T].defaultStringBased }
       else
         // For non-enums, use the regular implicit summon and naming logic
         // NOTE: Requires `import sttp.tapir.generic.auto.*` at the *call site*
-        val rawSchemaExpr = Expr.summon[Schema[T]].getOrElse {
+        def summonOrAbort: Expr[Schema[T]] = Expr.summon[Schema[T]].getOrElse {
           report.errorAndAbort(
             s"No Tapir Schema found for parameter '$paramName' of type: ${Type.show[T]}. Did you import sttp.tapir.generic.auto.* at the call site?"
           )
         }
+        // Scala 3 enums nested anywhere in T's field tree would render as coproducts of empty
+        // objects under generic.auto. Re-derive T's schema inside a block whose innermost scope
+        // carries string-based enum schemas: the block-local givens win over the imported
+        // generic.auto candidates when the derivation's per-field summons run (GH #78). The
+        // macro-time summon is kept purely for its friendly missing-import diagnostic.
+        val nestedEnums = com.tjclp.fastmcp.macros.EnumTypeCollector.collectSingletonEnums(tpeRepr)
+        val rawSchemaExpr: Expr[Schema[T]] =
+          if nestedEnums.isEmpty then summonOrAbort
+          else
+            val _ = summonOrAbort
+            def withLocalGivens(remaining: List[TypeRepr]): Expr[Schema[T]] =
+              remaining match
+                case Nil => '{ scala.compiletime.summonInline[Schema[T]] }
+                case e :: rest =>
+                  e.asType match
+                    case '[et] =>
+                      '{
+                        given Schema[et] = Schema.derivedEnumeration[et].defaultStringBased
+                        ${ withLocalGivens(rest) }
+                      }
+            withLocalGivens(nestedEnums)
         // Apply naming only to non-enum product types
         maybeAssignNameToSchema[T](rawSchemaExpr)
 

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/MapToFunctionMacroTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/MapToFunctionMacroTest.scala
@@ -68,6 +68,18 @@ class MapToFunctionMacroTest extends AnyFunSuite with Matchers {
     result4 should be("Dr. Alice")
   }
 
+  // GH #78: enum nested INSIDE a case-class param must decode with zero user givens
+  test("should decode a case-class param whose field is an enum") {
+    case class Payment(amount: Double, method: Color)
+    def describe(payment: Payment): String = s"${payment.amount}:${payment.method}"
+
+    val mapFunction = MapToFunctionMacro.callByMap(describe)
+    val result = mapFunction.asInstanceOf[Map[String, Any] => String](
+      Map("payment" -> Map("amount" -> 1.5, "method" -> "RED"))
+    )
+    result should be("1.5:RED")
+  }
+
   // Test with uppercase enum parameters (traditional Java-style)
   test("should handle uppercase enum parameters") {
     def getColorHex(color: Color): String =

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/schema/SchemaExtractorExtendedTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/schema/SchemaExtractorExtendedTest.scala
@@ -17,10 +17,53 @@ class SchemaExtractorExtendedTest extends AnyFunSuite {
   // Case class with enum field
   case class Payment(amount: Double, method: PaymentMethod)
 
-  // Just verify that the macro runs successfully and gets us a JSON object back
-  test("Schema extraction should handle complex enums") {
+  // Enum behind Option, nested one level deeper (annotation-path TaskUpdate shape)
+  case class PaymentUpdate(payment: Payment, fallback: Option[PaymentMethod])
+
+  /** Resolve a property node, following a `$defs` `$ref` if tapir named the product schema. */
+  private def property(schema: io.circe.Json, path: String*): io.circe.Json =
+    def deref(node: io.circe.Json): io.circe.Json =
+      node.hcursor.get[String]("$ref").toOption match
+        case Some(ref) =>
+          val name = ref.stripPrefix("#/$defs/")
+          schema.hcursor.downField("$defs").downField(name).focus.getOrElse(node)
+        case None => node
+    path.foldLeft(schema) { (node, key) =>
+      deref(node).hcursor.downField("properties").downField(key).focus.getOrElse(
+        fail(s"missing property '$key' in ${deref(node).noSpaces}")
+      )
+    }
+
+  private def assertStringEnum(rawNode: io.circe.Json, values: String*): Unit =
+    // Option[enum] renders as a nullable anyOf under markOptionsAsNullable — unwrap to the
+    // branch carrying the enum constraint.
+    val node = rawNode.hcursor.downField("anyOf").as[List[io.circe.Json]].toOption match
+      case Some(branches) =>
+        branches.find(_.hcursor.downField("enum").succeeded).getOrElse(
+          fail(s"no enum branch in anyOf: ${rawNode.noSpaces}")
+        )
+      case None => rawNode
+    val tpe = node.hcursor.get[String]("type").toOption
+      .orElse(node.hcursor.downField("type").as[List[String]].toOption.map(_.head))
+    assert(tpe.contains("string"), s"expected string type in ${node.noSpaces}")
+    val enumValues = node.hcursor.get[List[String]]("enum").getOrElse(Nil)
+    values.foreach(v => assert(enumValues.contains(v), s"missing enum value $v in ${node.noSpaces}"))
+
+  // Nested enum fields must render as string enums, not coproducts of empty objects (GH #78)
+  test("nested enum field renders as a string enum schema") {
     def processPayment(payment: Payment): Unit = ()
     val schema = JsonSchemaMacro.schemaForFunctionArgs(processPayment)
     assert(schema.isObject)
+    val method = property(schema, "payment", "method")
+    assertStringEnum(method, "CreditCard", "PayPal", "Crypto")
+  }
+
+  test("enum behind Option and one level deeper also renders as a string enum") {
+    def updatePayment(update: PaymentUpdate): Unit = ()
+    val schema = JsonSchemaMacro.schemaForFunctionArgs(updatePayment)
+    val nested = property(schema, "update", "payment", "method")
+    assertStringEnum(nested, "DebitCard", "BankTransfer")
+    val optional = property(schema, "update", "fallback")
+    assertStringEnum(optional, "CreditCard", "Crypto")
   }
 }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/TypedContractsTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/TypedContractsTest.scala
@@ -395,3 +395,31 @@ class TypedContractsTest extends AnyFunSuite with Matchers:
       case StructuredToolResult(List(TextContent(text, _, _)), _) => text shouldBe "ok"
       case other => fail(s"unexpected: $other")
   }
+
+  test("Out with enum field encodes and derives outputSchema with zero user givens (GH #78 Part 3)") {
+    case class Report(mood: Mood, n: Int)
+    val server = McpServer("EnumOutServer")
+    runUnsafe(
+      server.tool(
+        McpTool[MoodArgs, Report](name = "report-tool", description = Some("d")) { args =>
+          Report(args.mood, 7)
+        }.withOutputSchema
+      )
+    )
+    val defn = server.toolManager.getToolDefinition("report-tool").get
+    val outSchemaStr = {
+      import com.tjclp.fastmcp.core.wire.toJsonString
+      defn.outputSchema.get.toJsonString
+    }
+    val outSchema = parse(outSchemaStr).toOption.get
+    val mood = outSchema.hcursor.downField("properties").downField("mood")
+    mood.get[String]("type") shouldBe Right("string")
+    mood.get[List[String]]("enum").toOption.get should contain("happy")
+
+    val r = runUnsafe(server.toolManager.callTool("report-tool", Map("mood" -> "happy"), None))
+    r match
+      case StructuredToolResult(List(TextContent(text, _, _)), structured) =>
+        text should include(""""mood":"happy"""")
+        structured.map(_.toString).getOrElse("") should include(""""mood":"happy"""")
+      case other => fail(s"unexpected: $other")
+  }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/TypedContractsTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/TypedContractsTest.scala
@@ -36,6 +36,39 @@ class TypedContractsTest extends AnyFunSuite with Matchers:
 
   given JsonEncoder[AddResult] = DeriveJsonEncoder.gen[AddResult]
 
+  // --- GH #78 fixtures: Scala 3 enums in typed contracts, zero user-supplied givens ---
+  enum Mood:
+    case happy, sad, mixed
+  case class MoodArgs(mood: Mood, note: Option[String])
+  case class MoodInner(mood: Mood)
+  case class MoodOuter(inner: MoodInner, alt: Option[Mood])
+
+  // Override guard: a user companion decoder with CUSTOM (lowercase) naming must win.
+  enum Tone:
+    case Formal, Casual
+  object Tone:
+    given JsonDecoder[Tone] = JsonDecoder.string.mapOrFail {
+      case "formal" => Right(Tone.Formal)
+      case "casual" => Right(Tone.Casual)
+      case other => Left(s"unknown tone: $other")
+    }
+  case class ToneArgs(tone: Tone)
+
+  // Parameterized-case enum: schema stays a coproduct, decode uses wrapper objects — must compile.
+  enum Shape:
+    case Circle(radius: Double)
+    case Point
+  case class ShapeArgs(shape: Shape)
+
+  // Inline-budget headroom: many enum fields in one args type.
+  enum E1 { case A, B }; enum E2 { case A, B }; enum E3 { case A, B }; enum E4 { case A, B }
+  enum E5 { case A, B }; enum E6 { case A, B }; enum E7 { case A, B }; enum E8 { case A, B }
+  enum E9 { case A, B }; enum E10 { case A, B }
+  case class ManyEnums(
+      e1: E1, e2: E2, e3: E3, e4: E4, e5: E5,
+      e6: E6, e7: E7, e8: E8, e9: E9, e10: E10
+  )
+
   private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
     Unsafe.unsafe { implicit unsafe =>
       Runtime.default.unsafe.run(effect).getOrThrowFiberFailure()
@@ -245,4 +278,120 @@ class TypedContractsTest extends AnyFunSuite with Matchers:
     val statusEnum =
       schema.hcursor.downField("properties").downField("status").downField("enum").as[List[String]]
     statusEnum shouldBe Right(List("active", "disabled"))
+  }
+
+  test("enum field derives a string-enum schema with zero user givens (GH #78)") {
+    val schema = parse(ToolInputSchema.derived[MoodArgs].toJsonString).toOption.get
+    val mood = schema.hcursor.downField("properties").downField("mood")
+    mood.get[String]("type") shouldBe Right("string")
+    mood.get[List[String]]("enum").toOption.get should contain allOf ("happy", "sad", "mixed")
+  }
+
+  test("enum field decodes with zero user givens; invalid values error cleanly (GH #78)") {
+    val server = McpServer("EnumDecodeServer")
+    runUnsafe(
+      server.tool(
+        McpTool[MoodArgs, String](name = "mood-tool", description = Some("d")) { args =>
+          s"${args.mood} ${args.note.getOrElse("-")}"
+        }
+      )
+    )
+    val ok = runUnsafe(server.toolManager.callTool("mood-tool", Map("mood" -> "happy"), None))
+    ok match
+      case StructuredToolResult(List(TextContent(text, _, _)), _) => text shouldBe "happy -"
+      case other => fail(s"unexpected: $other")
+
+    val bad = runUnsafe(
+      server.toolManager.callTool("mood-tool", Map("mood" -> "furious"), None).either
+    )
+    bad.isLeft shouldBe true
+    bad.left.toOption.get.getMessage should (include("mood") and include("invalid enumeration value"))
+  }
+
+  test("enum nested one level deeper and behind Option decodes and schemas correctly (GH #78)") {
+    val schema = parse(ToolInputSchema.derived[MoodOuter].toJsonString).toOption.get
+    val nested = schema.hcursor
+      .downField("properties").downField("inner")
+      .downField("properties").downField("mood")
+    nested.get[String]("type") shouldBe Right("string")
+
+    val server = McpServer("EnumNestedServer")
+    runUnsafe(
+      server.tool(
+        McpTool[MoodOuter, String](name = "nested-tool", description = Some("d")) { args =>
+          s"${args.inner.mood}/${args.alt.getOrElse("-")}"
+        }
+      )
+    )
+    val r = runUnsafe(
+      server.toolManager.callTool(
+        "nested-tool",
+        Map("inner" -> Map("mood" -> "sad"), "alt" -> "mixed"),
+        None
+      )
+    )
+    r match
+      case StructuredToolResult(List(TextContent(text, _, _)), _) => text shouldBe "sad/mixed"
+      case other => fail(s"unexpected: $other")
+  }
+
+  test("a user-supplied companion JsonDecoder for an enum always wins (GH #78)") {
+    val server = McpServer("EnumOverrideServer")
+    runUnsafe(
+      server.tool(
+        McpTool[ToneArgs, String](name = "tone-tool", description = Some("d")) { args =>
+          args.tone.toString
+        }
+      )
+    )
+    val r = runUnsafe(server.toolManager.callTool("tone-tool", Map("tone" -> "formal"), None))
+    r match
+      case StructuredToolResult(List(TextContent(text, _, _)), _) => text shouldBe "Formal"
+      case other => fail(s"unexpected: $other")
+    // The derived (capitalized) name must NOT decode — proving the custom decoder was used.
+    val cap = runUnsafe(
+      server.toolManager.callTool("tone-tool", Map("tone" -> "Formal"), None).either
+    )
+    cap.isLeft shouldBe true
+  }
+
+  test("parameterized-case enums compile: coproduct schema, wrapper-object decode (GH #78)") {
+    val schema = parse(ToolInputSchema.derived[ShapeArgs].toJsonString).toOption.get
+    // Not a string enum — the coproduct path is intentional for parameterized cases.
+    schema.hcursor.downField("properties").downField("shape").get[String]("type") should not be Right("string")
+
+    val server = McpServer("ShapeServer")
+    runUnsafe(
+      server.tool(
+        McpTool[ShapeArgs, String](name = "shape-tool", description = Some("d")) { args =>
+          args.shape.toString
+        }
+      )
+    )
+    val r = runUnsafe(
+      server.toolManager.callTool(
+        "shape-tool",
+        Map("shape" -> Map("Circle" -> Map("radius" -> 2.0))),
+        None
+      )
+    )
+    r match
+      case StructuredToolResult(List(TextContent(text, _, _)), _) => text should include("Circle")
+      case other => fail(s"unexpected: $other")
+  }
+
+  test("ten enum fields derive within the inline budget (GH #78)") {
+    val schema = parse(ToolInputSchema.derived[ManyEnums].toJsonString).toOption.get
+    schema.hcursor.downField("properties").downField("e10").get[String]("type") shouldBe Right("string")
+    val server = McpServer("ManyEnumServer")
+    runUnsafe(
+      server.tool(
+        McpTool[ManyEnums, String](name = "many", description = Some("d"))(_ => "ok")
+      )
+    )
+    val args = (1 to 10).map(i => s"e$i" -> "A").toMap[String, Any]
+    val r = runUnsafe(server.toolManager.callTool("many", args, None))
+    r match
+      case StructuredToolResult(List(TextContent(text, _, _)), _) => text shouldBe "ok"
+      case other => fail(s"unexpected: $other")
   }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/TypedContractsTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/TypedContractsTest.scala
@@ -54,6 +54,15 @@ class TypedContractsTest extends AnyFunSuite with Matchers:
     }
   case class ToneArgs(tone: Tone)
 
+  // Schema-override guard: a user companion tapir Schema for an enum must win over the
+  // planted derivedEnumeration default (review finding on GH #78).
+  enum Grade:
+    case A, B, C
+  object Grade:
+    given sttp.tapir.Schema[Grade] =
+      sttp.tapir.Schema.string[Grade].description("user-grade-schema")
+  case class GradeArgs(grade: Grade)
+
   // Parameterized-case enum: schema stays a coproduct, decode uses wrapper objects — must compile.
   enum Shape:
     case Circle(radius: Double)
@@ -423,3 +432,12 @@ class TypedContractsTest extends AnyFunSuite with Matchers:
         structured.map(_.toString).getOrElse("") should include(""""mood":"happy"""")
       case other => fail(s"unexpected: $other")
   }
+
+  test("a user-supplied tapir Schema for a nested enum always wins (GH #78 review)") {
+    val schema = parse(ToolInputSchema.derived[GradeArgs].toJsonString).toOption.get
+    val grade = schema.hcursor.downField("properties").downField("grade")
+    grade.get[String]("description") shouldBe Right("user-grade-schema")
+    // The planted default would have added an enum constraint; the user schema has none.
+    grade.downField("enum").succeeded shouldBe false
+  }
+

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/codec/McpDecoders.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/codec/McpDecoders.scala
@@ -32,12 +32,17 @@ trait McpDecodersLowPriority:
     * `McpDecoder[Option[String]]` used to resolve HERE, deriving a sum decoder that expects
     * `{"Some": ...}` and rejects bare values (#64). With the product constraint, sum types with
     * zio-json built-ins (Option, Either, collections) resolve uniquely through `zioJsonDecoder`.
+    *
+    * Derivation goes through [[macros.ZioJsonEnumDerivation]], which plants string-based
+    * `JsonDecoder` locals for Scala 3 enum field types that have no user-supplied instance at the
+    * call site (GH #78) — user-defined enum decoders always win.
     */
-  inline given derivedZioJsonDecoder[T](using Mirror.ProductOf[T]): McpDecoder[T] =
+  inline given derivedZioJsonDecoder[T](using m: Mirror.ProductOf[T]): McpDecoder[T] =
+    val jsonDecoder = macros.ZioJsonEnumDerivation.deriveDecoder[T](using m)
     new McpDecoder[T]:
       def decode(name: String, rawValue: Any, context: McpDecodeContext): T =
         val json = context.writeValueAsString(rawValue)
-        DeriveJsonDecoder.gen[T].decodeJson(json) match
+        jsonDecoder.decodeJson(json) match
           case Right(value) => value
           case Left(err) =>
             throw new RuntimeException(

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/core/Contracts.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/core/Contracts.scala
@@ -97,6 +97,26 @@ trait McpEncoderLowPriority:
     override def encodeStructured(value: A): Option[zio.json.ast.Json] =
       value.toJsonAST.toOption
 
+  /** Mirror fallback for case classes with NO `JsonEncoder` anywhere in scope.
+    *
+    * The `NotGiven` guard makes eligibility DISJOINT from the `JsonEncoder`-based given above —
+    * `export McpEncoder.given` flattens trait-layer priorities (the #64 lesson), so disjointness,
+    * not layering, is what prevents ambiguity. Every call site with an explicit `given
+    * JsonEncoder[Out]` is untouched (`NotGiven` fails there and the given above applies).
+    * Derivation goes through [[com.tjclp.fastmcp.macros.ZioJsonEnumDerivation]], so `Out` case
+    * classes with Scala 3 enum or nested case-class fields encode zero-boilerplate (GH #78).
+    */
+  inline given derivedZioJsonEncoder[A](using
+      m: scala.deriving.Mirror.ProductOf[A],
+      ev: scala.util.NotGiven[JsonEncoder[A]]
+  ): McpEncoder[A] =
+    val jsonEncoder = com.tjclp.fastmcp.macros.ZioJsonEnumDerivation.deriveEncoder[A](using m)
+    new McpEncoder[A]:
+      def encode(value: A): List[Content] =
+        List(TextContent(jsonEncoder.encodeJson(value, None).toString))
+      override def encodeStructured(value: A): Option[zio.json.ast.Json] =
+        jsonEncoder.toJsonAST(value).toOption
+
 object McpEncoder extends McpEncoderLowPriority:
   def apply[A](using encoder: McpEncoder[A]): McpEncoder[A] = encoder
 

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/EnumTypeCollector.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/EnumTypeCollector.scala
@@ -1,0 +1,64 @@
+package com.tjclp.fastmcp.macros
+
+import scala.quoted.*
+
+/** Compile-time walker that finds Scala 3 enum types reachable through a type's field tree.
+  *
+  * Used by the schema and decoder derivation macros to plant block-local givens (string-based
+  * `Schema` / `JsonDecoder`) for enum fields that would otherwise fall through to tapir's coproduct
+  * rendering or fail zio-json's per-field summon (GH #78). Shared so both the JVM and Scala.js
+  * compilations of the macros can use it.
+  */
+private[fastmcp] object EnumTypeCollector:
+
+  /** All Scala 3 enum types reachable through `root`'s field tree, excluding `root` itself.
+    *
+    * Recurses into every `AppliedType` argument (covering `Option`/`List`/`Seq`/`Map`/`Either`/
+    * tuples/custom generics uniformly) and into the case fields of case classes. Dedupe and the
+    * cycle guard key on the full `TypeRepr` via `=:=` — not the type symbol — so a generic case
+    * class applied at two different enum arguments contributes both.
+    */
+  def collectEnums(using q: Quotes)(root: q.reflect.TypeRepr): List[q.reflect.TypeRepr] =
+    import q.reflect.*
+
+    val visited = scala.collection.mutable.ListBuffer.empty[TypeRepr]
+    val found = scala.collection.mutable.ListBuffer.empty[TypeRepr]
+
+    def walk(raw: TypeRepr, depth: Int): Unit =
+      if depth <= MaxDepth then
+        val tpe = raw.dealias.simplified
+        if !visited.exists(_ =:= tpe) then
+          visited += tpe
+          val sym = tpe.typeSymbol
+          val isScalaEnum =
+            sym.flags.is(Flags.Enum) && !sym.flags.is(Flags.Case) && !sym.flags.is(
+              Flags.JavaDefined
+            )
+          if isScalaEnum then found += tpe
+          tpe match
+            case AppliedType(_, args) => args.foreach(walk(_, depth + 1))
+            case _ => ()
+          if !isScalaEnum && sym.isClassDef && sym.caseFields.nonEmpty then
+            sym.caseFields.foreach(f => walk(tpe.memberType(f), depth + 1))
+
+    val rootTpe = root.dealias.simplified
+    visited += rootTpe
+    rootTpe match
+      case AppliedType(_, args) => args.foreach(walk(_, 1))
+      case _ => ()
+    val rootSym = rootTpe.typeSymbol
+    if rootSym.isClassDef && rootSym.caseFields.nonEmpty then
+      rootSym.caseFields.foreach(f => walk(rootTpe.memberType(f), 1))
+    found.toList
+
+  /** The subset of [[collectEnums]] safe for `Schema.derivedEnumeration` (all-singleton cases — a
+    * parameterized case desugars to a class child, and derivedEnumeration's validator macro aborts
+    * compilation on those).
+    */
+  def collectSingletonEnums(using q: Quotes)(root: q.reflect.TypeRepr): List[q.reflect.TypeRepr] =
+    collectEnums(root).filter { t =>
+      val children = t.typeSymbol.children
+      children.nonEmpty && children.forall(c => !c.isClassDef)
+    }
+
+  private val MaxDepth = 32

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/EnumTypeCollector.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/EnumTypeCollector.scala
@@ -51,6 +51,46 @@ private[fastmcp] object EnumTypeCollector:
       rootSym.caseFields.foreach(f => walk(rootTpe.memberType(f), 1))
     found.toList
 
+  /** All zio-json-derivable types (Scala 3 enums AND case classes) reachable through `root`'s field
+    * tree, excluding `root` itself, in POST-ORDER (dependencies before dependents) — so a planted
+    * `JsonDecoder` local for an inner type is in scope when an outer type's derivation expands.
+    * Same walk as [[collectEnums]]; ordering and the product inclusion differ.
+    */
+  def collectDerivable(using q: Quotes)(root: q.reflect.TypeRepr): List[q.reflect.TypeRepr] =
+    import q.reflect.*
+
+    val visited = scala.collection.mutable.ListBuffer.empty[TypeRepr]
+    val found = scala.collection.mutable.ListBuffer.empty[TypeRepr]
+
+    def walk(raw: TypeRepr, depth: Int): Unit =
+      if depth <= MaxDepth then
+        val tpe = raw.dealias.simplified
+        if !visited.exists(_ =:= tpe) then
+          visited += tpe
+          val sym = tpe.typeSymbol
+          val isScalaEnum =
+            sym.flags.is(Flags.Enum) && !sym.flags.is(Flags.Case) && !sym.flags.is(
+              Flags.JavaDefined
+            )
+          val isProduct = !isScalaEnum && sym.isClassDef && sym.flags.is(Flags.Case) &&
+            sym.caseFields.nonEmpty
+          tpe match
+            case AppliedType(_, args) => args.foreach(walk(_, depth + 1))
+            case _ => ()
+          if isProduct then sym.caseFields.foreach(f => walk(tpe.memberType(f), depth + 1))
+          // Post-order: children recorded above, self after — dependency-safe local ordering.
+          if isScalaEnum || (isProduct && tpe.typeArgs.isEmpty) then found += tpe
+
+    val rootTpe = root.dealias.simplified
+    visited += rootTpe
+    rootTpe match
+      case AppliedType(_, args) => args.foreach(walk(_, 1))
+      case _ => ()
+    val rootSym = rootTpe.typeSymbol
+    if rootSym.isClassDef && rootSym.caseFields.nonEmpty then
+      rootSym.caseFields.foreach(f => walk(rootTpe.memberType(f), 1))
+    found.toList
+
   /** The subset of [[collectEnums]] safe for `Schema.derivedEnumeration` (all-singleton cases — a
     * parameterized case desugars to a class child, and derivedEnumeration's validator macro aborts
     * compilation on those).

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/MapToFunctionMacro.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/MapToFunctionMacro.scala
@@ -149,8 +149,11 @@ object MapToFunctionMacro:
           Expr
             .summon[JsonDecoder[t]]
             .orElse(
+              // Enum-aware derivation: plants string-based JsonDecoder locals for enum FIELD
+              // types lacking a user instance, so case-class params with enum fields decode
+              // zero-boilerplate like top-level enum params already do (GH #78).
               Expr.summon[Mirror.Of[t]].map { mirror =>
-                '{ DeriveJsonDecoder.gen[t](using $mirror) }
+                ZioJsonEnumDerivation.deriveDecoderImpl[t](mirror)
               }
             )
             .getOrElse(

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ZioJsonEnumDerivation.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ZioJsonEnumDerivation.scala
@@ -1,0 +1,84 @@
+package com.tjclp.fastmcp.macros
+
+import scala.deriving.Mirror
+import scala.quoted.*
+
+import zio.json.*
+
+/** zio-json derivation with codec locals pre-planted for the field tree's derivable types.
+  *
+  * `DeriveJsonDecoder.gen[T]` summons a `JsonDecoder` per field and does not recurse, so a bare
+  * enum field — or a nested case class — fails to compile at the user's call site. These entry
+  * points expand `gen[T]` inside a block that carries `given JsonDecoder[X] = gen[X]` locals, in
+  * dependency (post-)order, for every reachable enum or monomorphic case-class type that has NO
+  * user-supplied instance at the call site (GH #78).
+  *
+  * The summon-first filter is the load-bearing design point: `Expr.summon` performs the full
+  * call-site implicit search (contextual scope, then companions) without adding candidates, so a
+  * user's hand-written enum codec — custom naming and all — is always preferred; a local is planted
+  * only where the search comes up empty. zio-json's own derivation on an all-parameterless-case
+  * enum already produces bare strings (`enumValuesAsStrings` defaults to true), so no shim is
+  * needed; parameterized-case enums derive zio-json's wrapper-object encoding.
+  */
+private[fastmcp] object ZioJsonEnumDerivation:
+
+  inline def deriveDecoder[T](using inline m: Mirror.Of[T]): JsonDecoder[T] =
+    ${ deriveDecoderImpl[T]('m) }
+
+  inline def deriveEncoder[T](using inline m: Mirror.Of[T]): JsonEncoder[T] =
+    ${ deriveEncoderImpl[T]('m) }
+
+  private[macros] def deriveDecoderImpl[T: Type](
+      mirror: Expr[Mirror.Of[T]]
+  )(using Quotes): Expr[JsonDecoder[T]] =
+    import quotes.reflect.*
+    val missing = EnumTypeCollector
+      .collectDerivable(TypeRepr.of[T])
+      .filter { e =>
+        e.asType match
+          case '[et] => Expr.summon[JsonDecoder[et]].isEmpty
+      }
+    def withLocals(remaining: List[TypeRepr]): Expr[JsonDecoder[T]] =
+      remaining match
+        case Nil => '{ DeriveJsonDecoder.gen[T](using $mirror) }
+        case e :: rest =>
+          e.asType match
+            case '[et] =>
+              Expr.summon[Mirror.Of[et]] match
+                case Some(em) =>
+                  '{
+                    given JsonDecoder[et] = DeriveJsonDecoder.gen[et](using $em)
+                    ${ withLocals(rest) }
+                  }
+                case None => withLocals(rest) // let gen[T] surface its own error
+    withLocals(missing)
+
+  private[macros] def deriveEncoderImpl[T: Type](
+      mirror: Expr[Mirror.Of[T]]
+  )(using Quotes): Expr[JsonEncoder[T]] =
+    import quotes.reflect.*
+    // DeriveJsonEncoder.gen (unlike the decoder's) takes (config, mirror); summon the
+    // configuration at the call site so user-supplied JsonCodecConfiguration is respected.
+    val config = Expr.summon[JsonCodecConfiguration].getOrElse {
+      report.errorAndAbort("No given JsonCodecConfiguration found (zio-json provides a default)")
+    }
+    val missing = EnumTypeCollector
+      .collectDerivable(TypeRepr.of[T])
+      .filter { e =>
+        e.asType match
+          case '[et] => Expr.summon[JsonEncoder[et]].isEmpty
+      }
+    def withLocals(remaining: List[TypeRepr]): Expr[JsonEncoder[T]] =
+      remaining match
+        case Nil => '{ DeriveJsonEncoder.gen[T](using $config, $mirror) }
+        case e :: rest =>
+          e.asType match
+            case '[et] =>
+              Expr.summon[Mirror.Of[et]] match
+                case Some(em) =>
+                  '{
+                    given JsonEncoder[et] = DeriveJsonEncoder.gen[et](using $config, $em)
+                    ${ withLocals(rest) }
+                  }
+                case None => withLocals(rest)
+    withLocals(missing)

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ZioJsonEnumDerivation.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ZioJsonEnumDerivation.scala
@@ -20,12 +20,18 @@ import zio.json.*
   * enum already produces bare strings (`enumValuesAsStrings` defaults to true), so no shim is
   * needed; parameterized-case enums derive zio-json's wrapper-object encoding.
   */
-private[fastmcp] object ZioJsonEnumDerivation:
+object ZioJsonEnumDerivation:
+  // Public (not private[fastmcp]) deliberately: the deriveDecoder/deriveEncoder entry points are
+  // called from inline givens in other packages, and a package-private member forces the compiler
+  // to synthesize an inline accessor whose parameter type is the *package class*
+  // (com/tjclp/fastmcp/macros) — a class that never exists in bytecode, blowing up any runtime
+  // reflection over inheritors (e.g. test discovery) with NoClassDefFoundError. Internal API:
+  // not exported from com.tjclp.fastmcp, not documented for direct use.
 
-  inline def deriveDecoder[T](using inline m: Mirror.Of[T]): JsonDecoder[T] =
+  inline def deriveDecoder[T](using m: Mirror.Of[T]): JsonDecoder[T] =
     ${ deriveDecoderImpl[T]('m) }
 
-  inline def deriveEncoder[T](using inline m: Mirror.Of[T]): JsonEncoder[T] =
+  inline def deriveEncoder[T](using m: Mirror.Of[T]): JsonEncoder[T] =
     ${ deriveEncoderImpl[T]('m) }
 
   private[macros] def deriveDecoderImpl[T: Type](


### PR DESCRIPTION
## Summary

Closes #78 — `McpTool[In, Out]` with Scala 3 enum fields now works with **zero user-supplied givens**, matching (and improving) the annotation path. Single PR, four commits, each independently green.

### One deliberate refinement vs. #78's proposal

The issue proposed exported inline givens. Research showed those **silently shadow user companion instances** (Scala 3 searches the contextual phase before companions; no ambiguity error; 3.7+ prefers-most-general kills bound-based outranking). The fix is **macro-side** instead: `Expr.summon` runs the full call-site search *without adding candidates*, so user-defined codecs — custom naming and all — always win, verified by a regression test.

### What's here

1. **Schema** (`EnumTypeCollector` + `SchemaExtractor` hook): enum fields at any nesting depth (incl. `Option`/collections/nested case classes) render `{"type":"string","enum":[...]}` via block-local `Schema.derivedEnumeration.defaultStringBased` givens planted before an in-block `summonInline`. Also fixes the **annotation path's** own nested-enum gap. Parameterized-case enums stay on the coproduct path (correct ADT rendering; derivedEnumeration would abort).
2. **Decode** (`ZioJsonEnumDerivation`): `gen[T]` expands inside a block carrying `given JsonDecoder[X] = gen[X]` locals in dependency order for every reachable enum **and nested case class** lacking a user instance (the nested-case-class gap turned out to be the same disease). Wired into `derivedZioJsonDecoder` (the #64 `Mirror.ProductOf` guard is untouched; error text byte-identical; derivation hoisted out of the per-call body) and `MapToFunctionMacro` (annotation parity).
3. **Encode**: Mirror-based `McpEncoder` fallback guarded by `NotGiven[JsonEncoder[A]]` — provably disjoint from the existing JsonEncoder-based given (export flattening kills layering; disjointness is the safe mechanism), so `Out` case classes need no hand-written encoders and every existing explicit-encoder site resolves as before.
4. Docs (README/CLAUDE.md/CHANGELOG).

### War story worth reviewing

The first cut made `ZioJsonEnumDerivation` `private[fastmcp]` — and inline givens in other packages made the compiler synthesize an inline accessor whose **parameter type is the package class** `com/tjclp/fastmcp/macros` (nonexistent in bytecode), so runtime reflection over inheritors threw `NoClassDefFoundError` — caught by Mill's test discovery. The object is now public (internal by convention); a reflection probe over every main+test classfile comes back clean.

## Test plan

- [x] 8 new `TypedContractsTest` cases: string-enum schema · decode + invalid-value message · nested + `Option[enum]` · **user-companion-decoder-wins** · parameterized-case semantics · 10-enum inline-budget headroom · zero-given `Out` with `withOutputSchema` + `structuredContent`
- [x] Annotation parity: `SchemaExtractorExtendedTest` nested string-enum assertions; `MapToFunctionMacroTest` case-class-with-enum-field decode
- [x] JS: new enum contract test (schema + decode + structured encode, zero givens) — `bunTest` 41/41 incl. the 17 TS-SDK conformance tests
- [x] Full JVM suite (incl. #64 Option regression) green; `checkFormat` green
- [x] `conformance.sh jvm` + `js`: baselines unchanged (empty)
- [x] Clean rebuild (`rm -rf out/fast-mcp-scala`) — the `-Xcheck-macros` incremental flake appeared twice mid-development and is confirmed absent on clean builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)