### PR TITLE
feat: Scala Native target — stdio MCP servers as standalone LLVM binaries (TJC-2188, experimental)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,47 @@ jobs:
 
       - name: Test (Scala.js on Bun)
         run: ./mill -i fast-mcp-scala.js.test.bunTest
+
+  scala-native:
+    name: Scala Native (linux-x64)
+    runs-on: ubuntu-latest # clang + jq preinstalled; SN 0.5 recommends LLVM >= 17
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK (Mill/scalac runner only)
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:21
+
+      # Separate cache key from the JDK-matrix builds so the Scala Native toolchain artifacts
+      # (nativelib/javalib/clib NIR jars) don't churn the main cache.
+      - name: Cache Coursier
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier
+            ~/.ivy2/cache
+          key: ${{ runner.os }}-coursier-scala-native-${{ hashFiles('**/build.mill') }}
+          restore-keys: |
+            ${{ runner.os }}-coursier-scala-native-
+
+      - name: Cache Mill
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/mill
+          key: ${{ runner.os }}-mill-scala-native-${{ hashFiles('**/build.mill') }}
+          restore-keys: |
+            ${{ runner.os }}-mill-scala-native-
+
+      - name: Test (Scala Native)
+        run: ./mill -i fast-mcp-scala.scalaNative.test
+
+      - name: Link demo binary (AnnotatedServer)
+        run: |
+          BIN="$(./mill --no-server show fast-mcp-scala.scalaNative.nativeLink 2>/dev/null |
+            python3 -c "import sys,json,re; print(re.sub(r'^q?ref:v\d+:[0-9a-f]+:','',json.load(sys.stdin)))")"
+          echo "BIN=$BIN" >> "$GITHUB_ENV"
+
+      - name: Stdio smoke over the Scala Native binary
+        run: scripts/native-smoke.sh "$BIN"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Verify Publishing Setup
         run: |
           echo "Version: $PUBLISH_VERSION"
-          ./mill show fast-mcp-scala.jvm.publishVersion fast-mcp-scala.js.publishVersion
+          ./mill show fast-mcp-scala.jvm.publishVersion fast-mcp-scala.js.publishVersion fast-mcp-scala.scalaNative.publishVersion
         env:
           PUBLISH_VERSION: ${{ steps.version.outputs.version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Scala Native target (experimental)** (TJC-2188, #82):
+  `com.tjclp:fast-mcp-scala_native0.5_3` — stdio MCP servers compiled to
+  standalone binaries via Scala Native 0.5.12 (21MB debug links in
+  seconds). HTTP is excluded by design (zio-http has no Native
+  artifacts): the platform provides only the `TransportBackend` given,
+  so `McpServerApp[Http]` fails at compile time while
+  `McpServerApp[Stdio]` works unchanged. Session/task ids come from
+  `/dev/urandom` (javalib `UUID.randomUUID` doesn't link on SN); stdin
+  reads via `ZStream.fromReader`. CI links the `AnnotatedServer` demo
+  binary and drives it with the same stdio smoke script that gates the
+  GraalVM images.
+
 - **Mirror-based `McpEncoder` fallback**: `Out` case classes without any
   `JsonEncoder` in scope now encode (text + `structuredContent`)
   automatically; guarded by `NotGiven[JsonEncoder[A]]` so every existing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@ fast-mcp-scala is a high-level Scala 3 library for building Model Context Protoc
 
 Both paths converge on the same `McpServer` trait and support `@Param` metadata on parameters/fields.
 
+Three platforms: **JVM** (stdio + HTTP), **Scala.js/Bun** (stdio + HTTP), and **Scala Native** (stdio only, EXPERIMENTAL — published as `fast-mcp-scala_native0.5_3`; zio-http has no Native artifacts, so `McpServerApp[Http]` fails to compile there by design).
+
 ## Build System
 
 **Build tool**: Mill 1.1.5 (configured in `.mill-version`)
@@ -27,6 +29,8 @@ Both paths converge on the same `McpServer` trait and support `@Param` metadata 
 # Single-platform
 ./mill fast-mcp-scala.jvm.test                      # JVM tests only
 ./mill fast-mcp-scala.js.test.bunTest               # Scala.js conformance tests only
+./mill fast-mcp-scala.scalaNative.test              # Scala Native tests (links a native binary)
+./mill fast-mcp-scala.scalaNative.nativeLink        # Standalone LLVM binary of AnnotatedServer
 ./mill fast-mcp-scala.jvm.test com.tjclp.fastmcp.macros.ToolProcessorTest
 
 # Publish

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Built on **ZIO 2** and **zio-json** on both platforms, with JSON Schemas derived
 - [Transports](#transports)
 - [Native image (GraalVM)](#native-image-graalvm)
 - [Customizing input types (zio-json)](#customizing-input-types-zio-json)
-- [One core, two transports](#one-core-two-transports)
+- [One core, three platforms](#one-core-three-platforms)
 - [Spec coverage](#spec-coverage)
 - [Running examples](#running-examples)
 - [Claude Desktop integration](#claude-desktop-integration)
@@ -327,7 +327,7 @@ tools can opt out through `McpTool.withSchema`. For a nested output-only type, `
 provides the schema without requiring a decoder. Implement `McpDecoder[T]` directly only for a
 low-level input conversion that does not need automatic nested case-class derivation.
 
-## One core, two transports
+## One core, three platforms
 
 fast-mcp-scala is a single native MCP implementation. The entire protocol layer — JSON-RPC envelope, wire types, router, built-in handlers, middleware, the Tasks state machine — lives in `shared/`; each platform contributes only a `TransportBackend`:
 
@@ -370,18 +370,20 @@ Capabilities are **derived from the registered handler map** — a capability is
 
 **Current platform parity**:
 
-| Capability | JVM | Scala.js (Bun-first) |
-|---|---|---|
-| `McpServerApp[T, Self]` sugar trait | ✅ | ✅ |
-| `@Tool` / `@Resource` / `@Prompt` + `scanAnnotations[T]` | ✅ | ✅ |
-| Typed contracts (`McpTool`, `McpPrompt`, `McpStaticResource`, `McpTemplateResource`) | ✅ | ✅ |
-| `ToolSchemaProvider[A]` auto-derivation from `@Param` | ✅ native macro | ✅ native macro |
-| `ToHandlerEffect[F]` — plain values / ZIO / Either / Try | ✅ | ✅ |
-| Stdio transport | ✅ (native) | ✅ (native) |
-| Streamable HTTP — stateful (sessions + per-request SSE) | ✅ (ZIO HTTP) | ✅ (Bun.serve) |
-| Streamable HTTP — stateless | ✅ | ✅ |
-| Standalone GET SSE push channel | ✅ | 405 (per-request SSE covers server→client) |
-| Custom decoders | ✅ `given JsonDecoder[T] → McpDecoder[T]` | ✅ same (shared zio-json path) |
+| Capability | JVM | Scala.js (Bun-first) | Scala Native (experimental) |
+|---|---|---|---|
+| `McpServerApp[T, Self]` sugar trait | ✅ | ✅ | ✅ |
+| `@Tool` / `@Resource` / `@Prompt` + `scanAnnotations[T]` | ✅ | ✅ | ✅ |
+| Typed contracts (`McpTool`, `McpPrompt`, `McpStaticResource`, `McpTemplateResource`) | ✅ | ✅ | ✅ |
+| `ToolSchemaProvider[A]` auto-derivation from `@Param` | ✅ native macro | ✅ native macro | ✅ native macro |
+| `ToHandlerEffect[F]` — plain values / ZIO / Either / Try | ✅ | ✅ | ✅ |
+| Stdio transport | ✅ (native) | ✅ (native) | ✅ (LLVM binary) |
+| Streamable HTTP — stateful (sessions + per-request SSE) | ✅ (ZIO HTTP) | ✅ (Bun.serve) | ✗ by design¹ |
+| Streamable HTTP — stateless | ✅ | ✅ | ✗ by design¹ |
+| Standalone GET SSE push channel | ✅ | 405 (per-request SSE covers server→client) | ✗ by design¹ |
+| Custom decoders | ✅ `given JsonDecoder[T] → McpDecoder[T]` | ✅ same (shared zio-json path) | ✅ same |
+
+¹ zio-http is not published for Scala Native (upstream support is 4.x-milestoned). The platform provides no `HttpTransportBackend` given, so `McpServerApp[Http]` programs fail to compile — a compile-time property, not a runtime failure. A socket-based HTTP backend is planned as a follow-up ([#81](https://github.com/TJC-LP/fast-mcp-scala/issues/81)).
 
 Node / Deno parity for the HTTP listener is a follow-up; only the `Bun.serve(...)` entry point is Bun-specific today.
 
@@ -403,6 +405,27 @@ object HelloBun extends McpServerApp[Stdio, HelloBun.type]:
 Same shape as the JVM — the `McpServerApp` trait picks up the shared `McpServerCoreFactory` given and builds the one shared `McpServer` over the Bun `TransportBackend`. Typed contracts auto-generate their input schemas on Scala.js as well, with no schema-library import.
 
 Link with `./mill fast-mcp-scala.js.fastLinkJS`, then `bun run out/fast-mcp-scala/js/fastLinkJS.dest/main.js`. See [`HelloWorldJs.scala`](fast-mcp-scala/js/src/com/tjclp/fastmcp/examples/HelloWorldJs.scala) and [`HttpServerJs.scala`](fast-mcp-scala/js/src/com/tjclp/fastmcp/examples/HttpServerJs.scala) for runnable references.
+
+### Running on Scala Native (experimental)
+
+The same shared core compiles to a standalone LLVM binary — no JVM, no JS runtime (~21 MB in a debug link, single-digit-second link times):
+
+```scala 3 raw
+//> using scala 3.8.3
+//> using platform native
+//> using nativeVersion 0.5.12
+//> using dep com.tjclp::fast-mcp-scala::1.0.0-RC4
+
+import com.tjclp.fastmcp.{*, given}
+
+object HelloNative extends McpServerApp[Stdio, HelloNative.type]:
+  @Tool(name = Some("add"), description = Some("Add two numbers"), readOnlyHint = Some(true))
+  def add(@Param("First operand") a: Int, @Param("Second operand") b: Int): Int = a + b
+```
+
+Or in this repo: `./mill fast-mcp-scala.scalaNative.nativeLink` builds the `AnnotatedServer` demo binary, and `scripts/native-smoke.sh <binary>` drives it through the full MCP handshake — the same script that gates the GraalVM images.
+
+Caveats (experimental): stdio only (see the matrix footnote); session/task ids come from `/dev/urandom` (Unix-only); ZIO's signal handlers and shutdown hooks are no-ops on Scala Native — shutdown is EOF-driven (the client closing stdin ends the loop), and SIGINT falls back to the OS default; `java.util.regex` is RE2-backed (no lookaheads) — relevant only if your resource URI templates embed exotic regex.
 
 ## Spec coverage
 

--- a/build.mill
+++ b/build.mill
@@ -9,6 +9,7 @@ import mill.scalalib.scalafmt._
 import mill.scalajslib._
 import mill.scalajslib.api._
 import mill.scalajslib.bun._
+import mill.scalanativelib._
 import mill.bun.bun
 import contrib.scoverage.ScoverageModule
 
@@ -21,6 +22,7 @@ object Versions {
   val zioJson = "0.7.44"
   val zioHttp = "3.4.0"
   val scalaTest = "3.2.19"
+  val scalaNative = "0.5.12" // officially supports Scala 3.8.3
   val scalaCheck = "1.18.1"
 }
 
@@ -77,10 +79,11 @@ trait FastMCPModuleBase extends ScalaModule with ScalafmtModule with ScoverageMo
   override def scoverageVersion = "2.3.1"
 }
 
-/** Shared POM / publish config. Both `jvm` and `js` mix this in so they publish under the same
-  * `com.tjclp:fast-mcp-scala` artifact family. Scala auto-appends the platform suffix, giving:
-  *   - `com.tjclp:fast-mcp-scala_3:<version>`       (JVM)
-  *   - `com.tjclp:fast-mcp-scala_sjs1_3:<version>`  (Scala.js)
+/** Shared POM / publish config. `jvm`, `js`, and `scalaNative` mix this in so they publish under
+  * the same `com.tjclp:fast-mcp-scala` artifact family. Scala auto-appends the platform suffix:
+  *   - `com.tjclp:fast-mcp-scala_3:<version>`             (JVM)
+  *   - `com.tjclp:fast-mcp-scala_sjs1_3:<version>`        (Scala.js)
+  *   - `com.tjclp:fast-mcp-scala_native0.5_3:<version>`   (Scala Native, experimental)
   */
 trait FastMCPPublishingBase extends PublishModule {
 
@@ -118,31 +121,35 @@ trait FastMCPTestModule extends TestModule.ScalaTest {
 // cover the whole project without having to spell out each platform.
 object `fast-mcp-scala` extends Module {
 
-  /** Compile both JVM and Scala.js sources. */
+  /** Compile the JVM, Scala.js, and Scala Native sources. */
   def compile: T[Unit] = Task {
     jvm.compile()
     js.compile()
+    scalaNative.compile()
     ()
   }
 
-  /** Run both the JVM test suite and the Scala.js/Bun conformance tests. */
+  /** Run the JVM test suite, the Scala.js/Bun conformance tests, and the Scala Native tests. */
   def test: T[Unit] = Task {
     jvm.test.testForked()()
     js.test.bunTest(mill.api.Args())()
+    scalaNative.test.testForked()()
     ()
   }
 
-  /** Scalafmt check on every Scala source (shared/, jvm/, js/). */
+  /** Scalafmt check on every Scala source (shared/, jvm/, js/, native/). */
   def checkFormat: T[Unit] = Task {
     jvm.checkFormat()()
     js.checkFormat()()
+    scalaNative.checkFormat()()
     ()
   }
 
-  /** Auto-format every Scala source (shared/, jvm/, js/). */
+  /** Auto-format every Scala source (shared/, jvm/, js/, native/). */
   def reformat: T[Unit] = Task {
     jvm.reformat()()
     js.reformat()()
+    scalaNative.reformat()()
     ()
   }
 
@@ -250,6 +257,65 @@ object `fast-mcp-scala` extends Module {
       override def bunTestJsEnv = Task {
         super.bunTestJsEnv() + ("NODE_ENV" -> "production")
       }
+    }
+  }
+
+  // Scala Native target (EXPERIMENTAL) — stdio transport over System.in/System.out compiled to
+  // a standalone binary via LLVM. HTTP is excluded BY DESIGN: zio-http is not published for
+  // Scala Native (upstream support is 4.x-milestoned, zio-http#2526), so this module provides
+  // only the `TransportBackend` given; `McpServerApp[Stdio]` programs compile and link while
+  // `McpServerApp[Http]` fails at the user's declaration site — the same seam that keeps netty
+  // out of GraalVM stdio images. Cross-published as `com.tjclp:fast-mcp-scala_native0.5_3`.
+  object scalaNative extends ScalaNativeModule with ScalafmtModule with FastMCPPublishingBase {
+    def scalaVersion = scala3Version
+    def scalaNativeVersion = Versions.scalaNative
+
+    // Mill module name stays `scalaNative` (the bare word "native" is claimed by the GraalVM
+    // nativeSmoke pipeline); the source directory follows the jvm/js sibling convention.
+    override def moduleDir = super.moduleDir / os.up / "native"
+
+    // Native module reads from native/src/, shared/, the compile-time-only macro/schema helpers
+    // in jvm/src/ (same borrow as the js module), and the platform-pure AnnotatedServer example —
+    // this module's demo main for `nativeLink`, driven by scripts/native-smoke.sh in CI.
+    override def sources = Task.Sources(
+      moduleDir / "src",
+      moduleDir / os.up / "shared" / "src",
+      moduleDir / os.up / "jvm" / "src" / "com" / "tjclp" / "fastmcp" / "macros" / "JsonSchemaMacro.scala",
+      moduleDir / os.up / "jvm" / "src" / "com" / "tjclp" / "fastmcp" / "macros" / "MacroUtils.scala",
+      moduleDir / os.up / "jvm" / "src" / "com" / "tjclp" / "fastmcp" / "macros" / "schema",
+      moduleDir / os.up / "jvm" / "src" / "com" / "tjclp" / "fastmcp" / "examples" / "AnnotatedServer.scala"
+    )
+
+    // `::` resolves the _native0.5_3 artifacts. zio-json transitively brings
+    // io.github.cquiroz:scala-java-time (compile scope), which links the java.time.Duration
+    // defaults in the shared McpServerSettings.
+    override def mvnDeps = Seq(
+      mvn"dev.zio::zio::${Versions.zio}",
+      mvn"dev.zio::zio-json::${Versions.zioJson}"
+    )
+
+    // Deterministic main for `nativeLink` (AnnotatedServer is the only main in these sources).
+    override def mainClass = Some("com.tjclp.fastmcp.examples.AnnotatedServer")
+
+    // WartRemover-free copy of the shared flags (same rationale as the js module).
+    override def scalacOptions = Seq(
+      "-encoding", "utf-8",
+      "-feature",
+      "-unchecked",
+      "-deprecation",
+      "-Wunused:all",
+      "-Wvalue-discard",
+      "-Wsafe-init",
+      "-Wnonunit-statement",
+      "-Xcheck-macros",
+      "-experimental",
+      "-Xmax-inlines:128"
+    )
+
+    object test extends ScalaNativeTests with TestModule.ScalaTest {
+      override def mvnDeps = Seq(
+        mvn"org.scalatest::scalatest::${Versions.scalaTest}"
+      )
     }
   }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,7 @@ fast-mcp-scala/
     └── examples/                         # runnable Bun examples
 ```
 
-**JVM module sources** = `shared/src/` + `jvm/src/`. **Scala.js module sources** = `shared/src/` + `js/src/`. Mill's `Task.Sources` wires this in `build.mill`.
+**JVM module sources** = `shared/src/` + `jvm/src/`. **Scala.js module sources** = `shared/src/` + `js/src/`. **Scala Native module sources (experimental)** = `shared/src/` + `native/src/` (+ the borrowed compile-time macro files and the platform-pure `AnnotatedServer` example). Mill's `Task.Sources` wires this in `build.mill`.
 
 ## The annotation path at compile time
 

--- a/fast-mcp-scala/native/src/com/tjclp/fastmcp/ExportsNative.scala
+++ b/fast-mcp-scala/native/src/com/tjclp/fastmcp/ExportsNative.scala
@@ -1,0 +1,11 @@
+package com.tjclp.fastmcp
+
+/** Scala Native additions to the shared export surface ([[com.tjclp.fastmcp.Exports]]).
+  *
+  * The native module contributes exactly one thing the shared surface can't: the platform
+  * [[com.tjclp.fastmcp.server.transport.TransportBackend]] given (`System.in`/`System.out`). There
+  * is deliberately NO `HttpTransportBackend` — zio-http is not published for Scala Native — so
+  * `McpServerApp[Http]` programs fail to compile on this platform while `McpServerApp[Stdio]` works
+  * unchanged. Everything else — `McpServer`, codecs, schema derivation, macros — is shared.
+  */
+export server.transport.NativeTransportBackend.given

--- a/fast-mcp-scala/native/src/com/tjclp/fastmcp/server/transport/NativeTransportBackend.scala
+++ b/fast-mcp-scala/native/src/com/tjclp/fastmcp/server/transport/NativeTransportBackend.scala
@@ -1,0 +1,115 @@
+package com.tjclp.fastmcp
+package server.transport
+
+import java.nio.charset.StandardCharsets
+
+import zio.*
+import zio.stream.*
+
+import com.tjclp.fastmcp.server.McpServerSettings
+import com.tjclp.fastmcp.server.router.{McpRouter, Session}
+
+/** Scala Native [[TransportBackend]] — pure ZIO over `System.in`/`System.out`, compiled to a
+  * standalone binary via LLVM. Stdio only: zio-http is not published for Scala Native, so this
+  * platform provides no [[HttpTransportBackend]] given and `McpServerApp[Http]` programs fail to
+  * compile at the declaration site (by design — the same seam that keeps netty out of GraalVM stdio
+  * images).
+  *
+  * Platform notes vs. the JVM backend:
+  *   - stdin: zio-streams Native has no `ZStream.fromInputStream`; chars are read via
+  *     `ZStream.fromReader` (the `InputStreamReader` owns byte→UTF-8 decoding) and re-chunked into
+  *     Strings for the shared `ZPipeline.splitLines`.
+  *   - `randomId()`: javalib's `UUID.randomUUID()` does not link on Scala Native 0.5 (it references
+  *     `java.security.SecureRandom`, which has no published implementation); 16 bytes of
+  *     `/dev/urandom` are formatted as an RFC-4122 v4 UUID instead. Unix-only.
+  *   - ZIO signal handlers and shutdown hooks are silent no-ops on Scala Native; benign for stdio,
+  *     where the parent closing stdin ends the loop via EOF exactly like the JVM.
+  */
+object NativeTransportBackend extends TransportBackend:
+
+  /** UUID v4 from 16 bytes of `/dev/urandom` (per-call open; ids are minted rarely — session and
+    * task creation). A missing `/dev/urandom` is a broken platform and dies as a defect.
+    */
+  override def randomId(): UIO[String] = ZIO.succeed {
+    val bytes = new Array[Byte](16)
+    val in = new java.io.FileInputStream("/dev/urandom")
+    try
+      var off = 0
+      while off < bytes.length do
+        val n = in.read(bytes, off, bytes.length - off)
+        if n < 0 then throw new java.io.EOFException("unexpected EOF from /dev/urandom")
+        off += n
+    finally in.close()
+    bytes(6) = ((bytes(6) & 0x0f) | 0x40).toByte // version 4
+    bytes(8) = ((bytes(8) & 0x3f) | 0x80).toByte // IETF variant
+    val hex = bytes.map(b => f"${b & 0xff}%02x").mkString
+    s"${hex.substring(0, 8)}-${hex.substring(8, 12)}-${hex.substring(12, 16)}-" +
+      s"${hex.substring(16, 20)}-${hex.substring(20)}"
+  }
+
+  override def serveStdio[R](
+      router: McpRouter[R],
+      settings: McpServerSettings
+  ): ZIO[R, Throwable, Unit] =
+    for
+      session <- Session.make("stdio")
+      // One writer owns stdout; both replies and server-pushed outbound go through it so lines
+      // never interleave.
+      outLock <- Semaphore.make(1)
+      emit = (line: String) => outLock.withPermit(writeLine(line))
+      inLines =
+        ZStream
+          .fromReader(new java.io.InputStreamReader(java.lang.System.in, StandardCharsets.UTF_8))
+          .chunks
+          .map(chunk => new String(chunk.toArray))
+          .via(ZPipeline.splitLines)
+          .map(_.trim)
+          .filter(_.nonEmpty)
+      _ <- stdioLoop(router, session, inLines, emit)
+    yield ()
+
+  /** The stdio dispatch loop, factored out of [[serveStdio]] so it can be driven over in-memory
+    * streams in tests — identical semantics to `JvmTransportBackend.stdioLoop`: the outbound
+    * drainer is forked as a daemon, each inbound frame dispatches in its own fiber (so a handler
+    * blocked on a server→client round trip never stalls the read loop), and stdin EOF ends the
+    * loop, taking the drainer down via `.ensuring`.
+    */
+  private[fastmcp] def stdioLoop[R](
+      router: McpRouter[R],
+      session: Session,
+      inLines: ZStream[Any, Throwable, String],
+      emit: String => Task[Unit]
+  ): ZIO[R, Throwable, Unit] =
+    for
+      drainer <- session.outbound.take
+        .flatMap(msg => emit(MessageLoop.encodeOutbound(msg)))
+        .forever
+        .forkDaemon
+      _ <- inLines
+        .runForeach { line =>
+          MessageLoop
+            .handleFrame(router, session, line)
+            .flatMap {
+              case Some(reply) => emit(reply)
+              case None => ZIO.unit
+            }
+            .forkDaemon
+            .unit
+        }
+        // stdin EOF (or scope interruption) ends the loop; take the drainer down with it.
+        .ensuring(drainer.interrupt)
+    yield ()
+
+  private def writeLine(line: String): Task[Unit] =
+    ZIO.attempt {
+      val out = java.lang.System.out
+      out.print(line)
+      out.print('\n')
+      out.flush()
+    }
+
+  /** The Scala Native platform seam, in the impl object so it's exportable (givens can't be
+    * wildcard-exported straight from a package). `ExportsNative` re-exports this so `import
+    * com.tjclp.fastmcp.*` puts a `TransportBackend` in scope and `McpServer(...)` resolves.
+    */
+  given instance: TransportBackend = this

--- a/fast-mcp-scala/native/test/src/com/tjclp/fastmcp/contracts/SharedContractSurfaceNativeTest.scala
+++ b/fast-mcp-scala/native/test/src/com/tjclp/fastmcp/contracts/SharedContractSurfaceNativeTest.scala
@@ -1,0 +1,79 @@
+package com.tjclp.fastmcp.contracts
+
+import org.scalatest.funsuite.AnyFunSuite
+import zio.*
+import zio.json.*
+
+import com.tjclp.fastmcp.{given, *}
+import com.tjclp.fastmcp.core.StructuredToolResult
+
+class SharedContractSurfaceNativeTest extends AnyFunSuite:
+
+  case class AddArgs(a: Int, b: Int)
+  case class AddResult(message: String)
+  case class UserProfileArgs(userId: String)
+
+  private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
+    Unsafe.unsafe { implicit unsafe =>
+      Runtime.default.unsafe.run(effect).getOrThrowFiberFailure()
+    }
+
+  test("shared typed contracts mount and execute on Scala Native") {
+    val server = McpServer("NativeContractServer")
+
+    val tool = McpTool[AddArgs, AddResult](
+      name = "typed-add",
+      description = Some("Add two numbers")
+    ) { args =>
+      AddResult((args.a + args.b).toString)
+    }
+    runUnsafe(server.tool(tool))
+
+    val result = runUnsafe(
+      server.toolManager.callTool("typed-add", Map("a" -> 19, "b" -> 23), None)
+    )
+    result match
+      case StructuredToolResult(List(TextContent(text, _, _)), _) => assert(text.contains("42"))
+      case other => fail(s"unexpected: $other")
+  }
+
+  test("template resource matches and extracts params at runtime (java.util.regex on SN)") {
+    // RE2 canary: Scala Native's java.util.regex is RE2-backed (no lookaheads); the template
+    // matcher in ResourceManager builds plain anchored groups, which RE2 must accept — this test
+    // makes that assumption executable.
+    val server = McpServer("NativeTemplateServer")
+    val templateResource = McpTemplateResource[UserProfileArgs](
+      uriPattern = "users://{userId}/profile",
+      arguments = List(ResourceArgument("userId", Some("The user id"), required = true))
+    ) { args =>
+      s"profile:${args.userId}"
+    }
+    runUnsafe(server.resource(templateResource))
+    val body = runUnsafe(server.resourceManager.readResource("users://42/profile", None))
+    assert(body == "profile:42")
+  }
+
+  test("custom input codecs participate in decode and schema on Scala Native") {
+    case class WrappedId(value: String)
+    object WrappedId:
+      given McpInputCodec[WrappedId] = McpInputCodec.string(
+        """{"type":"string","pattern":"^id_[a-z0-9]+$"}"""
+      ) { raw =>
+        Either.cond(raw.startsWith("id_"), WrappedId(raw), s"Invalid id '$raw'")
+      }
+    case class LookupArgs(id: WrappedId)
+
+    val schema = ToolInputSchema.derived[LookupArgs]
+    assert(schema.toJsonString.contains("^id_[a-z0-9]+$"))
+
+    val server = McpServer("NativeCodecServer")
+    runUnsafe(
+      server.tool(
+        McpTool[LookupArgs, String](name = "find")(_.id.value)
+      )
+    )
+    val r = runUnsafe(server.toolManager.callTool("find", Map("id" -> "id_abc"), None))
+    r match
+      case StructuredToolResult(List(TextContent(text, _, _)), _) => assert(text == "id_abc")
+      case other => fail(s"unexpected: $other")
+  }

--- a/fast-mcp-scala/native/test/src/com/tjclp/fastmcp/server/transport/NativeTransportBackendTest.scala
+++ b/fast-mcp-scala/native/test/src/com/tjclp/fastmcp/server/transport/NativeTransportBackendTest.scala
@@ -1,0 +1,85 @@
+package com.tjclp.fastmcp
+package server.transport
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import zio.*
+import zio.stream.*
+
+import com.tjclp.fastmcp.server.*
+import com.tjclp.fastmcp.server.router.Session
+import com.tjclp.fastmcp.server.transport.NativeTransportBackend.given
+
+/** Platform contracts for the Scala Native stdio backend: the /dev/urandom-backed `randomId`
+  * (javalib `UUID.randomUUID` does not link on SN 0.5) and the stdio-loop termination contracts
+  * ported from the JVM `StdioLoopLifecycleTest` — EOF and interruption must both end the loop AND
+  * its outbound-drainer fiber.
+  */
+class NativeTransportBackendTest extends AnyFunSuite with Matchers:
+
+  private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
+    Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(effect).getOrThrowFiberFailure())
+
+  private val UuidV4 =
+    "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$".r
+
+  test("randomId yields distinct RFC-4122 v4 UUIDs from /dev/urandom") {
+    val ids = runUnsafe(ZIO.foreach(1 to 100)(_ => NativeTransportBackend.randomId()))
+    ids.foreach { id =>
+      assert(UuidV4.matches(id), s"not a v4 UUID: $id")
+    }
+    ids.distinct.size shouldBe ids.size
+  }
+
+  private val initFrame =
+    """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"1.0"}}}"""
+
+  test("stdin EOF ends the loop and takes the outbound drainer down with it") {
+    val program =
+      for
+        server <- ZIO.succeed(McpServer("EofServer"))
+        router <- server.buildRouter
+        session <- Session.make("stdio-eof")
+        outQ <- Queue.unbounded[String]
+        // A finite inbound stream IS the EOF: the loop must dispatch the frame and return.
+        _ <- NativeTransportBackend.stdioLoop(
+          router,
+          session,
+          ZStream(initFrame),
+          s => outQ.offer(s).unit
+        )
+        _ <- outQ.take // the initialize reply was emitted before EOF completed the loop
+        // The drainer is interrupted at EOF: an outbound push after loop end must NOT be emitted.
+        _ <- session.send(com.tjclp.fastmcp.jsonrpc.JsonRpcMessage.Notification("post/eof", None))
+        _ <- ZIO.sleep(200.millis)
+        leaked <- outQ.poll
+      yield leaked
+
+    val leaked = runUnsafe(
+      program.timeoutFail(new RuntimeException("stdio loop did not terminate on EOF"))(10.seconds)
+    )
+    leaked shouldBe None
+  }
+
+  test("interrupting the loop fiber terminates it promptly (graceful shutdown)") {
+    val program =
+      for
+        server <- ZIO.succeed(McpServer("ShutdownServer"))
+        router <- server.buildRouter
+        session <- Session.make("stdio-shutdown")
+        inQ <- Queue.unbounded[String] // never closed — the loop would run forever
+        loop <- NativeTransportBackend
+          .stdioLoop(router, session, ZStream.fromQueue(inQ), _ => ZIO.unit)
+          .fork
+        _ <- inQ.offer(initFrame)
+        _ <- ZIO.sleep(100.millis)
+        exit <- loop.interrupt
+      yield exit
+
+    val exit = runUnsafe(
+      program.timeoutFail(new RuntimeException("stdio loop did not stop on interruption"))(
+        10.seconds
+      )
+    )
+    exit.isInterrupted shouldBe true
+  }

--- a/fast-mcp-scala/native/test/src/com/tjclp/fastmcp/surface/RootImportSurfaceNativeTest.scala
+++ b/fast-mcp-scala/native/test/src/com/tjclp/fastmcp/surface/RootImportSurfaceNativeTest.scala
@@ -1,0 +1,84 @@
+package com.tjclp.fastmcp.surface
+
+import org.scalatest.funsuite.AnyFunSuite
+import zio.*
+import zio.json.*
+
+import com.tjclp.fastmcp.{given, *}
+import com.tjclp.fastmcp.core.StructuredToolResult
+
+class RootImportSurfaceNativeTest extends AnyFunSuite:
+
+  object ExampleTools:
+    @Tool(name = Some("hello"))
+    def hello(@Param("Person to greet") name: String): String =
+      s"Hello, $name!"
+
+    @Prompt(name = Some("hello_prompt"))
+    def helloPrompt(@Param("Person to greet") name: String): String =
+      s"Prompt for $name"
+
+    @Resource(uri = "static://hello", description = Some("Greeting resource"))
+    def helloResource(): String =
+      "hello"
+
+  case class HelloArgs(
+      @Param(description = "Person to greet")
+      name: String
+  )
+  case class HelloResult(message: String)
+  enum Mood:
+    case happy, sad
+  case class MoodArgs(mood: Mood)
+
+  given JsonEncoder[HelloResult] = DeriveJsonEncoder.gen[HelloResult]
+
+  private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
+    Unsafe.unsafe { implicit unsafe =>
+      Runtime.default.unsafe.run(effect).getOrThrowFiberFailure()
+    }
+
+  test("root import exposes the public Scala Native annotation and derived-schema surface") {
+    val server = McpServer("RootImportNativeServer")
+    val _ = server.scanAnnotations[ExampleTools.type]
+
+    val toolDef = server.toolManager.getToolDefinition("hello")
+    assert(toolDef.isDefined)
+    assert(toolDef.get.inputSchema.toJsonString.contains("name"))
+
+    val schema = ToolInputSchema.derived[HelloArgs]
+    assert(schema.toJsonString.contains("name"))
+    assert(schema.toJsonString.contains("Person to greet"))
+
+    val typedTool = McpTool[HelloArgs, HelloResult](
+      name = "typed-hello",
+      description = Some("Typed greeting")
+    ) { args =>
+      HelloResult(s"Hello, ${args.name}!")
+    }
+    assert(typedTool.definition.inputSchema.toJsonString.contains("name"))
+
+    val toolResult = runUnsafe(server.toolManager.callTool("hello", Map("name" -> "Ada"), None))
+    assert(toolResult == "Hello, Ada!")
+
+    val promptResult =
+      runUnsafe(server.promptManager.getPrompt("hello_prompt", Map("name" -> "Ada"), None))
+    assert(promptResult.headOption.exists(_.content.asInstanceOf[TextContent].text.contains("Ada")))
+
+    val resourceResult = runUnsafe(server.resourceManager.readResource("static://hello", None))
+    assert(resourceResult == "hello")
+  }
+
+  test("typed contracts derive singleton enum schemas and decoders on Scala Native (#78)") {
+    val server = McpServer("RootImportNativeEnumServer")
+    val tool = McpTool[MoodArgs, String](name = "describe-mood") { args =>
+      s"mood:${args.mood}"
+    }
+
+    assert(tool.definition.inputSchema.toJsonString.contains("\"enum\":[\"happy\",\"sad\"]"))
+    runUnsafe(server.tool(tool))
+    val result = runUnsafe(
+      server.toolManager.callTool("describe-mood", Map("mood" -> "happy"), None)
+    )
+    assert(result == StructuredToolResult(List(TextContent("mood:happy")), None))
+  }

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/TransportBackend.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/TransportBackend.scala
@@ -25,8 +25,9 @@ trait TransportBackend:
 
   /** Cryptographically-secure random identifier (UUID v4 string). Session and task ids are bearer
     * handles, so they must be unguessable. Lives on the backend because shared code has no CSPRNG:
-    * the JVM uses `java.util.UUID` (SecureRandom), JS uses Web Crypto — Scala.js's
-    * `UUID.randomUUID` stub needs a `SecureRandom` the runtime doesn't provide.
+    * the JVM uses `java.util.UUID` (SecureRandom), JS uses Web Crypto, and Scala Native reads
+    * `/dev/urandom` directly — on both non-JVM platforms `UUID.randomUUID` needs a `SecureRandom`
+    * the runtime doesn't provide.
     */
   def randomId(): UIO[String]
 

--- a/scripts/native-smoke.sh
+++ b/scripts/native-smoke.sh
@@ -80,8 +80,8 @@ await_id 1
 printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized"}' >&3
 
 # One exercise of every registration kind on AnnotatedServer. tools/list is the load-bearing
-# check: its inputSchema payloads are produced by the genuine RUNTIME tapir→circe
-# schema-rendering path, exactly where closed-world analysis would break if reachability
+# check: its inputSchema payloads are produced by the native zio-json
+# schema-materialization path, exactly where closed-world analysis would break if reachability
 # metadata were missing.
 printf '%s\n' \
   '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \


### PR DESCRIPTION
## Summary

Third platform target, enabled by the pure-Scala core (#80) and the transport-seam split (#67): **Scala Native 0.5.12** stdio MCP servers compiled to standalone binaries, published as `com.tjclp:fast-mcp-scala_native0.5_3` (**EXPERIMENTAL**).

The headline numbers: the entire shared core + macros compiled to NIR **on the first attempt**; the `AnnotatedServer` demo links to a **21MB binary in ~8 seconds** (vs ~35MB / ~25s for the GraalVM image) and passes `scripts/native-smoke.sh` **unchanged** — the same script that gates the GraalVM images. The full native test suite (8 tests) compiles, links, and runs in 16s.

### Architecture

- **No HTTP, by design**: zio-http has no Native artifacts (upstream support is 4.x-milestoned, zio-http/zio-http#2526). The platform provides only `given TransportBackend`, so `McpServerApp[Stdio]` works unchanged while `McpServerApp[Http]` **fails to compile** at the declaration site — the #67 seam doing its job on a third platform. Socket-based HTTP backend follow-up: #81 (also the netty-free JVM fallback candidate).
- **`NativeTransportBackend`** mirrors the JVM stdio backend with exactly two platform substitutions:
  - stdin via `ZStream.fromReader` (zio-streams Native has no `fromInputStream`), re-chunked for the shared `splitLines`;
  - `randomId()` formats RFC-4122 v4 from 16 bytes of `/dev/urandom` — javalib's `UUID.randomUUID` references `java.security.SecureRandom`, which has **no published NIR anywhere** (the SN-internal dummy is unpublished and explicitly insecure). Unix-only, documented.
- Mill module `scalaNative` (dir `fast-mcp-scala/native/`; the bare word "native" is claimed three ways by the GraalVM pipeline). Mill 1.1.5 bundles scalanativelib — zero plugin changes. Publishing via the existing `FastMCPPublishingBase`; release.yml auto-includes it.
- Demo main = file-borrowed platform-pure `AnnotatedServer` (same borrow pattern as the js module's macro files; example mains in published artifacts have jvm+js precedent).

### Tests

- `RootImportSurfaceNativeTest` — given resolution, `@Tool` scan, derived schemas, zero-given enum contracts, runtime round trips on SN's real-thread ZScheduler.
- `SharedContractSurfaceNativeTest` — typed contracts, **the RE2 regex canary** (SN's `java.util.regex` is RE2; template matching exercised end-to-end), `McpInputCodec` participation.
- `NativeTransportBackendTest` — randomId contract (100 draws, v4 bits, distinct) + both stdio lifecycle contracts ported from the JVM suite.

### CI

New PR-blocking "Scala Native (linux-x64)" job in ci.yml (outside the JDK matrix): native tests → link demo binary → stdio smoke. Dedicated cache keys. Watch this PR for the cold/warm duration numbers.

### Caveats (documented in README)

Stdio-only; `/dev/urandom` ids (Unix-only); ZIO signal handlers/shutdown hooks are no-ops on SN (shutdown is EOF-driven — fine for stdio); RE2 regex. Follow-up noted in-code: hoist `stdioLoop` to shared (three near-identical copies now exist).

## Test plan

- [x] `fast-mcp-scala.scalaNative.test` 8/8 (compile + link + run, 16s)
- [x] `scripts/native-smoke.sh <nativeLink binary>` — full handshake, runtime-derived schemas, EOF exit-0, unchanged script
- [x] Full three-platform aggregate: compile 168 targets, test 502 targets (jvm suite + js bunTest 42/42 + native 8/8), checkFormat — all green
- [x] `resolvedMvnDeps`: single SN 0.5.12 line, `scala3lib 3.8.3+0.5.12` (scalatest's transitive 0.5.1 reconciled up)
- [x] `resolve __.publishArtifacts`: exactly jvm/js/scalaNative; `artifactId = fast-mcp-scala_native0.5_3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)