### PR TITLE
feat: streamable HTTP on Scala Native (java.net.ServerSocket backend) + netty-free JVM opt-in (TJC-2223)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,7 +1,9 @@
 name: Conformance
 
 # Runs the official MCP conformance "active" server suite (via `bunx @modelcontextprotocol/conformance`)
-# against the fast-mcp-scala ConformanceServer over streamable HTTP, on both platforms.
+# against the fast-mcp-scala ConformanceServer over streamable HTTP, on all three platforms: the JVM
+# (ZIO HTTP), Scala.js on Bun (Bun.serve), and Scala Native (the java.net.ServerSocket backend, as
+# a linked LLVM binary).
 on:
   pull_request:
   push:
@@ -13,8 +15,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [jvm, js]
-    runs-on: ubuntu-latest
+        platform: [jvm, js, scala-native]
+        include:
+          # Share the ci.yml Scala Native toolchain cache (nativelib/javalib/clib NIR jars) instead
+          # of churning the JDK-matrix cache.
+          - platform: scala-native
+            cache-prefix: scala-native
+    runs-on: ubuntu-latest # scala-native: clang preinstalled; SN 0.5 recommends LLVM >= 17
 
     steps:
       - uses: actions/checkout@v4
@@ -23,8 +30,10 @@ jobs:
         uses: ./.github/actions/setup-build
         with:
           bun: "true"
+          cache-prefix: ${{ matrix.cache-prefix || '' }}
 
       # Boots the server, drives it with the pinned conformance harness, and checks the result against
-      # conformance/baseline-${platform}.yml (both baselines are empty — full active-suite green).
+      # conformance/baseline-${platform}.yml (scala-native reuses baseline-jvm.yml; every baseline is
+      # empty — full active-suite green).
       - name: Run MCP conformance active suite (${{ matrix.platform }})
         run: ./scripts/conformance.sh ${{ matrix.platform }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Scala Native target (experimental)** (TJC-2188, #82):
   `com.tjclp:fast-mcp-scala_native0.5_3` — stdio MCP servers compiled to
   standalone binaries via Scala Native 0.5.12 (21MB debug links in
-  seconds). HTTP is excluded by design (zio-http has no Native
-  artifacts): the platform provides only the `TransportBackend` given,
-  so `McpServerApp[Http]` fails at compile time while
-  `McpServerApp[Stdio]` works unchanged. Session/task ids come from
+  seconds). Streamable HTTP followed in the same cycle over the socket
+  backend below (zio-http has no Native artifacts). Session/task ids come from
   `/dev/urandom` (javalib `UUID.randomUUID` doesn't link on SN); stdin
   reads via `ZStream.fromReader`. CI links the `AnnotatedServer` demo
   binary and drives it with the same stdio smoke script that gates the
   GraalVM images.
+
+- **Streamable HTTP on Scala Native + netty-free JVM opt-in** (TJC-2223,
+  #81): a hand-rolled HTTP/1.1 + SSE server over `java.net.ServerSocket`
+  (`fast-mcp-scala/jvm-native/`, compiled by both the JVM and Scala Native
+  modules) now backs `McpServerApp[Http]` / `runHttp()` on Scala Native
+  (`NativeHttpBackend`, exported by default) and ships on the JVM as the
+  explicit opt-in `JvmSocketHttpBackend` — the `JdkHttpBackend` scoped in
+  TJC-2114. Opt in with `given JvmSocketHttpBackend.type =
+  JvmSocketHttpBackend` and exclude `zio-http` to drop Netty. Keep-alive,
+  `Content-Length` and chunked request bodies, `Expect: 100-continue`,
+  HTTP/1.0 clients, chunked SSE with a reader-side disconnect watch; caps:
+  8 KiB head (431), 16 MiB body (413), 256 concurrent connections, 60 s
+  idle; plaintext only (no `javax.net.ssl` on Native). Held to the same
+  EMPTY conformance baseline as the JVM via the new
+  `scripts/conformance.sh scala-native` lane (73/0 locally, 2026-07-28
+  scenario set identical to the JVM's). `FASTMCP_HTTP_DEBUG=1` prints
+  per-connection failures to stderr.
 
 - **Mirror-based `McpEncoder` fallback**: `Out` case classes without any
   `JsonEncoder` in scope now encode (text + `structuredContent`)
@@ -31,6 +46,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   custom wire type.
 
 ### Changed
+
+- **`JvmHttpBackend` is now a zio-http adapter** over the shared
+  `StreamableHttpHandler` (`shared/.../server/transport/http/`), which owns
+  every streamable-HTTP MCP decision exactly once — session store and idle
+  sweeper, only-`initialize`-mints, request→SSE with the per-request sink
+  and close sentinel, the 2026-07-28 stateless path, GET push channel
+  (409 on a second stream), DELETE, keepalive, JSON-RPC transport errors
+  (TJC-2223, #81). Wire behaviour is unchanged: every HTTP test and the
+  conformance suite pass unmodified. The Scala.js backend still carries
+  its own rendering (follow-up). Keepalive pings are now emitted when a
+  stream has been quiet for `keepAliveInterval` (a queue-fed timed pull)
+  rather than merged in on a fixed schedule — the merge's halt path
+  overflowed a Scala Native thread stack.
 
 - **Build and source layout modularized** (TJC-2198): Mill 1.1.5 → 1.1.8;
   module definitions moved out of the monolithic `build.mill` into

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ fast-mcp-scala is a high-level Scala 3 library for building Model Context Protoc
 
 Both paths converge on the same `McpServer` trait and support `@Param` metadata on parameters/fields.
 
-Three platforms: **JVM** (stdio + HTTP), **Scala.js/Bun** (stdio + HTTP), and **Scala Native** (stdio only, EXPERIMENTAL — published as `fast-mcp-scala_native0.5_3`; zio-http has no Native artifacts, so `McpServerApp[Http]` fails to compile there by design).
+Three platforms: **JVM** (stdio + HTTP), **Scala.js/Bun** (stdio + HTTP), and **Scala Native** (stdio + HTTP, EXPERIMENTAL — published as `fast-mcp-scala_native0.5_3`). zio-http has no Native artifacts, so HTTP on Scala Native runs on a hand-rolled `java.net.ServerSocket` backend (`jvm-native/`) that renders the same shared streamable-HTTP handler as the JVM; the JVM can opt into that netty-free backend too (`JvmSocketHttpBackend`).
 
 ## Build System
 
@@ -31,6 +31,7 @@ Three platforms: **JVM** (stdio + HTTP), **Scala.js/Bun** (stdio + HTTP), and **
 ./mill fast-mcp-scala.js.test.bunTest               # Scala.js conformance tests only
 ./mill fast-mcp-scala.scalaNative.test              # Scala Native tests (links a native binary)
 ./mill fast-mcp-scala.scalaNative.nativeLink        # Standalone LLVM binary of AnnotatedServer
+./mill fast-mcp-scala.scalaNative.conformanceLink   # LLVM binary of ConformanceServerNative (HTTP)
 ./mill fast-mcp-scala.jvm.test com.tjclp.fastmcp.macros.ToolProcessorTest
 
 # Publish
@@ -71,18 +72,26 @@ fast-mcp-scala/
 │   │           ├── manager/             # Tool/Prompt/Resource/Task managers
 │   │           ├── router/              # McpRouter, Builtins, Session, middleware
 │   │           └── transport/           # TransportBackend seam, StdioLoop, MessageLoop, HostGuard
+│   │           └── transport/http/      # StreamableHttpHandler: the streamable-HTTP semantics,
+│   │                                    #   rendered by every HTTP backend (neutral HttpRequest/HttpReply)
+│   ├── jvm-native/            # Compiled by BOTH jvm and scalaNative (no Scala.js)
+│   │   ├── src/               # SocketHttpServer (HTTP/1.1 + SSE over java.net.ServerSocket),
+│   │   │                      #   Http1 parser, SocketHttpBackend
+│   │   └── test/src/          # SocketHttpBackendTest + Http1ParserTest — run on both platforms
 │   ├── jvm/
 │   │   ├── src/               # JVM-specific code
 │   │   │   └── com/tjclp/fastmcp/
-│   │   │       ├── server/transport/        # JvmTransportBackend (stdio) + JvmHttpBackend (netty)
+│   │   │       ├── server/transport/        # JvmTransportBackend (stdio), JvmHttpBackend (netty,
+│   │   │       │                            #   default), JvmSocketHttpBackend (netty-free opt-in)
 │   │   │       └── examples/                # JVM-only: HttpServer, TaskManagerServer
 │   │   └── test/src/          # JVM test sources
 │   ├── js/                    # Scala.js code (Bun-first runtime)
 │   │   ├── src/               # JsTransportBackend (Bun.serve + Node stdio), facades, examples
 │   │   └── test/src/          # Conformance, HTTP, codec, contract surface tests
-│   └── native/                # Scala Native code (EXPERIMENTAL, stdio only)
-│       ├── src/               # NativeTransportBackend (System.in/out + /dev/urandom)
-│       └── test/src/          # Surface, contract, and stdio-lifecycle canaries
+│   └── native/                # Scala Native code (EXPERIMENTAL)
+│       ├── src/               # NativeTransportBackend (System.in/out + /dev/urandom),
+│       │                      #   NativeHttpBackend (socket HTTP), ConformanceServerNative
+│       └── test/src/          # Surface, contract, stdio-lifecycle and HTTP-surface canaries
 ```
 
 ## Key Concepts
@@ -179,7 +188,7 @@ server.tool(addTool)
 ### Transports
 
 - **Stdio** (`runStdio()`) — stdin/stdout, used by MCP clients
-- **HTTP** (`runHttp()`) — streamable (sessions + per-request SSE, GET push channel on JVM, DELETE termination) by default; set `stateless = true` for stateless. Binds `127.0.0.1` by default (set `host = "0.0.0.0"` for containers); only `initialize` mints a session; idle sessions evict after `sessionIdleTimeout`; `allowedHosts` enables the DNS-rebinding guard; `keepAliveInterval` enables SSE heartbeats
+- **HTTP** (`runHttp()`) — streamable (sessions + per-request SSE, GET push channel on JVM and Scala Native, DELETE termination) by default; set `stateless = true` for stateless. Binds `127.0.0.1` by default (set `host = "0.0.0.0"` for containers); only `initialize` mints a session; idle sessions evict after `sessionIdleTimeout`; `allowedHosts` enables the DNS-rebinding guard; `keepAliveInterval` enables SSE heartbeats (a `ping` event whenever a stream is quiet for the interval). The JVM serves it with ZIO HTTP (`JvmHttpBackend`); Scala Native — and the JVM when you opt in with `given JvmSocketHttpBackend.type = JvmSocketHttpBackend` — with the hand-rolled `SocketHttpServer` (`jvm-native/`). Both render the shared `StreamableHttpHandler`, so semantics are identical; the socket layer adds fixed caps (8 KiB head → 431, 16 MiB body → 413, 256 connections, 60 s idle) and is plaintext only
 
 ### Tasks (experimental, off by default)
 
@@ -229,11 +238,12 @@ The `tasks` capability is advertised on `initialize` only when `settings.tasks.e
 
 The codebase is split into three sibling trees under `fast-mcp-scala/`:
 - `shared/` — the entire native MCP core: annotations, wire types, JSON-RPC, ZIO JSON codecs, the router + built-in handlers + middleware, `McpServer[R]` + `McpServerCore`, typed contracts, and the `TransportBackend` seam
-- `jvm/` — the JVM `TransportBackend` (`System.in`/`System.out`), the `HttpTransportBackend` (ZIO HTTP), and JVM-only examples
+- `jvm-native/` — the HTTP/1.1 + SSE socket server (`SocketHttpServer`, `Http1`) and `SocketHttpBackend`, compiled by both the `jvm` and `scalaNative` modules (so it must satisfy the JVM WartRemover tiers); its tests in `jvm-native/test/src` run on both platforms through the `CrossPlatformTests` trait in `build.mill`
+- `jvm/` — the JVM `TransportBackend` (`System.in`/`System.out`), the default `HttpTransportBackend` (ZIO HTTP, `JvmHttpBackend`), the netty-free opt-in `JvmSocketHttpBackend`, and JVM-only examples
 - `js/` — the Scala.js `TransportBackend` (`Bun.serve` + Node stdio), small JS facades, and the Bun HTTP example
-- `native/` — the Scala Native `TransportBackend` (stdio only, EXPERIMENTAL)
+- `native/` — the Scala Native `TransportBackend` (stdio) and `NativeHttpBackend` (HTTP over the socket server), EXPERIMENTAL
 
-Every module reads exactly `shared/src/ + <platform>/src/`. Nothing reaches across platform trees: the schema-derivation macros and every platform-pure example live in `shared/`, so `shared/` compiles standalone on all three targets.
+Every module reads `shared/src/ + <platform>/src/`; `jvm` and `scalaNative` additionally read `jvm-native/src/`. Nothing else reaches across platform trees: the schema-derivation macros and every platform-pure example live in `shared/`, so `shared/` compiles standalone on all three targets.
 
 ### Native MCP core (no vendored SDK)
 
@@ -242,9 +252,9 @@ As of 0.5.0 there is **no wrapped SDK** — the MCP protocol layer is pure Scala
 - `core/wire/` + `core/Types.scala` — the 2025-11-25 wire types with ZIO JSON codecs
 - `server/router/` — `McpRouter`, `Builtins`, `Middleware`, `RouterBuilder`, `WireMapping`, Tasks
 - `codec/` — `DefaultDecodeContext` + `McpDecoders` (one ZIO JSON decode path for both platforms)
-- `server/transport/` — `TransportBackend` (the platform seam) + `MessageLoop` (parse → dispatch → encode)
+- `server/transport/` — `TransportBackend` + `HttpTransportBackend` (the platform seam), `MessageLoop` (parse → dispatch → encode), `StdioLoop`, and `http/StreamableHttpHandler` (every streamable-HTTP decision, over a neutral `HttpRequest`/`HttpReply`/`SseFrame` model that each HTTP backend renders)
 
-Each platform provides exactly one `given TransportBackend` (`JvmTransportBackend` / `JsTransportBackend`); everything else is shared. The TypeScript `@modelcontextprotocol/sdk` is used only as a test-time conformance client.
+Each platform provides exactly one `given TransportBackend` (`JvmTransportBackend` / `JsTransportBackend` / `NativeTransportBackend`) and one `given HttpTransportBackend` (`JvmHttpBackend` / `JsTransportBackend` / `NativeHttpBackend`); everything else is shared. The TypeScript `@modelcontextprotocol/sdk` is used only as a test-time conformance client.
 
 ## Code Quality
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fast-mcp-scala
 
-**Scala 3 for MCP: annotation-driven and typed-contract APIs on both JVM and Scala.js/Bun.**
+**Scala 3 for MCP: annotation-driven and typed-contract APIs on the JVM, Scala.js/Bun, and Scala Native.**
 
 fast-mcp-scala is a developer-friendly library for building [Model Context Protocol](https://modelcontextprotocol.io/) servers. Extend one trait, declare your tools, done:
 
@@ -226,6 +226,20 @@ object MyHttpServer extends McpServerApp[Http, MyHttpServer.type]:
 
 Need lower-level control? Skip the sugar trait and construct directly — `val server = McpServer("name", "0.1.0")` returns the platform-appropriate server, and you can call `.tool(...)` / `.runHttp()` yourself inside your own `ZIOAppDefault`.
 
+**Netty-free on the JVM.** The JVM default is ZIO HTTP (Netty). The same `java.net.ServerSocket` server that serves Scala Native is available as an explicit opt-in — declare a given of the object's singleton type, which wins over the imported default on specificity, and exclude `dev.zio::zio-http` from your dependencies to drop Netty (20 of the 40 jars) from the classpath:
+
+```scala 3 raw
+import com.tjclp.fastmcp.{*, given}
+import com.tjclp.fastmcp.server.transport.JvmSocketHttpBackend
+
+given JvmSocketHttpBackend.type = JvmSocketHttpBackend
+
+object MyServer extends McpServerApp[Http, MyServer.type]:
+  @Tool() def add(a: Int, b: Int): Int = a + b
+```
+
+Wire behaviour is identical (both backends render the shared handler and pass the same conformance suite); the socket backend trades Netty's event loop for one blocking thread per idle connection (capped at 256), plaintext HTTP/1.1 only.
+
 | Setting | Default | Description |
 |---|---|---|
 | `host` | `127.0.0.1` | Bind address (**changed in 0.5.0** from `0.0.0.0` per the spec's bind-localhost guidance; set `"0.0.0.0"` explicitly for containers / external exposure) |
@@ -356,9 +370,11 @@ fast-mcp-scala is a single native MCP implementation. The entire protocol layer 
     ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
     │  stdio (NDJSON) │    │  HTTP stateless │    │ HTTP streamable │
     │  ZIO Stream /   │    │  ZIO HTTP /     │    │ ZIO HTTP /      │
-    │  Node stdin     │    │  Bun.serve      │    │ Bun.serve + SSE │
+    │  Node stdin     │    │  Bun / sockets  │    │ Bun, sockets+SSE│
     └─────────────────┘    └─────────────────┘    └─────────────────┘
 ```
+
+Every HTTP backend — ZIO HTTP on the JVM, `Bun.serve` on Scala.js, and the hand-rolled `java.net.ServerSocket` server on Scala Native (also the JVM's netty-free opt-in, `JvmSocketHttpBackend`) — is a thin adapter over the shared `StreamableHttpHandler`, so the streamable-HTTP semantics exist exactly once.
 
 Capabilities are **derived from the registered handler map** — a capability is advertised only when its handler is actually wired, so the server can never over-advertise (the root cause of #56 is gone by construction). `McpServerApp[T, Self]` is the declarative entry point on both targets; typed contracts (`McpTool`, `McpPrompt`, `McpStaticResource`, `McpTemplateResource`) compile and mount unchanged on both.
 
@@ -378,16 +394,16 @@ Capabilities are **derived from the registered handler map** — a capability is
 | `ToolSchemaProvider[A]` auto-derivation from `@Param` | ✅ native macro | ✅ native macro | ✅ native macro |
 | `ToHandlerEffect[F]` — plain values / ZIO / Either / Try | ✅ | ✅ | ✅ |
 | Stdio transport | ✅ (native) | ✅ (native) | ✅ (LLVM binary) |
-| Streamable HTTP — stateful (sessions + per-request SSE) | ✅ (ZIO HTTP) | ✅ (Bun.serve) | ✗ by design¹ |
-| Streamable HTTP — stateless | ✅ | ✅ | ✗ by design¹ |
-| Standalone GET SSE push channel | ✅ | 405 (per-request SSE covers server→client) | ✗ by design¹ |
+| Streamable HTTP — stateful (sessions + per-request SSE) | ✅ (ZIO HTTP) | ✅ (Bun.serve) | ✅ (`java.net.ServerSocket`)¹ |
+| Streamable HTTP — stateless | ✅ | ✅ | ✅¹ |
+| Standalone GET SSE push channel | ✅ | 405 (per-request SSE covers server→client) | ✅¹ |
 | Custom decoders | ✅ `given JsonDecoder[T] → McpDecoder[T]` | ✅ same (shared zio-json path) | ✅ same |
 
-¹ zio-http is not published for Scala Native (upstream support is 4.x-milestoned). The platform provides no `HttpTransportBackend` given, so `McpServerApp[Http]` programs fail to compile — a compile-time property, not a runtime failure. A socket-based HTTP backend is planned as a follow-up ([#81](https://github.com/TJC-LP/fast-mcp-scala/issues/81)).
+¹ zio-http is not published for Scala Native (upstream support is 4.x-milestoned), so HTTP on Scala Native is served by a hand-rolled HTTP/1.1 + SSE server over `java.net.ServerSocket` ([#81](https://github.com/TJC-LP/fast-mcp-scala/issues/81)) that renders the same shared streamable-HTTP handler as the JVM — the official conformance suite holds it to the JVM's empty baseline. It is plaintext only (no `javax.net.ssl` on Native — terminate TLS at a proxy), blocking-socket based (one thread per idle connection or stream), and capped at 8 KiB request heads (431), 16 MiB bodies (413), 256 concurrent connections and a 60 s idle timeout. The same backend is available on the JVM as the netty-free opt-in `JvmSocketHttpBackend` (see [HTTP](#http-for-remote-clients-load-balancers-test-harnesses)).
 
 Node / Deno parity for the HTTP listener is a follow-up; only the `Bun.serve(...)` entry point is Bun-specific today.
 
-Proof: the official **MCP conformance suite** runs against both platforms in CI ([`scripts/conformance.sh`](scripts/conformance.sh) + [`.github/workflows/conformance.yml`](.github/workflows/conformance.yml)) at **42/42** with zero expected failures; [`ConformanceTest.scala`](fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/ConformanceTest.scala) additionally drives the official TS SDK client against the JVM server over stdio, and [`JsServerHttpTest.scala`](fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerHttpTest.scala) verifies the Bun HTTP routing.
+Proof: the official **MCP conformance suite** runs against all three platforms in CI — the JVM, Bun, and the Scala Native binary ([`scripts/conformance.sh`](scripts/conformance.sh) + [`.github/workflows/conformance.yml`](.github/workflows/conformance.yml)) — with zero expected failures on every platform; [`ConformanceTest.scala`](fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/ConformanceTest.scala) additionally drives the official TS SDK client against the JVM server over stdio, and [`JsServerHttpTest.scala`](fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerHttpTest.scala) verifies the Bun HTTP routing.
 
 ### Running on Bun
 
@@ -423,9 +439,11 @@ object HelloNative extends McpServerApp[Stdio, HelloNative.type]:
   def add(@Param("First operand") a: Int, @Param("Second operand") b: Int): Int = a + b
 ```
 
-Or in this repo: `./mill fast-mcp-scala.scalaNative.nativeLink` builds the `AnnotatedServer` demo binary, and `scripts/native-smoke.sh <binary>` drives it through the full MCP handshake — the same script that gates the GraalVM images.
+Swap `Stdio` for `Http` (and set `settings = McpServerSettings(port = 8090)`) and the same program serves **streamable HTTP** from the native binary: sessions, per-request SSE, the standalone GET push channel, DELETE, keepalive — everything the JVM does, because both render the shared handler (see the matrix footnote for the socket layer's limits).
 
-Caveats (experimental): stdio only (see the matrix footnote); session/task ids come from `/dev/urandom` (Unix-only); ZIO's signal handlers and shutdown hooks are no-ops on Scala Native — shutdown is EOF-driven (the client closing stdin ends the loop), and SIGINT falls back to the OS default; `java.util.regex` is RE2-backed (no lookaheads) — relevant only if your resource URI templates embed exotic regex.
+Or in this repo: `./mill fast-mcp-scala.scalaNative.nativeLink` builds the `AnnotatedServer` demo binary, and `scripts/native-smoke.sh <binary>` drives it through the full MCP handshake — the same script that gates the GraalVM images. `./mill fast-mcp-scala.scalaNative.conformanceLink` builds the HTTP conformance binary that `scripts/conformance.sh scala-native` holds to the JVM's baseline.
+
+Caveats (experimental): HTTP is plaintext HTTP/1.1 over blocking sockets — one thread per idle connection, capped at 256 (see the matrix footnote), `FASTMCP_HTTP_DEBUG=1` prints per-connection failures to stderr; session/task ids come from `/dev/urandom` (Unix-only); ZIO's signal handlers and shutdown hooks are no-ops on Scala Native — stdio shutdown is EOF-driven (the client closing stdin ends the loop), and for HTTP as for SIGINT the OS default action ends the process (no drain); `java.util.regex` is RE2-backed (no lookaheads) — relevant only if your resource URI templates embed exotic regex; ZIO trampolines its run loop only at depth 300, and Native frames are large — if you build deeply nested stream pipelines and hit a `StackOverflowError` on a `ZScheduler-Worker`, `SCALANATIVE_THREAD_STACK_SIZE=4m` raises the thread stack.
 
 ## Spec coverage
 

--- a/build.mill
+++ b/build.mill
@@ -128,3 +128,17 @@ trait FastMCPModule extends FastMCPModuleBase with FastMCPPublishingBase
 trait FastMCPTestModule extends TestModule.ScalaTest {
   override def forkArgs: T[Seq[String]] = BuildConfig.lazyValsJvmArgs
 }
+
+/** Test modules that also compile the cross-platform socket-HTTP tests in
+  * `fast-mcp-scala/jvm-native/test/src` next to their own `test/src` — the same suite then runs on
+  * the JVM and inside the linked Scala Native test binary. This is a named top-level trait rather
+  * than an inline `override def sources` in each nested `test` object because Mill's
+  * code-signature tracking cannot name a task overridden inside a nested object of a dash-named
+  * package module ("Could not detect the parent class of task ...") and aborts the build.
+  */
+trait CrossPlatformTests extends JavaModule {
+  override def sources = Task.Sources(
+    moduleDir / "src",
+    moduleDir / os.up / os.up / "jvm-native" / "test" / "src"
+  )
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ A short tour of how the library is put together. For a user-facing overview see 
 
 ## One native core, one platform seam
 
-As of 0.5.0 the entire MCP protocol layer is native Scala 3 in `shared/` — JSON-RPC envelope, wire types, router, built-in handlers, middleware, and the Tasks state machine. There is exactly one server class, `McpServer[R]`, and one platform seam split along transport lines: `TransportBackend` (stdio + `randomId`) and `HttpTransportBackend` (HTTP) — split so stdio-only programs, and their GraalVM native images, never reach the HTTP stack. The JVM supplies `System.in/out` (`JvmTransportBackend`) and ZIO HTTP (`JvmHttpBackend`); Scala.js supplies Node stdio + `Bun.serve` (`JsTransportBackend`, both givens). No vendored SDK remains on either platform (the official TS SDK survives only as a test-time conformance client).
+As of 0.5.0 the entire MCP protocol layer is native Scala 3 in `shared/` — JSON-RPC envelope, wire types, router, built-in handlers, middleware, and the Tasks state machine. There is exactly one server class, `McpServer[R]`, and one platform seam split along transport lines: `TransportBackend` (stdio + `randomId`) and `HttpTransportBackend` (HTTP) — split so stdio-only programs, and their GraalVM native images, never reach the HTTP stack. The JVM supplies `System.in/out` (`JvmTransportBackend`) and ZIO HTTP (`JvmHttpBackend`); Scala.js supplies Node stdio + `Bun.serve` (`JsTransportBackend`, both givens); Scala Native supplies `System.in/out` (`NativeTransportBackend`) and a hand-rolled HTTP/1.1 + SSE server over `java.net.ServerSocket` (`NativeHttpBackend`), which the JVM can also opt into as the netty-free `JvmSocketHttpBackend`. Every streamable-HTTP decision — session store, only-`initialize`-mints, request→SSE, GET push channel, DELETE, keepalive, transport error bodies — lives once in the shared `StreamableHttpHandler` (`server/transport/http/`), which the JVM and socket backends render onto their own request/response types (the Scala.js backend still carries its own rendering — a follow-up). No vendored SDK remains on any platform (the official TS SDK survives only as a test-time conformance client).
 
 ```
                    ┌──────────────────────────────────────┐
@@ -35,7 +35,7 @@ As of 0.5.0 the entire MCP protocol layer is native Scala 3 in `shared/` — JSO
     ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
     │  stdio (NDJSON) │    │  HTTP stateless │    │ HTTP streamable │
     │  ZIO Stream /   │    │  ZIO HTTP /     │    │ ZIO HTTP /      │
-    │  Node stdin     │    │  Bun.serve      │    │ Bun.serve + SSE │
+    │  Node stdin     │    │  Bun / sockets  │    │ Bun, sockets+SSE│
     └─────────────────┘    └─────────────────┘    └─────────────────┘
 ```
 
@@ -65,11 +65,20 @@ fast-mcp-scala/
 │       ├── manager/                      # Tool/Prompt/Resource/Task managers
 │       ├── router/                       # McpRouter, Builtins, Session, middleware
 │       └── transport/                    # TransportBackend + HttpTransportBackend seam,
-│                                         #   StdioLoop, MessageLoop, HostGuard
+│           │                             #   StdioLoop, MessageLoop, HostGuard
+│           └── http/                     # StreamableHttpHandler + HttpRequest/HttpReply/SseFrame:
+│                                         #   the streamable-HTTP semantics, rendered by every backend
+│
+├── jvm-native/src/com/tjclp/fastmcp/    # compiled by BOTH jvm and scalaNative (not Scala.js)
+│   └── server/transport/
+│       ├── http/SocketHttpServer.scala   # HTTP/1.1 + SSE over java.net.ServerSocket
+│       ├── http/Http1.scala              # request-head parser (Locale-free, RE2-free)
+│       └── SocketHttpBackend.scala       # HttpTransportBackend = handler + socket server
 │
 ├── jvm/src/com/tjclp/fastmcp/           # JVM-specific
 │   ├── server/transport/JvmTransportBackend.scala   # System.in/out (stdio; netty-free)
-│   ├── server/transport/JvmHttpBackend.scala          # ZIO HTTP (streamable + stateless)
+│   ├── server/transport/JvmHttpBackend.scala          # ZIO HTTP adapter (default HTTP given)
+│   ├── server/transport/JvmSocketHttpBackend.scala    # netty-free opt-in (socket server)
 │   └── examples/                         # JVM-only examples (HttpServer, TaskManagerServer)
 │
 ├── js/src/com/tjclp/fastmcp/            # Scala.js (Bun-first)
@@ -78,11 +87,13 @@ fast-mcp-scala/
 │   ├── server/transport/JsTransportBackend.scala    # Bun.serve + Node stdio
 │   └── examples/                         # Bun HTTP example
 │
-└── native/src/com/tjclp/fastmcp/        # Scala Native (EXPERIMENTAL, stdio only)
-    └── server/transport/NativeTransportBackend.scala # System.in/out + /dev/urandom ids
+└── native/src/com/tjclp/fastmcp/        # Scala Native (EXPERIMENTAL)
+    ├── server/transport/NativeTransportBackend.scala # System.in/out + /dev/urandom ids
+    ├── server/transport/NativeHttpBackend.scala      # socket HTTP given (exported)
+    └── examples/conformance/ConformanceServerNative.scala
 ```
 
-Every module's sources are exactly `shared/src/` + its own platform tree — no module reaches across into another's. That is an invariant worth preserving: the schema-derivation macros and every platform-pure example live in `shared/`, so `shared/` compiles standalone on all three targets. Mill wires this in `fast-mcp-scala/package.mill` (module definitions live next to the code; the root `build.mill` holds only versions, compiler flags, and shared traits).
+Every module's sources are `shared/src/` + its own platform tree, and `jvm`/`scalaNative` additionally compile `jvm-native/src/` (the socket HTTP layer both share and Scala.js cannot use; its tests in `jvm-native/test/src` run on both platforms through the `CrossPlatformTests` trait). No module reaches across into another's tree otherwise. That is an invariant worth preserving: the schema-derivation macros and every platform-pure example live in `shared/`, so `shared/` compiles standalone on all three targets. Mill wires this in `fast-mcp-scala/package.mill` (module definitions live next to the code; the root `build.mill` holds only versions, compiler flags, and shared traits).
 
 The stdio serving lifecycle is shared too: `StdioLoop` owns the session, the single-writer stdout lock, the outbound drainer fiber, and EOF teardown, so the JVM and Scala Native backends contribute only their stdin stream and their `randomId` source. The JS backend drives Node's callback IO directly and does not use it.
 
@@ -132,11 +143,13 @@ Users only see the public methods on `McpServer` (`.tool`, `.prompt`, `.resource
 
 All transports are thin adapters over the shared `MessageLoop` + router:
 
-| Transport | Entry point | JVM | Scala.js |
-|---|---|---|---|
-| Stdio | `server.runStdio()` | `ZStream` over `System.in`, serialized writer on `System.out` | Node `process.stdin`/`stdout` |
-| Streamable HTTP (default) | `server.runHttp()` | ZIO HTTP | `Bun.serve` |
-| Stateless HTTP | `server.runHttp()` with `stateless = true` | ZIO HTTP | `Bun.serve` |
+| Transport | Entry point | JVM | Scala.js | Scala Native |
+|---|---|---|---|---|
+| Stdio | `server.runStdio()` | `ZStream` over `System.in`, serialized writer on `System.out` | Node `process.stdin`/`stdout` | `ZStream.fromReader` over `System.in`, same shared `StdioLoop` |
+| Streamable HTTP (default) | `server.runHttp()` | ZIO HTTP (or the `JvmSocketHttpBackend` opt-in) | `Bun.serve` | `SocketHttpServer` over `java.net.ServerSocket` |
+| Stateless HTTP | `server.runHttp()` with `stateless = true` | ZIO HTTP (or the opt-in) | `Bun.serve` | `SocketHttpServer` |
+
+The socket server (`jvm-native/`) is deliberately minimal: a blocking accept loop and one fiber per connection on ZIO's blocking executor (`attemptBlockingCancelable`, since closing the socket is the only way to unblock a read on Native), gated at 256 concurrent connections; HTTP/1.1 keep-alive with sequential requests; `Content-Length` and chunked request bodies; `Expect: 100-continue`; HTTP/1.0 close-delimited replies; SSE as chunked transfer-encoding with one flushed chunk per event and a reader-side watcher that notices a vanished peer on a quiet stream. Caps: 8 KiB head (431), 16 MiB body (413), 60 s idle. Plaintext only. `FASTMCP_HTTP_DEBUG=1` prints per-connection failures to stderr.
 
 Modern Streamable HTTP is identical on both platforms: every request is an independent POST, carries per-request protocol metadata plus `MCP-Protocol-Version`/`Mcp-Method`/conditional `Mcp-Name` headers, and receives JSON or a request-scoped SSE stream. There is no modern protocol session, GET endpoint, DELETE lifecycle, SSE event ID, replay, or redelivery. Closing a response stream interrupts its dispatch fiber; `subscriptions/listen` uses the same long-lived POST response. Header mismatches are HTTP 400/`-32020`, unsupported versions are HTTP 400/`-32022`, missing required client capabilities are HTTP 400/`-32021`, and unknown request methods are HTTP 404/`-32601`.
 
@@ -153,7 +166,7 @@ Tool handlers return `ZIO[Any, Throwable, Out]`. Handler failures surface in-ban
 Pinned in `build.mill`:
 
 - **Scala** 3.8.3
-- **ZIO** 2.1.20, **zio-json** 0.7.44 (the wire codec on both platforms), **zio-http** 3.4.0
+- **ZIO** 2.1.20, **zio-json** 0.7.44 (the wire codec on all platforms), **zio-http** 3.4.0 (JVM default HTTP backend only — the Scala Native / opt-in socket backend has no HTTP dependency)
 - **Native Scala 3 macros** for JSON Schema derivation, emitted as `zio-json` ASTs
 - **mill-bun-plugin** 0.2.1 (Scala.js + Bun integration)
 - **WartRemover** 3.5.6 (linting)

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -167,3 +167,25 @@ against the native binary, held to the unchanged (empty) JVM baseline. CI runs t
 enforces scenario-level JVM/native parity on the 2026 requirements run, requires a clean server
 log (no `UnsupportedFeatureError`), and requires the binary to exit within 15s of SIGTERM — on
 every PR.
+
+## Netty-free HTTP images (opt-in, not yet CI-verified)
+
+The JVM's default `HttpTransportBackend` is ZIO HTTP on Netty, which is why the HTTP image above
+needs the netty-specific flags. Since TJC-2223 (#81) the JVM can also serve streamable HTTP with
+`JvmSocketHttpBackend` — the same `java.net.ServerSocket` server that is the Scala Native HTTP
+backend, rendering the same shared `StreamableHttpHandler`. Opt in with a given of its singleton
+type and exclude `dev.zio::zio-http` from the dependency:
+
+```scala
+import com.tjclp.fastmcp.{*, given}
+import com.tjclp.fastmcp.server.transport.JvmSocketHttpBackend
+
+given JvmSocketHttpBackend.type = JvmSocketHttpBackend
+
+object MyServer extends McpServerApp[Http, MyServer.type]: ...
+```
+
+With zio-http excluded, none of the netty flags (`--initialize-at-run-time=io.netty`,
+`SharedArenaSupport`, the channel-type pin) apply — the image is the stdio recipe plus blocking
+sockets. This path is exercised by the JVM and Scala Native test suites but does not yet have its
+own native-image smoke job; treat it as a follow-up before relying on it in an image.

--- a/fast-mcp-scala/docs/parity-audit.md
+++ b/fast-mcp-scala/docs/parity-audit.md
@@ -314,7 +314,7 @@ Gaps closed to get there (all shared logic, so both platforms benefit):
 |---------|------|----|----|---------|-----|-------|
 | Stdio framing (NDJSON) | 2025-11-25 | ✓ | ✓ | ✓ PARITY | — | Both JSON+newline |
 | Streamable HTTP POST (request/response + SSE notifications) | 2025-11-25 | ✓ | ✓ | ✓ PARITY | — | Both support stateful POST |
-| Streamable HTTP GET (SSE server→client push) | 2025-11-25 | ✓ | ⚠ PARTIAL | ⚠ PARTIAL | — | TS: supports; Scala JVM: supports (single stream, keepalives); Scala JS: 405 (by-design — per-request POST SSE carries server→client) |
+| Streamable HTTP GET (SSE server→client push) | 2025-11-25 | ✓ | ⚠ PARTIAL | ⚠ PARTIAL | — | TS: supports; Scala JVM and Scala Native: support (single stream, keepalives — both render the shared `StreamableHttpHandler`, TJC-2223); Scala JS: 405 (by-design — per-request POST SSE carries server→client) |
 | Streamable HTTP DELETE (session cleanup) | 2025-11-25 | ✓ | ✓ | ✓ PARITY | — | Both validate session, remove, shutdown queue |
 | mcp-session-id header (generation + echo) | 2025-11-25 | ✓ | ✓ | ✓ PARITY | — | Both mint UUID on initialize; echo on response |
 | Stateless HTTP mode (POST request/response, no SSE) | 2025-11-25 | ✓ | ✓ | ✓ PARITY | — | Both branch on config flag |

--- a/fast-mcp-scala/jvm-native/src/com/tjclp/fastmcp/server/transport/SocketHttpBackend.scala
+++ b/fast-mcp-scala/jvm-native/src/com/tjclp/fastmcp/server/transport/SocketHttpBackend.scala
@@ -1,0 +1,43 @@
+package com.tjclp.fastmcp
+package server.transport
+
+import zio.*
+
+import com.tjclp.fastmcp.server.McpServerSettings
+import com.tjclp.fastmcp.server.router.McpRouter
+import com.tjclp.fastmcp.server.transport.http.{SocketHttpServer, StreamableHttpHandler}
+
+/** [[HttpTransportBackend]] over `java.net.ServerSocket` — the shared [[StreamableHttpHandler]]
+  * served by [[SocketHttpServer]], with no HTTP library underneath. It is the Scala Native HTTP
+  * backend (`NativeHttpBackend`, where zio-http does not exist) and the JVM's netty-free opt-in
+  * (`JvmSocketHttpBackend`); the two differ only in which platform [[TransportBackend]] supplies
+  * `randomId()` for session ids (`/dev/urandom` on Native, `SecureRandom` on the JVM).
+  *
+  * Semantics are byte-for-byte those of the zio-http backend because both render the same handler;
+  * the transport-level differences are the ones listed on [[SocketHttpServer]] (caps, idle timeout,
+  * connection gate, plaintext only).
+  */
+class SocketHttpBackend(entropy: TransportBackend) extends HttpTransportBackend:
+
+  override def serveHttp[R](
+      router: McpRouter[R],
+      settings: McpServerSettings
+  ): ZIO[R, Throwable, Unit] =
+    // The accept loop runs forever; joining it means a loop failure (a bind that later breaks, a
+    // platform surprise in `accept`) fails `serveHttp` loudly instead of leaving a deaf listener.
+    ZIO.scoped(start(router, settings).flatMap(_.loop.join))
+
+  /** Bind and start serving inside the enclosing `Scope`, returning the bound address and the
+    * accept-loop fiber — the seam tests use (`settings.port = 0` picks a free port; closing the
+    * scope stops the server).
+    */
+  private[fastmcp] def start[R](
+      router: McpRouter[R],
+      settings: McpServerSettings
+  ): ZIO[R & Scope, Throwable, SocketHttpServer.Started] =
+    for
+      handler <- StreamableHttpHandler.make(router, settings, entropy.randomId())
+      // Scoped to the server's lifetime, exactly like the zio-http backend forks it.
+      _ <- handler.evictIdleSessions.forkScoped
+      started <- SocketHttpServer.start(settings.host, settings.port)(handler.handle)
+    yield started

--- a/fast-mcp-scala/jvm-native/src/com/tjclp/fastmcp/server/transport/http/Http1.scala
+++ b/fast-mcp-scala/jvm-native/src/com/tjclp/fastmcp/server/transport/http/Http1.scala
@@ -1,0 +1,154 @@
+package com.tjclp.fastmcp
+package server.transport.http
+
+import java.nio.charset.StandardCharsets
+
+/** HTTP/1.x request-head model and parser for [[SocketHttpServer]]. Pure functions over bytes, so
+  * the parsing rules are unit-testable without a socket. Shared by the JVM and Scala Native builds
+  * (`jvm-native/`), so it uses only the javalib subset both platforms link.
+  */
+private[fastmcp] object Http1:
+
+  enum Version:
+    case Http10, Http11
+
+  /** A transport-level rejection the server answers before the MCP layer ever sees the request: a
+    * JSON-RPC error body with this status, then `Connection: close`.
+    */
+  final case class Rejection(status: Int, message: String)
+
+  /** The parsed request line + headers. Header names are ASCII-lowercased; values are trimmed;
+    * lookup returns the first occurrence (the same rule zio-http's `rawHeader` follows).
+    */
+  final case class Head(
+      method: String,
+      target: String,
+      version: Version,
+      headers: List[(String, String)]
+  ):
+
+    def header(name: String): Option[String] =
+      val key = asciiLower(name)
+      headers.collectFirst { case (k, v) if k == key => v }
+
+    /** The request-target with any query string removed; absolute-form targets are reduced to their
+      * path.
+      */
+    def path: String =
+      val noQuery = target.indexOf('?') match
+        case -1 => target
+        case i => target.substring(0, i)
+      if noQuery.startsWith("http://") || noQuery.startsWith("https://") then
+        val afterScheme = noQuery.indexOf("://") + 3
+        noQuery.indexOf('/', afterScheme) match
+          case -1 => "/"
+          case i => noQuery.substring(i)
+      else noQuery
+
+    /** How the request body is delimited, or a [[Rejection]] when the framing headers are
+      * contradictory / unsupported / over the caps.
+      */
+    def bodyFraming(maxBody: Int): Either[Rejection, Framing] =
+      val lengths = headers.collect { case ("content-length", v) => v.trim }.distinct
+      val encodings = headers.collect { case ("transfer-encoding", v) => asciiLower(v.trim) }
+      if lengths.nonEmpty && encodings.nonEmpty then
+        Left(Rejection(400, "Both Content-Length and Transfer-Encoding present"))
+      else if encodings.nonEmpty then
+        if encodings == List("chunked") then Right(Framing.Chunked)
+        else Left(Rejection(501, s"Unsupported Transfer-Encoding: ${encodings.mkString(", ")}"))
+      else
+        lengths match
+          case Nil => Right(Framing.Empty)
+          case single :: Nil =>
+            if single.nonEmpty && single.forall(_.isDigit) then
+              val n = single.toLongOption.getOrElse(Long.MaxValue)
+              if n > maxBody then Left(Rejection(413, s"Request body exceeds $maxBody bytes"))
+              else Right(Framing.Length(n.toInt))
+            else Left(Rejection(400, "Malformed Content-Length"))
+          case _ => Left(Rejection(400, "Conflicting Content-Length headers"))
+
+    def expectsContinue: Boolean =
+      header("expect").exists(v => asciiLower(v.trim) == "100-continue")
+
+    /** `true` when the client asked for the connection to close after this exchange. */
+    def wantsClose: Boolean =
+      version == Version.Http10 ||
+        header("connection").exists(v => asciiLower(v).split(',').exists(_.trim == "close"))
+
+  enum Framing:
+    case Empty
+    case Length(n: Int)
+    case Chunked
+
+  /** ASCII-only lowercase — `java.util.Locale` is absent from the Scala Native javalib, and HTTP
+    * tokens are ASCII by definition, so this is also the correct fold (no Turkish-i surprises).
+    */
+  def asciiLower(s: String): String =
+    if s.forall(c => c < 'A' || c > 'Z') then s
+    else s.map(c => if c >= 'A' && c <= 'Z' then (c + 32).toChar else c)
+
+  /** Parse a request head (request line + headers, up to and excluding the blank line). Lines may
+    * end in CRLF or bare LF. Obsolete line folding is rejected.
+    */
+  def parseHead(bytes: Array[Byte]): Either[Rejection, Head] =
+    val text = new String(bytes, StandardCharsets.ISO_8859_1)
+    val lines = text.split("\r?\n", -1).toList.dropWhile(_.isEmpty)
+    lines match
+      case Nil => Left(Rejection(400, "Empty request"))
+      case requestLine :: rest =>
+        parseRequestLine(requestLine).flatMap { case (method, target, version) =>
+          parseHeaders(rest.takeWhile(_.nonEmpty), Nil).map(hs => Head(method, target, version, hs))
+        }
+
+  private def parseRequestLine(line: String): Either[Rejection, (String, String, Version)] =
+    line.split(' ').toList.filter(_.nonEmpty) match
+      case method :: target :: versionToken :: Nil if isToken(method) =>
+        versionToken match
+          case "HTTP/1.1" => Right((method, target, Version.Http11))
+          case "HTTP/1.0" => Right((method, target, Version.Http10))
+          case v if v.startsWith("HTTP/") => Left(Rejection(505, s"Unsupported HTTP version: $v"))
+          case _ => Left(Rejection(400, "Malformed request line"))
+      case _ => Left(Rejection(400, "Malformed request line"))
+
+  private def parseHeaders(
+      lines: List[String],
+      acc: List[(String, String)]
+  ): Either[Rejection, List[(String, String)]] =
+    lines match
+      case Nil => Right(acc.reverse)
+      case line :: rest =>
+        if line.charAt(0) == ' ' || line.charAt(0) == '\t' then
+          Left(Rejection(400, "Obsolete header line folding is not supported"))
+        else
+          line.indexOf(':') match
+            case -1 | 0 => Left(Rejection(400, "Malformed header line"))
+            case i =>
+              val name = line.substring(0, i)
+              if !isToken(name) then Left(Rejection(400, "Malformed header name"))
+              else parseHeaders(rest, (asciiLower(name) -> line.substring(i + 1).trim) :: acc)
+
+  /** RFC 9110 `token`: one or more tchar. */
+  private def isToken(s: String): Boolean =
+    s.nonEmpty && s.forall { c =>
+      c.isLetterOrDigit || "!#$%&'*+-.^_`|~".indexOf(c.toInt) >= 0
+    }
+
+  /** Reason phrases for the statuses this server emits; unknown codes get an empty phrase. */
+  def reason(status: Int): String =
+    status match
+      case 100 => "Continue"
+      case 200 => "OK"
+      case 202 => "Accepted"
+      case 400 => "Bad Request"
+      case 403 => "Forbidden"
+      case 404 => "Not Found"
+      case 405 => "Method Not Allowed"
+      case 406 => "Not Acceptable"
+      case 409 => "Conflict"
+      case 413 => "Content Too Large"
+      case 415 => "Unsupported Media Type"
+      case 431 => "Request Header Fields Too Large"
+      case 500 => "Internal Server Error"
+      case 501 => "Not Implemented"
+      case 505 => "HTTP Version Not Supported"
+      case _ => ""

--- a/fast-mcp-scala/jvm-native/src/com/tjclp/fastmcp/server/transport/http/SocketHttpServer.scala
+++ b/fast-mcp-scala/jvm-native/src/com/tjclp/fastmcp/server/transport/http/SocketHttpServer.scala
@@ -4,7 +4,7 @@ package server.transport.http
 import java.io.{BufferedOutputStream, InputStream, OutputStream}
 import java.net.{InetSocketAddress, ServerSocket, Socket, SocketTimeoutException}
 import java.nio.charset.StandardCharsets
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
 import zio.*
 import zio.stm.TSemaphore
@@ -188,19 +188,49 @@ private[fastmcp] object SocketHttpServer:
       head.bodyFraming(MaxBodyBytes) match
         case Left(rejection) => reject(rejection).as(false)
         case Right(framing) =>
-          val interim =
-            if head.expectsContinue && framing != Framing.Empty then
-              blocking {
-                writeRaw("HTTP/1.1 100 Continue\r\n\r\n")
-                out.flush()
-              }
-            else ZIO.unit
-          interim *> readBody(framing).flatMap {
-            case Left(rejection) => reject(rejection).as(false)
-            case Right(body) =>
-              val request = HttpRequest(head.method, head.path, head.header, ZIO.succeed(body))
-              handle(request).flatMap(reply => writeReply(reply, head.version, head.wantsClose))
+          // The body is read lazily: the shared handler forces `request.body` only after its
+          // Host/Origin and Accept guards pass, so a request those guards reject never costs the
+          // read (up to 16 MiB) — the same ordering the zio-http adapter gets from its lazy body.
+          // `100 Continue`, which solicits the body, is sent at that same point; RFC 9110 lets a
+          // server answer on the head alone without ever asking for the body.
+          val consumed = new AtomicBoolean(false)
+          val failed = new AtomicReference[Option[Rejection]](None)
+          for
+            body <- deferredBody(head, framing, consumed, failed).memoize
+            reply <- handle(HttpRequest(head.method, head.path, head.header, body))
+            // A body read that failed mid-way keeps its own status (413 for an over-cap chunked
+            // body, 400 for truncation) rather than the handler's generic 400.
+            finalReply = failed.get.fold(reply)(r =>
+              StreamableHttpHandler.transportError(r.status, r.message)
+            )
+            // A declared body that was never consumed, or failed part-way, leaves unknown bytes on
+            // the socket: close after the reply so they are never parsed as the next request.
+            bodyClean = framing == Framing.Empty || (consumed.get && failed.get.isEmpty)
+            usable <- writeReply(finalReply, head.version, head.wantsClose || !bodyClean)
+          yield usable
+
+    private def deferredBody(
+        head: Head,
+        framing: Framing,
+        consumed: AtomicBoolean,
+        failed: AtomicReference[Option[Rejection]]
+    ): Task[String] =
+      val interim =
+        if head.expectsContinue && framing != Framing.Empty then
+          blocking {
+            writeRaw("HTTP/1.1 100 Continue\r\n\r\n")
+            out.flush()
           }
+        else ZIO.unit
+      interim *> readBody(framing).flatMap {
+        case Right(body) =>
+          ZIO.succeed(consumed.set(true)).as(body)
+        case Left(rejection) =>
+          ZIO.succeed {
+            consumed.set(true)
+            failed.set(Some(rejection))
+          } *> ZIO.fail(new java.io.IOException(rejection.message))
+      }
 
     private def readBody(framing: Framing): Task[Either[Rejection, String]] =
       framing match
@@ -260,7 +290,7 @@ private[fastmcp] object SocketHttpServer:
       val closeAfter = close || !chunked
       val stop = new AtomicBoolean(false)
       for
-        _ <- blocking {
+        headWritten <- blocking {
           writeHead(
             200,
             headers ++ List(
@@ -270,8 +300,14 @@ private[fastmcp] object SocketHttpServer:
             closeAfter
           )
           out.flush()
-        }
+        }.foldCause(_ => false, _ => true)
         dead <- Promise.make[Nothing, Unit]
+        // If the peer vanished before the head even went out, the stream must STILL run — halted
+        // at once through `dead` — because its finalizers are the only thing that interrupts the
+        // request's dispatch fiber, shuts its queue, and releases the session's GET slot. Skipping
+        // the stream here would leave a `subscriptions/listen` dispatch running forever and every
+        // later GET on the session answering 409.
+        _ <- ZIO.unless(headWritten)(dead.succeed(()))
         // The read side is otherwise silent while we stream, so a peer that vanishes would go
         // unnoticed until the next write — never, for a quiet GET channel. Watch it: EOF or an
         // error completes `dead`, which halts the stream and runs the MCP layer's finalizers.
@@ -295,8 +331,8 @@ private[fastmcp] object SocketHttpServer:
             _ => ZIO.succeed(true)
           )
         clientGone <- dead.isDone
-        usable = streamed && !clientGone && !closeAfter
-        _ <- ZIO.when(streamed && !clientGone && chunked)(blocking {
+        usable = headWritten && streamed && !clientGone && !closeAfter
+        _ <- ZIO.when(headWritten && streamed && !clientGone && chunked)(blocking {
           writeRaw("0\r\n\r\n")
           out.flush()
         })
@@ -335,7 +371,8 @@ private[fastmcp] object SocketHttpServer:
     */
   @SuppressWarnings(Array("org.wartremover.warts.Var"))
   private final class ConnectionInput(in: InputStream):
-    private var buf: Array[Byte] = new Array[Byte](8 * 1024)
+    private val InitialBufferBytes = 8 * 1024
+    private var buf: Array[Byte] = new Array[Byte](InitialBufferBytes)
     private var start = 0
     private var end = 0
 
@@ -348,6 +385,9 @@ private[fastmcp] object SocketHttpServer:
       if start == end then
         start = 0
         end = 0
+        // Drained: drop a buffer that a large body grew, so one 16 MiB request on a keep-alive
+        // connection does not pin 16 MiB for the connection's whole lifetime.
+        if buf.length > InitialBufferBytes then buf = new Array[Byte](InitialBufferBytes)
       else if end == buf.length then
         if start > 0 then
           java.lang.System.arraycopy(buf, start, buf, 0, end - start)
@@ -377,6 +417,11 @@ private[fastmcp] object SocketHttpServer:
       var scanned = 0 // bytes from `start` already scanned without finding the terminator
       var result: Option[Either[Rejection, Option[Array[Byte]]]] = None
       while result.isEmpty do
+        // RFC 9112 §2.2: ignore empty lines received before the request-line, so a stray extra
+        // CRLF from a proxy is not taken as an (empty) head terminator.
+        while start < end && (buf(start) == '\r' || buf(start) == '\n') do
+          start += 1
+          scanned = math.max(0, scanned - 1)
         headEnd(start + scanned) match
           case Some((headEnd, _)) if headEnd - start > max =>
             result = Some(Left(Rejection(431, s"Request head exceeds $max bytes")))

--- a/fast-mcp-scala/jvm-native/src/com/tjclp/fastmcp/server/transport/http/SocketHttpServer.scala
+++ b/fast-mcp-scala/jvm-native/src/com/tjclp/fastmcp/server/transport/http/SocketHttpServer.scala
@@ -58,6 +58,12 @@ private[fastmcp] object SocketHttpServer:
     */
   val AcceptPollMs: Int = 500
 
+  /** While an SSE reply streams, the read-side watcher polls this often, so it notices the stream
+    * ending and hands any bytes it buffered (a pipelined request) back to the request loop without
+    * waiting out the idle timeout.
+    */
+  val WatchPollMs: Int = 1_000
+
   final case class Bound(host: String, port: Int)
 
   /** A running server: its address and the accept-loop fiber (join it to serve "forever" — the loop
@@ -311,6 +317,9 @@ private[fastmcp] object SocketHttpServer:
         // The read side is otherwise silent while we stream, so a peer that vanishes would go
         // unnoticed until the next write — never, for a quiet GET channel. Watch it: EOF or an
         // error completes `dead`, which halts the stream and runs the MCP layer's finalizers.
+        // Short read timeouts while streaming: the watcher re-checks `stop` every poll instead of
+        // sitting in one idle-timeout-long read after the stream has already ended.
+        _ <- ZIO.attempt(socket.setSoTimeout(WatchPollMs)).ignore
         watcher <- blocking(input.awaitActivity(stop))
           .tap(outcome => ZIO.when(outcome == Watch.Dead)(dead.succeed(())))
           .catchAll(_ => dead.succeed(()).as(Watch.Dead))
@@ -341,6 +350,7 @@ private[fastmcp] object SocketHttpServer:
         // soon as the client sends its next request (bytes stay buffered), or on idle timeout /
         // EOF, both of which end the connection like any other idle keep-alive would.
         activity <- if usable then watcher.join else watcher.interrupt.as(Watch.Dead)
+        _ <- ZIO.attempt(socket.setSoTimeout(IdleReadTimeoutMs)).ignore
       yield usable && activity == Watch.Data
 
     private def writeHead(status: Int, headers: List[(String, String)], close: Boolean): Unit =
@@ -403,11 +413,27 @@ private[fastmcp] object SocketHttpServer:
       */
     def awaitActivity(stop: AtomicBoolean): Watch =
       var outcome: Option[Watch] = None
+      var idleSince = -1L
       while outcome.isEmpty do
         try
           val n = fill()
-          outcome = Some(if n < 0 then Watch.Dead else Watch.Data)
-        catch case _: SocketTimeoutException => if stop.get then outcome = Some(Watch.Timeout)
+          if n < 0 then outcome = Some(Watch.Dead)
+          else if stop.get then outcome = Some(Watch.Data)
+          else if available > MaxHeadBytes then
+            // More than a request head's worth of unsolicited bytes while we stream is not a
+            // pipelined request: treat the peer as broken rather than buffer without bound.
+            outcome = Some(Watch.Dead)
+          // Otherwise the bytes stay buffered (a pipelined request, served after the stream) and
+          // the watch continues — returning here would leave a peer that vanishes afterwards
+          // undetected, parking the connection (and its permit + GET slot) forever.
+        catch
+          case _: SocketTimeoutException =>
+            if stop.get then
+              if available > 0 then outcome = Some(Watch.Data)
+              else
+                val now = java.lang.System.currentTimeMillis()
+                if idleSince < 0 then idleSince = now
+                else if now - idleSince >= IdleReadTimeoutMs then outcome = Some(Watch.Timeout)
       outcome.getOrElse(Watch.Dead)
 
     /** Read a request head up to (excluding) its blank-line terminator (`CRLF CRLF`, or bare `LF

--- a/fast-mcp-scala/jvm-native/src/com/tjclp/fastmcp/server/transport/http/SocketHttpServer.scala
+++ b/fast-mcp-scala/jvm-native/src/com/tjclp/fastmcp/server/transport/http/SocketHttpServer.scala
@@ -1,0 +1,489 @@
+package com.tjclp.fastmcp
+package server.transport.http
+
+import java.io.{BufferedOutputStream, InputStream, OutputStream}
+import java.net.{InetSocketAddress, ServerSocket, Socket, SocketTimeoutException}
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicBoolean
+
+import zio.*
+import zio.stm.TSemaphore
+import zio.stream.*
+
+import com.tjclp.fastmcp.server.transport.http.Http1.{Framing, Head, Rejection, Version}
+
+/** A minimal HTTP/1.1 + SSE server over `java.net.ServerSocket`, sufficient for MCP streamable HTTP
+  * and nothing more. It exists because zio-http has no Scala Native artifacts; on the JVM the same
+  * code is the netty-free opt-in. Compiled by both the `jvm` and `scalaNative` modules
+  * (`jvm-native/`), so it uses only the javalib subset both platforms link — blocking sockets, no
+  * NIO channels, no `Locale`, no TLS.
+  *
+  * Threading model: the accept loop and every socket read/write run on ZIO's blocking executor via
+  * `attemptBlockingCancelable`, whose cancel action closes the socket — the only way to unblock a
+  * read on Scala Native, where `Thread.interrupt` has no effect on sockets. One fiber per
+  * connection; an idle keep-alive connection or an idle SSE stream costs one parked blocking
+  * thread, so the accept loop is gated by [[MaxConnections]] (ZIO's blocking pool is unbounded).
+  *
+  * Wire behaviour: HTTP/1.1 keep-alive with requests handled sequentially per connection;
+  * `Content-Length` and `Transfer-Encoding: chunked` request bodies; `Expect: 100-continue` (curl
+  * sends it for bodies over 1 KiB); HTTP/1.0 and `Connection: close` clients get close-delimited
+  * responses; SSE replies stream as chunked transfer-encoding with one chunk per event, flushed
+  * immediately, and a terminating chunk so the connection stays reusable. While an SSE reply
+  * streams, a watcher fiber blocks on the socket's read side so a client that silently disconnects
+  * is noticed even when the stream is quiet — that is what lets the MCP layer's finalizers
+  * (`session.releaseGet`, request-queue shutdown) run for abandoned GET streams.
+  */
+private[fastmcp] object SocketHttpServer:
+
+  /** Request line + headers cap; larger heads are rejected with `431`. */
+  val MaxHeadBytes: Int = 8 * 1024
+
+  /** Request body cap (declared or chunked); larger bodies are rejected with `413`. */
+  val MaxBodyBytes: Int = 16 * 1024 * 1024
+
+  /** Concurrent connection cap — one blocking thread each while idle. Extra connections wait in the
+    * kernel backlog.
+    */
+  val MaxConnections: Int = 256
+
+  val Backlog: Int = 128
+
+  /** A connection with no request activity (or an SSE stream whose client stays silent after it
+    * ended) is closed after this long.
+    */
+  val IdleReadTimeoutMs: Int = 60_000
+
+  /** `accept` wakes this often so a shutdown request is honoured promptly even on platforms where
+    * closing the listener does not unblock a pending `accept`.
+    */
+  val AcceptPollMs: Int = 500
+
+  final case class Bound(host: String, port: Int)
+
+  /** A running server: its address and the accept-loop fiber (join it to serve "forever" — the loop
+    * only ends by failing, which must surface rather than leave a listener that never answers).
+    */
+  final case class Started(bound: Bound, loop: Fiber.Runtime[Throwable, Nothing])
+
+  /** Set `FASTMCP_HTTP_DEBUG=1` to print per-connection failures (a peer resetting mid-request, a
+    * rejected head, an idle timeout) to stderr; they are otherwise swallowed, as a misbehaving
+    * client must not be able to affect the server. Scala Native has no logging framework to route
+    * them to, so this is the one diagnostic knob.
+    */
+  private val debug: Boolean =
+    Option(java.lang.System.getenv("FASTMCP_HTTP_DEBUG")).exists(v => v.nonEmpty && v != "0")
+
+  private def debugLog(message: => String): UIO[Unit] =
+    if debug then ZIO.succeed(java.lang.System.err.println(s"[fastmcp-http] $message"))
+    else ZIO.unit
+
+  /** Bind `host:port` (port `0` picks a free port — see the returned [[Bound]]) and fork the accept
+    * loop into the enclosing `Scope`. Closing the scope interrupts the loop, which closes the
+    * listener, and — through fiber supervision — every connection fiber, each of which closes its
+    * socket.
+    */
+  def start[R](host: String, port: Int)(
+      handle: HttpRequest => URIO[R, HttpReply]
+  ): ZIO[R & Scope, Throwable, Started] =
+    for
+      server <- ZIO.acquireRelease(
+        ZIO.attemptBlocking {
+          val s = new ServerSocket()
+          s.setReuseAddress(true)
+          s.bind(new InetSocketAddress(host, port), Backlog)
+          s.setSoTimeout(AcceptPollMs)
+          s
+        }
+      )(s => ZIO.attemptBlocking(s.close()).ignore)
+      gate <- TSemaphore.make(MaxConnections.toLong).commit
+      loop <- acceptLoop(server, gate, handle)
+        .tapErrorCause(cause => debugLog(s"accept loop failed: ${cause.prettyPrint}"))
+        .forkScoped
+    yield Started(Bound(host, server.getLocalPort), loop)
+
+  private def acceptLoop[R](
+      server: ServerSocket,
+      gate: TSemaphore,
+      handle: HttpRequest => URIO[R, HttpReply]
+  ): ZIO[R, Throwable, Nothing] =
+    val acceptOne: IO[Throwable, Option[Socket]] =
+      ZIO
+        .attemptBlockingCancelable(server.accept())(ZIO.succeed(server.close()))
+        .asSome
+        .catchSome { case _: SocketTimeoutException => ZIO.none }
+    val step: ZIO[R, Throwable, Unit] =
+      gate.acquire.commit *> acceptOne.foldCauseZIO(
+        cause => gate.release.commit *> ZIO.refailCause(cause),
+        {
+          case None => gate.release.commit
+          case Some(socket) =>
+            // Plain `fork`: connections are children of the accept loop, so ending the loop
+            // (scope close) interrupts them all; per-connection `forkScoped` would pile up
+            // finalizers in the server scope for the life of the process.
+            serveConnection(socket, handle).ensuring(gate.release.commit).fork.unit
+        }
+      )
+    step.forever
+
+  private def serveConnection[R](
+      socket: Socket,
+      handle: HttpRequest => URIO[R, HttpReply]
+  ): URIO[R, Unit] =
+    ZIO
+      .scoped {
+        ZIO
+          .acquireRelease(
+            ZIO.attempt {
+              socket.setTcpNoDelay(true)
+              socket.setSoTimeout(IdleReadTimeoutMs)
+              new Connection(socket)
+            }
+          )(_.close)
+          .flatMap(_.run(handle))
+      }
+      // A misbehaving peer (malformed bytes, reset, idle timeout) affects only its own connection.
+      .tapErrorCause(cause => debugLog(s"connection ended: ${cause.prettyPrint}"))
+      .catchAllDefect(_ => ZIO.unit)
+      .ignore
+
+  /** Outcome of watching a connection's read side while an SSE reply streams. */
+  private enum Watch:
+    case Dead, Data, Timeout
+
+  /** One accepted socket: the request loop, framing, and response writing. */
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  private final class Connection(socket: Socket):
+    private val input = new ConnectionInput(socket.getInputStream)
+    private val out: OutputStream = new BufferedOutputStream(socket.getOutputStream, 16 * 1024)
+
+    def close: UIO[Unit] = ZIO.attemptBlocking(socket.close()).ignore
+
+    /** Run blocking socket work; interrupting the fiber closes the socket, which unblocks it. */
+    private def blocking[A](thunk: => A): Task[A] =
+      ZIO.attemptBlockingCancelable(thunk)(close)
+
+    def run[R](handle: HttpRequest => URIO[R, HttpReply]): ZIO[R, Throwable, Unit] =
+      handleOne(handle).flatMap(keepAlive => if keepAlive then run(handle) else ZIO.unit)
+
+    /** Serve one request; `true` when the connection can carry another. An idle-timeout while
+      * waiting for the next request surfaces as a `SocketTimeoutException` failure, which closes
+      * the connection.
+      */
+    private def handleOne[R](
+        handle: HttpRequest => URIO[R, HttpReply]
+    ): ZIO[R, Throwable, Boolean] =
+      blocking(input.readHead(MaxHeadBytes)).flatMap {
+        case Left(rejection) => reject(rejection).as(false)
+        case Right(None) => ZIO.succeed(false) // clean EOF between requests
+        case Right(Some(headBytes)) =>
+          Http1.parseHead(headBytes) match
+            case Left(rejection) => reject(rejection).as(false)
+            case Right(head) => dispatch(head, handle)
+      }
+
+    private def dispatch[R](
+        head: Head,
+        handle: HttpRequest => URIO[R, HttpReply]
+    ): ZIO[R, Throwable, Boolean] =
+      head.bodyFraming(MaxBodyBytes) match
+        case Left(rejection) => reject(rejection).as(false)
+        case Right(framing) =>
+          val interim =
+            if head.expectsContinue && framing != Framing.Empty then
+              blocking {
+                writeRaw("HTTP/1.1 100 Continue\r\n\r\n")
+                out.flush()
+              }
+            else ZIO.unit
+          interim *> readBody(framing).flatMap {
+            case Left(rejection) => reject(rejection).as(false)
+            case Right(body) =>
+              val request = HttpRequest(head.method, head.path, head.header, ZIO.succeed(body))
+              handle(request).flatMap(reply => writeReply(reply, head.version, head.wantsClose))
+          }
+
+    private def readBody(framing: Framing): Task[Either[Rejection, String]] =
+      framing match
+        case Framing.Empty => ZIO.succeed(Right(""))
+        case Framing.Length(n) =>
+          blocking(input.readExactly(n)).map {
+            case Some(bytes) => Right(new String(bytes, StandardCharsets.UTF_8))
+            case None => Left(Rejection(400, "Request body ended prematurely"))
+          }
+        case Framing.Chunked =>
+          blocking(input.readChunked(MaxBodyBytes))
+            .map(_.map(bytes => new String(bytes, StandardCharsets.UTF_8)))
+
+    /** Transport-level rejection: the same JSON-RPC error body the MCP layer uses, then close. */
+    private def reject(rejection: Rejection): Task[Unit] =
+      writeJson(
+        StreamableHttpHandler.transportError(rejection.status, rejection.message),
+        close = true
+      ).unit
+
+    private def writeReply(reply: HttpReply, version: Version, close: Boolean): Task[Boolean] =
+      reply match
+        case HttpReply.Empty(status, headers) =>
+          blocking {
+            writeHead(status, headers :+ ("content-length" -> "0"), close)
+            out.flush()
+          }.as(!close)
+        case json: HttpReply.Json => writeJson(json, close)
+        case HttpReply.Sse(headers, frames) => streamSse(headers, frames, version, close)
+
+    private def writeJson(json: HttpReply.Json, close: Boolean): Task[Boolean] =
+      blocking {
+        val bytes = json.body.getBytes(StandardCharsets.UTF_8)
+        writeHead(
+          json.status,
+          json.headers ++ List(
+            "content-type" -> "application/json",
+            "content-length" -> bytes.length.toString
+          ),
+          close
+        )
+        out.write(bytes)
+        out.flush()
+      }.as(!close)
+
+    /** Stream an SSE reply. HTTP/1.1 clients get chunked transfer-encoding and keep the connection;
+      * HTTP/1.0 clients get a close-delimited body. Returns whether the connection is still usable
+      * for another request.
+      */
+    private def streamSse(
+        headers: List[(String, String)],
+        frames: ZStream[Any, Nothing, SseFrame],
+        version: Version,
+        close: Boolean
+    ): Task[Boolean] =
+      val chunked = version == Version.Http11
+      val closeAfter = close || !chunked
+      val stop = new AtomicBoolean(false)
+      for
+        _ <- blocking {
+          writeHead(
+            200,
+            headers ++ List(
+              "content-type" -> "text/event-stream",
+              "cache-control" -> "no-cache"
+            ) ++ (if chunked then List("transfer-encoding" -> "chunked") else Nil),
+            closeAfter
+          )
+          out.flush()
+        }
+        dead <- Promise.make[Nothing, Unit]
+        // The read side is otherwise silent while we stream, so a peer that vanishes would go
+        // unnoticed until the next write — never, for a quiet GET channel. Watch it: EOF or an
+        // error completes `dead`, which halts the stream and runs the MCP layer's finalizers.
+        watcher <- blocking(input.awaitActivity(stop))
+          .tap(outcome => ZIO.when(outcome == Watch.Dead)(dead.succeed(())))
+          .catchAll(_ => dead.succeed(()).as(Watch.Dead))
+          .fork
+        // Run the stream in a fresh fiber and join it: a forked fiber starts ZIO's run loop at
+        // depth zero, so the stream interpreter (merge + schedule + interruptWhen) never inherits
+        // the connection fiber's nesting. On Scala Native that is the difference between running
+        // and a StackOverflowError — ZIO only trampolines at depth 300, and Native frames are
+        // large enough that a keepalive-merged stream started deep in a request overflows the
+        // 1 MiB thread stack.
+        streamed <- frames
+          .interruptWhen(dead)
+          .runForeach(frame => blocking(writeFrame(frame.encode, chunked)))
+          .fork
+          .flatMap(_.join)
+          .foldCauseZIO(
+            cause => if cause.isInterrupted then ZIO.refailCause(cause) else ZIO.succeed(false),
+            _ => ZIO.succeed(true)
+          )
+        clientGone <- dead.isDone
+        usable = streamed && !clientGone && !closeAfter
+        _ <- ZIO.when(streamed && !clientGone && chunked)(blocking {
+          writeRaw("0\r\n\r\n")
+          out.flush()
+        })
+        _ <- ZIO.succeed(stop.set(true))
+        // A usable connection waits for the watcher to hand back the read side: it returns as
+        // soon as the client sends its next request (bytes stay buffered), or on idle timeout /
+        // EOF, both of which end the connection like any other idle keep-alive would.
+        activity <- if usable then watcher.join else watcher.interrupt.as(Watch.Dead)
+      yield usable && activity == Watch.Data
+
+    private def writeHead(status: Int, headers: List[(String, String)], close: Boolean): Unit =
+      val head = new StringBuilder(256)
+      head ++= s"HTTP/1.1 $status ${Http1.reason(status)}\r\n"
+      headers.foreach { case (name, value) => head ++= s"$name: $value\r\n" }
+      head ++= s"connection: ${if close then "close" else "keep-alive"}\r\n\r\n"
+      writeRaw(head.toString)
+
+    private def writeRaw(s: String): Unit =
+      out.write(s.getBytes(StandardCharsets.ISO_8859_1))
+
+    private def writeFrame(encoded: String, chunked: Boolean): Unit =
+      val bytes = encoded.getBytes(StandardCharsets.UTF_8)
+      if chunked then
+        writeRaw(Integer.toHexString(bytes.length))
+        writeRaw("\r\n")
+        out.write(bytes)
+        writeRaw("\r\n")
+      else out.write(bytes)
+      out.flush()
+
+  /** Single-reader buffered view of a socket's input: byte-exact reads of request heads, fixed
+    * lengths, and chunked bodies, plus the SSE-time activity watch. Every method blocks; callers
+    * wrap them in `attemptBlockingCancelable`. Exactly one fiber may be inside at a time — the
+    * request loop hands the reader to the watcher while streaming and joins it before reading the
+    * next head.
+    */
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  private final class ConnectionInput(in: InputStream):
+    private var buf: Array[Byte] = new Array[Byte](8 * 1024)
+    private var start = 0
+    private var end = 0
+
+    private def available: Int = end - start
+
+    /** One blocking read appended to the buffer; the count read, or -1 at EOF. Compacts or grows
+      * the buffer first, so byte offsets *relative to `start`* stay valid across calls.
+      */
+    def fill(): Int =
+      if start == end then
+        start = 0
+        end = 0
+      else if end == buf.length then
+        if start > 0 then
+          java.lang.System.arraycopy(buf, start, buf, 0, end - start)
+          end -= start
+          start = 0
+        else buf = java.util.Arrays.copyOf(buf, buf.length * 2)
+      val n = in.read(buf, end, buf.length - end)
+      if n > 0 then end += n
+      n
+
+    /** Block until the peer sends something, closes, or errors — or, once `stop` is set, until the
+      * socket's read timeout fires. Bytes read stay buffered for the next [[readHead]].
+      */
+    def awaitActivity(stop: AtomicBoolean): Watch =
+      var outcome: Option[Watch] = None
+      while outcome.isEmpty do
+        try
+          val n = fill()
+          outcome = Some(if n < 0 then Watch.Dead else Watch.Data)
+        catch case _: SocketTimeoutException => if stop.get then outcome = Some(Watch.Timeout)
+      outcome.getOrElse(Watch.Dead)
+
+    /** Read a request head up to (excluding) its blank-line terminator (`CRLF CRLF`, or bare `LF
+      * LF` / `LF CRLF` for lenient clients). `Right(None)` on EOF before any byte.
+      */
+    def readHead(max: Int): Either[Rejection, Option[Array[Byte]]] =
+      var scanned = 0 // bytes from `start` already scanned without finding the terminator
+      var result: Option[Either[Rejection, Option[Array[Byte]]]] = None
+      while result.isEmpty do
+        headEnd(start + scanned) match
+          case Some((headEnd, _)) if headEnd - start > max =>
+            result = Some(Left(Rejection(431, s"Request head exceeds $max bytes")))
+          case Some((headEnd, terminatorLength)) =>
+            val bytes = java.util.Arrays.copyOfRange(buf, start, headEnd)
+            start = headEnd + terminatorLength
+            result = Some(Right(Some(bytes)))
+          case None =>
+            if available > max then
+              result = Some(Left(Rejection(431, s"Request head exceeds $max bytes")))
+            else
+              // Re-scan the last 3 bytes next time: a terminator may straddle two reads.
+              scanned = math.max(0, available - 3)
+              if fill() < 0 then
+                result = Some(
+                  if available == 0 then Right(None)
+                  else Left(Rejection(400, "Truncated request head"))
+                )
+      result.getOrElse(Right(None))
+
+    /** Index just past the head and the terminator length, if a terminator ends at or after `from`.
+      */
+    private def headEnd(from: Int): Option[(Int, Int)] =
+      var i = math.max(from, start)
+      var found: Option[(Int, Int)] = None
+      while found.isEmpty && i < end do
+        if buf(i) == '\n' then
+          if i - 3 >= start && buf(i - 1) == '\r' && buf(i - 2) == '\n' && buf(i - 3) == '\r' then
+            found = Some((i - 3, 4))
+          else if i - 2 >= start && buf(i - 1) == '\r' && buf(i - 2) == '\n' then
+            found = Some((i - 2, 3))
+          else if i - 1 >= start && buf(i - 1) == '\n' then found = Some((i - 1, 2))
+        i += 1
+      found
+
+    /** Exactly `n` bytes, or `None` if the peer closed first. */
+    def readExactly(n: Int): Option[Array[Byte]] =
+      var eof = false
+      while available < n && !eof do if fill() < 0 then eof = true
+      if available < n then None
+      else
+        val bytes = java.util.Arrays.copyOfRange(buf, start, start + n)
+        start += n
+        Some(bytes)
+
+    /** One line up to LF (CR stripped), or `None` at EOF; `Left(400)` past `max` bytes. */
+    private def readLine(max: Int): Either[Rejection, Option[String]] =
+      var scanned = 0
+      var result: Option[Either[Rejection, Option[String]]] = None
+      while result.isEmpty do
+        var i = start + scanned
+        var lf = -1
+        while lf < 0 && i < end do
+          if buf(i) == '\n' then lf = i
+          i += 1
+        if lf >= 0 then
+          val lineEnd = if lf > start && buf(lf - 1) == '\r' then lf - 1 else lf
+          val line = new String(buf, start, lineEnd - start, StandardCharsets.ISO_8859_1)
+          start = lf + 1
+          result = Some(Right(Some(line)))
+        else if available > max then
+          result = Some(Left(Rejection(400, "Chunk header line too long")))
+        else
+          scanned = available
+          if fill() < 0 then result = Some(Right(None))
+      result.getOrElse(Right(None))
+
+    /** Decode a `Transfer-Encoding: chunked` body (extensions ignored, trailers skipped). */
+    def readChunked(max: Int): Either[Rejection, Array[Byte]] =
+      val body = new java.io.ByteArrayOutputStream()
+      var result: Option[Either[Rejection, Array[Byte]]] = None
+      while result.isEmpty do
+        readLine(1024) match
+          case Left(rejection) => result = Some(Left(rejection))
+          case Right(None) => result = Some(Left(Rejection(400, "Truncated chunked body")))
+          case Right(Some(line)) =>
+            val sizeToken = line.indexOf(';') match
+              case -1 => line.trim
+              case i => line.substring(0, i).trim
+            parseChunkSize(sizeToken) match
+              case None => result = Some(Left(Rejection(400, "Malformed chunk size")))
+              case Some(0) => result = Some(skipTrailers().map(_ => body.toByteArray))
+              case Some(size) =>
+                if body.size() + size > max then
+                  result = Some(Left(Rejection(413, s"Request body exceeds $max bytes")))
+                else
+                  readExactly(size) match
+                    case None => result = Some(Left(Rejection(400, "Truncated chunk")))
+                    case Some(bytes) =>
+                      body.write(bytes)
+                      readLine(8) match
+                        case Right(Some("")) => ()
+                        case _ => result = Some(Left(Rejection(400, "Missing CRLF after chunk")))
+      result.getOrElse(Left(Rejection(400, "Truncated chunked body")))
+
+    private def skipTrailers(): Either[Rejection, Unit] =
+      var result: Option[Either[Rejection, Unit]] = None
+      while result.isEmpty do
+        readLine(1024) match
+          case Right(Some("")) => result = Some(Right(()))
+          case Right(Some(_)) => ()
+          case Right(None) => result = Some(Left(Rejection(400, "Truncated chunked trailers")))
+          case Left(rejection) => result = Some(Left(rejection))
+      result.getOrElse(Right(()))
+
+    /** Hex chunk size, capped at 7 digits (≤ 256 MiB) so it always fits an `Int`. */
+    private def parseChunkSize(token: String): Option[Int] =
+      if token.isEmpty || token.length > 7 || !token.forall(c => Character.digit(c, 16) >= 0) then
+        None
+      else Some(Integer.parseInt(token, 16))

--- a/fast-mcp-scala/jvm-native/test/src/com/tjclp/fastmcp/server/transport/SocketHttpBackendTest.scala
+++ b/fast-mcp-scala/jvm-native/test/src/com/tjclp/fastmcp/server/transport/SocketHttpBackendTest.scala
@@ -523,6 +523,50 @@ class SocketHttpBackendTest extends AnyFunSuite with Matchers:
     }
   }
 
+  test("stray bytes on an open GET stream do not blind the disconnect watch") {
+    withServer() { port =>
+      val sid = initSession(port)
+      val stream = new RawClient(port)
+      stream.send(get(Some(sid)))
+      stream.readHead()._1 shouldBe 200
+      // Unsolicited bytes on the stream's connection (not a request), then vanish. The watcher
+      // must keep watching past them: otherwise the connection fiber parks forever, holding a
+      // connection permit and the session's GET slot, and the session can never be evicted.
+      stream.send("\r\n")
+      Thread.sleep(200)
+      stream.abort()
+
+      val deadline = java.lang.System.currentTimeMillis() + 5_000
+      var status = 409
+      while status == 409 && java.lang.System.currentTimeMillis() < deadline do
+        Thread.sleep(100)
+        val retry = new RawClient(port)
+        retry.send(get(Some(sid)))
+        status = retry.readHead()._1
+        retry.close()
+      status shouldBe 200
+    }
+  }
+
+  test("a request pipelined behind an open GET stream is served once the stream ends") {
+    withServer() { port =>
+      val sid = initSession(port)
+      val stream = new RawClient(port)
+      stream.send(get(Some(sid)))
+      stream.readHead()._1 shouldBe 200
+      // Pipeline the next request on the same connection while the stream is open ...
+      stream.send(post(initFrame))
+      // ... end the stream from elsewhere ...
+      request(port, delete(sid)).status shouldBe 200
+      stream.readChunk() shouldBe None
+      // ... and the buffered request is answered on the same connection.
+      val next = stream.readReply()
+      next.status shouldBe 200
+      next.header("mcp-session-id").isDefined shouldBe true
+      stream.close()
+    }
+  }
+
   test("concurrent connections are served independently") {
     withServer() { port =>
       val results = (1 to 8).map { _ =>

--- a/fast-mcp-scala/jvm-native/test/src/com/tjclp/fastmcp/server/transport/SocketHttpBackendTest.scala
+++ b/fast-mcp-scala/jvm-native/test/src/com/tjclp/fastmcp/server/transport/SocketHttpBackendTest.scala
@@ -1,0 +1,509 @@
+package com.tjclp.fastmcp
+package server.transport
+
+import java.io.{BufferedInputStream, ByteArrayOutputStream, InputStream, OutputStream}
+import java.net.{InetSocketAddress, ServerSocket, Socket, SocketTimeoutException}
+import java.nio.charset.StandardCharsets
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import zio.*
+import zio.json.*
+import zio.json.ast.Json
+
+import com.tjclp.fastmcp.{*, given}
+import com.tjclp.fastmcp.core.{LoggingLevel, ProgressToken, TaskSupport}
+import com.tjclp.fastmcp.server.TaskSettings
+import com.tjclp.fastmcp.server.transport.http.SocketHttpServer
+
+/** Wire-level contract of the `java.net.ServerSocket` HTTP backend, driven by a hand-rolled
+  * blocking HTTP/1.1 client over `java.net.Socket` (there is no `java.net.http` on Scala Native).
+  * Compiled into both the JVM and the Scala Native test binaries (`jvm-native/test`): the MCP
+  * semantics are the shared handler's and are pinned by `JvmHttpTransportTest`; what this suite
+  * pins is the socket layer — framing, keep-alive, chunked SSE, disconnect detection, the caps —
+  * on both platforms' thread and socket runtimes.
+  */
+class SocketHttpBackendTest extends AnyFunSuite with Matchers:
+
+  // --- server under test -------------------------------------------------------------------
+
+  case class AddArgs(a: Int, b: Int)
+  case class AddResult(sum: Int)
+
+  private val addTool =
+    McpTool[AddArgs, AddResult](name = "add", description = Some("Add two numbers")) { args =>
+      AddResult(args.a + args.b)
+    }
+
+  case class ChattyArgs(msg: Option[String] = None)
+  given JsonDecoder[ChattyArgs] = DeriveJsonDecoder.gen[ChattyArgs]
+
+  /** Emits progress + a log after a beat. Run as a task, those pushes land on the session's
+    * outbound queue — i.e. the standalone GET SSE channel.
+    */
+  private val chattyTool = McpTool
+    .withSchema[ChattyArgs, String](
+      name = "chatty",
+      inputSchema = ToolInputSchema.unsafeFromJsonString("""{"type":"object","properties":{}}"""),
+      description = Some("Emits progress and a log mid-task")
+    )
+    .contextual { (_, ctx) =>
+      ZIO.sleep(200.millis) *>
+        ctx.get.sendProgress(ProgressToken.StringToken("t"), 0.5) *>
+        ctx.get.sendLogMessage(LoggingLevel.Info, Json.Str("mid-task")).as("chatty done")
+    }
+    .withTaskSupport(TaskSupport.Optional)
+
+  private def baseSettings: McpServerSettings =
+    McpServerSettings(
+      host = "127.0.0.1",
+      port = 0,
+      loggingEnabled = true,
+      tasks = TaskSettings(enabled = true, pollIntervalMs = 50)
+    )
+
+  private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
+    Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(effect).getOrThrowFiberFailure())
+
+  /** Start the socket backend on a free port for the duration of `body`, then tear it down. */
+  private def withServer[A](settings: McpServerSettings = baseSettings)(body: Int => A): A =
+    val server = McpServer.typed[Any]("SocketT", "0.1.0", settings)
+    runUnsafe(server.tool(addTool) *> server.tool(chattyTool))
+    runUnsafe(
+      ZIO
+        .scoped {
+          for
+            router <- server.buildRouter
+            started <- new SocketHttpBackend(summon[TransportBackend]).start(router, settings)
+            // Blocking client reads cannot be interrupted, so race the body against the accept
+            // loop: a loop that dies (a platform surprise in `accept`) fails the test at once
+            // instead of leaving the client waiting on a listener that never answers.
+            result <- ZIO.attemptBlocking(body(started.bound.port)).raceFirst(started.loop.join)
+          yield result
+        }
+        .timeoutFail(new RuntimeException("socket backend test timed out"))(60.seconds)
+    )
+
+  // --- raw HTTP/1.1 client ---------------------------------------------------------------------
+
+  final case class Reply(status: Int, headers: Map[String, String], body: String):
+    def header(name: String): Option[String] = headers.get(name.toLowerCase)
+
+  /** One blocking HTTP/1.1 connection; reads heads, fixed bodies, and SSE chunks byte-exactly.
+    * A watchdog thread closes the socket after `readTimeoutMs` of total lifetime so a server that
+    * never answers fails the test instead of hanging it — `setSoTimeout` is not honoured for reads
+    * on every platform, and a blocked socket read cannot be interrupted.
+    */
+  final class RawClient(port: Int, readTimeoutMs: Int = 10_000):
+    private val socket = new Socket()
+    socket.connect(new InetSocketAddress("127.0.0.1", port), 5_000)
+    socket.setSoTimeout(readTimeoutMs)
+    private val in: InputStream = new BufferedInputStream(socket.getInputStream)
+    private val out: OutputStream = socket.getOutputStream
+    private val watchdog = new Thread(() =>
+      try
+        Thread.sleep(readTimeoutMs.toLong)
+        java.lang.System.err.println(s"[raw-client] watchdog closing socket on port $port")
+        socket.close()
+      catch case _: InterruptedException => ()
+    )
+    watchdog.setDaemon(true)
+    watchdog.start()
+
+    def send(raw: String): Unit =
+      out.write(raw.getBytes(StandardCharsets.UTF_8))
+      out.flush()
+
+    def close(): Unit =
+      watchdog.interrupt()
+      socket.close()
+
+    /** Abrupt teardown as a vanished client would do it. */
+    def abort(): Unit =
+      watchdog.interrupt()
+      socket.setSoLinger(true, 0)
+      socket.close()
+
+    /** Next line without its CR/LF; `None` at EOF. */
+    def readLine(): Option[String] =
+      val buf = new ByteArrayOutputStream()
+      var byte = in.read()
+      while byte != -1 && byte != '\n' do
+        buf.write(byte)
+        byte = in.read()
+      if byte == -1 && buf.size() == 0 then None
+      else
+        val line = buf.toString("ISO-8859-1")
+        Some(if line.endsWith("\r") then line.dropRight(1) else line)
+
+    /** Status line + headers (names lowercased). Fails at EOF. */
+    def readHead(): (Int, Map[String, String]) =
+      val statusLine = readLine().getOrElse(fail("EOF before status line"))
+      statusLine should startWith("HTTP/1.1 ")
+      val status = statusLine.substring(9, 12).toInt
+      val headers = Iterator
+        .continually(readLine().getOrElse(fail("EOF inside headers")))
+        .takeWhile(_.nonEmpty)
+        .map { line =>
+          val i = line.indexOf(':')
+          line.substring(0, i).trim.toLowerCase -> line.substring(i + 1).trim
+        }
+        .toMap
+      (status, headers)
+
+    def readExactly(n: Int): Array[Byte] =
+      val bytes = new Array[Byte](n)
+      var off = 0
+      while off < n do
+        val read = in.read(bytes, off, n - off)
+        if read < 0 then fail(s"EOF after $off of $n body bytes")
+        off += read
+      bytes
+
+    /** One chunk of a chunked body as text, or `None` at the terminating zero chunk. */
+    def readChunk(): Option[String] =
+      val sizeLine = readLine().getOrElse(fail("EOF inside chunked body"))
+      val size = Integer.parseInt(sizeLine.trim, 16)
+      if size == 0 then
+        // trailers (none expected) up to the blank line
+        Iterator.continually(readLine().getOrElse("")).takeWhile(_.nonEmpty).foreach(_ => ())
+        None
+      else
+        val data = new String(readExactly(size), StandardCharsets.UTF_8)
+        readLine() shouldBe Some("")
+        Some(data)
+
+    /** Read a whole reply: fixed-length, chunked (all chunks), or nothing. */
+    def readReply(): Reply =
+      val (status, headers) = readHead()
+      val body =
+        headers.get("transfer-encoding") match
+          case Some(te) if te.equalsIgnoreCase("chunked") =>
+            Iterator.continually(readChunk()).takeWhile(_.isDefined).flatten.mkString
+          case _ =>
+            headers.get("content-length").map(_.toInt).filter(_ > 0) match
+              case Some(n) => new String(readExactly(n), StandardCharsets.UTF_8)
+              case None => ""
+      Reply(status, headers, body)
+
+    /** `true` once the server has closed its side (read returns EOF). */
+    def atEof(): Boolean =
+      try in.read() == -1
+      catch case _: SocketTimeoutException => false
+
+  /** One-shot request on a fresh connection. */
+  private def request(port: Int, raw: String): Reply =
+    val client = new RawClient(port)
+    try
+      client.send(raw)
+      client.readReply()
+    finally client.close()
+
+  // --- request builders -----------------------------------------------------------------------
+
+  private val initFrame =
+    """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"1.0"}}}"""
+  private val initializedFrame = """{"jsonrpc":"2.0","method":"notifications/initialized"}"""
+  private val listFrame = """{"jsonrpc":"2.0","id":2,"method":"tools/list"}"""
+  private val addFrame =
+    """{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"add","arguments":{"a":2,"b":40}}}"""
+  private val chattyTaskFrame =
+    """{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"chatty","arguments":{},"task":{"ttl":60000}}}"""
+
+  private def headerLines(extra: List[(String, String)]): String =
+    extra.map { case (k, v) => s"$k: $v\r\n" }.mkString
+
+  private def post(
+      body: String,
+      sid: Option[String] = None,
+      extra: List[(String, String)] = Nil,
+      accept: String = "application/json, text/event-stream",
+      host: String = "127.0.0.1"
+  ): String =
+    val bytes = body.getBytes(StandardCharsets.UTF_8).length
+    s"POST /mcp HTTP/1.1\r\nHost: $host\r\nContent-Type: application/json\r\nAccept: $accept\r\n" +
+      sid.fold("")(s => s"Mcp-Session-Id: $s\r\n") + headerLines(extra) +
+      s"Content-Length: $bytes\r\n\r\n$body"
+
+  private def get(sid: Option[String], extra: List[(String, String)] = Nil): String =
+    s"GET /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nAccept: text/event-stream\r\n" +
+      sid.fold("")(s => s"Mcp-Session-Id: $s\r\n") + headerLines(extra) + "\r\n"
+
+  private def delete(sid: String): String =
+    s"DELETE /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nMcp-Session-Id: $sid\r\n\r\n"
+
+  private def initSession(port: Int): String =
+    val reply = request(port, post(initFrame))
+    reply.status shouldBe 200
+    reply.header("mcp-session-id").getOrElse(fail("initialize did not mint a session"))
+
+  // --- tests --------------------------------------------------------------------------------------
+
+  test("initialize mints a session and streams the reply as chunked SSE") {
+    withServer() { port =>
+      val reply = request(port, post(initFrame))
+      reply.status shouldBe 200
+      reply.header("content-type") shouldBe Some("text/event-stream")
+      reply.header("transfer-encoding") shouldBe Some("chunked")
+      reply.header("connection") shouldBe Some("keep-alive")
+      reply.header("mcp-session-id").exists(_.nonEmpty) shouldBe true
+      reply.body should startWith("event: message\ndata: ")
+      reply.body should include(""""protocolVersion":"2025-11-25"""")
+      reply.body should endWith("\n\n")
+    }
+  }
+
+  test("a request reply carries the tool result; a notification gets 202 with no body") {
+    withServer() { port =>
+      val sid = initSession(port)
+      val call = request(port, post(addFrame, Some(sid)))
+      call.status shouldBe 200
+      call.body should include("""{\"sum\":42}""")
+      val ack = request(port, post(initializedFrame, Some(sid)))
+      ack.status shouldBe 202
+      ack.header("content-length") shouldBe Some("0")
+      ack.body shouldBe ""
+    }
+  }
+
+  test("unknown session → 404 with the SessionNotFound code; headerless non-initialize → 400") {
+    withServer() { port =>
+      val unknown = request(port, post(listFrame, Some("nope")))
+      unknown.status shouldBe 404
+      unknown.header("content-type") shouldBe Some("application/json")
+      unknown.body should include(""""code":-32001""")
+      val headerless = request(port, post(listFrame))
+      headerless.status shouldBe 400
+      headerless.body should include("mcp-session-id")
+    }
+  }
+
+  test("GET channel: 405 without a session, 200 stream, 409 on a second stream, DELETE ends it") {
+    withServer() { port =>
+      request(port, get(None)).status shouldBe 405
+      val sid = initSession(port)
+
+      val stream = new RawClient(port)
+      stream.send(get(Some(sid)))
+      val (status, headers) = stream.readHead()
+      status shouldBe 200
+      headers.get("content-type") shouldBe Some("text/event-stream")
+      headers.get("transfer-encoding") shouldBe Some("chunked")
+
+      val second = request(port, get(Some(sid)))
+      second.status shouldBe 409
+
+      val deleted = request(port, delete(sid))
+      deleted.status shouldBe 200
+      // The DELETE shut the outbound queue: the open stream ends with the terminating chunk.
+      stream.readChunk() shouldBe None
+      stream.close()
+
+      request(port, get(Some(sid))).status shouldBe 404
+    }
+  }
+
+  test("server-initiated pushes (task progress/log) arrive on the GET channel") {
+    withServer() { port =>
+      val sid = initSession(port)
+      val stream = new RawClient(port)
+      stream.send(get(Some(sid)))
+      stream.readHead()._1 shouldBe 200
+
+      val created = request(port, post(chattyTaskFrame, Some(sid)))
+      created.status shouldBe 200
+      created.body should include(""""taskId"""")
+
+      // The task's pushes are emitted after its creating POST completed; they can only travel
+      // over the standalone stream. Collect until the log line shows up.
+      val events = scala.collection.mutable.ListBuffer.empty[String]
+      while !events.exists(_.contains("mid-task")) && events.size < 8 do
+        events += stream.readChunk().getOrElse(fail("GET stream ended early"))
+      events.exists(_.contains("mid-task")) shouldBe true
+      events.exists(_.contains("notifications/")) shouldBe true
+      stream.close()
+    }
+  }
+
+  test("keepalive pings flow on a quiet GET stream") {
+    withServer(baseSettings.copy(keepAliveInterval = Some(java.time.Duration.ofMillis(100)))) {
+      port =>
+        val sid = initSession(port)
+        val stream = new RawClient(port)
+        stream.send(get(Some(sid)))
+        stream.readHead()._1 shouldBe 200
+        val first = stream.readChunk().getOrElse(fail("stream ended"))
+        val secondPing = stream.readChunk().getOrElse(fail("stream ended"))
+        first shouldBe "event: ping\n\n"
+        secondPing shouldBe "event: ping\n\n"
+        stream.close()
+    }
+  }
+
+  test("keep-alive: several requests on one connection, including an SSE reply in the middle") {
+    withServer() { port =>
+      val client = new RawClient(port)
+      client.send(post(initFrame))
+      val init = client.readReply()
+      init.status shouldBe 200
+      val sid = init.header("mcp-session-id").getOrElse(fail("no session"))
+      client.send(post(addFrame, Some(sid)))
+      val call = client.readReply()
+      call.status shouldBe 200
+      call.body should include("""{\"sum\":42}""")
+      client.send(post(initializedFrame, Some(sid)))
+      client.readReply().status shouldBe 202
+      client.send(post(listFrame, Some(sid)))
+      client.readReply().body should include(""""name":"add"""")
+      client.close()
+    }
+  }
+
+  test("malformed request line → 400 JSON-RPC error and the connection closes") {
+    withServer() { port =>
+      val client = new RawClient(port)
+      client.send("GARBAGE\r\n\r\n")
+      val reply = client.readReply()
+      reply.status shouldBe 400
+      reply.header("connection") shouldBe Some("close")
+      reply.body should include(""""code":-32000""")
+      client.atEof() shouldBe true
+      client.close()
+    }
+  }
+
+  test("oversized head → 431; declared body over the cap → 413 before reading it") {
+    withServer() { port =>
+      val huge = "x" * (SocketHttpServer.MaxHeadBytes + 512)
+      val big = request(port, get(None, extra = List("X-Pad" -> huge)))
+      big.status shouldBe 431
+
+      val client = new RawClient(port)
+      client.send(
+        s"POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: ${SocketHttpServer.MaxBodyBytes + 1}\r\n\r\n"
+      )
+      val reply = client.readReply()
+      reply.status shouldBe 413
+      reply.header("connection") shouldBe Some("close")
+      client.close()
+    }
+  }
+
+  test("chunked request bodies are decoded") {
+    withServer() { port =>
+      val (a, b) = initFrame.splitAt(40)
+      def chunk(s: String) = s"${Integer.toHexString(s.length)}\r\n$s\r\n"
+      val raw =
+        "POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\n" +
+          "Accept: application/json, text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n" +
+          chunk(a) + chunk(b) + "0\r\n\r\n"
+      val reply = request(port, raw)
+      reply.status shouldBe 200
+      reply.header("mcp-session-id").isDefined shouldBe true
+    }
+  }
+
+  test("Expect: 100-continue receives the interim response before the body is sent") {
+    withServer() { port =>
+      val client = new RawClient(port)
+      val bytes = initFrame.getBytes(StandardCharsets.UTF_8).length
+      client.send(
+        "POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\n" +
+          "Accept: application/json, text/event-stream\r\nExpect: 100-continue\r\n" +
+          s"Content-Length: $bytes\r\n\r\n"
+      )
+      client.readLine() shouldBe Some("HTTP/1.1 100 Continue")
+      client.readLine() shouldBe Some("")
+      client.send(initFrame)
+      client.readReply().status shouldBe 200
+      client.close()
+    }
+  }
+
+  test("HTTP/1.0 requests get close-delimited responses") {
+    withServer() { port =>
+      val client = new RawClient(port)
+      client.send("GET /mcp HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n")
+      val reply = client.readReply()
+      reply.status shouldBe 405
+      reply.header("connection") shouldBe Some("close")
+      client.atEof() shouldBe true
+      client.close()
+    }
+  }
+
+  test("unknown path → 404; unsupported method → 405 with Allow") {
+    withServer() { port =>
+      request(port, "GET /other HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n").status shouldBe 404
+      val put = request(port, "PUT /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 0\r\n\r\n")
+      put.status shouldBe 405
+      put.header("allow") shouldBe Some("POST, GET, DELETE")
+    }
+  }
+
+  test("Host guard (403) and Accept negotiation (406) reach the wire") {
+    withServer(baseSettings.copy(allowedHosts = Some(Set("localhost")))) { port =>
+      request(port, post(initFrame, host = "evil.example")).status shouldBe 403
+      val ok = request(port, post(initFrame, host = "localhost:1234"))
+      ok.status shouldBe 200
+      request(port, post(initFrame, host = "localhost", accept = "text/plain")).status shouldBe 406
+    }
+  }
+
+  test("stateless mode answers with plain JSON and refuses GET") {
+    withServer(baseSettings.copy(stateless = true)) { port =>
+      val reply = request(port, post(initFrame, accept = "application/json"))
+      reply.status shouldBe 200
+      reply.header("content-type") shouldBe Some("application/json")
+      reply.header("content-length").isDefined shouldBe true
+      reply.header("mcp-session-id") shouldBe None
+      reply.body should include(""""protocolVersion"""")
+      request(port, get(None)).status shouldBe 405
+    }
+  }
+
+  test("a client that vanishes mid-GET releases the session's stream slot") {
+    withServer() { port =>
+      val sid = initSession(port)
+      val stream = new RawClient(port)
+      stream.send(get(Some(sid)))
+      stream.readHead()._1 shouldBe 200
+      stream.abort()
+
+      // The server notices the disconnect on its read side (no writes are pending) and runs the
+      // stream's finalizer, so a replacement GET is accepted instead of answering 409.
+      val deadline = java.lang.System.currentTimeMillis() + 5_000
+      var status = 409
+      while status == 409 && java.lang.System.currentTimeMillis() < deadline do
+        Thread.sleep(100)
+        val retry = new RawClient(port)
+        retry.send(get(Some(sid)))
+        status = retry.readHead()._1
+        retry.close()
+      status shouldBe 200
+    }
+  }
+
+  test("concurrent connections are served independently") {
+    withServer() { port =>
+      val results = (1 to 8).map { _ =>
+        ZIO.attemptBlocking {
+          val sid = initSession(port)
+          request(port, post(addFrame, Some(sid)))
+        }
+      }
+      val replies = runUnsafe(ZIO.collectAllPar(results))
+      replies.foreach { reply =>
+        reply.status shouldBe 200
+        reply.body should include("""{\"sum\":42}""")
+      }
+    }
+  }
+
+  test("closing the server scope frees the port") {
+    val port = withServer()(identity)
+    val probe = new ServerSocket()
+    probe.setReuseAddress(true)
+    probe.bind(new InetSocketAddress("127.0.0.1", port))
+    probe.close()
+  }

--- a/fast-mcp-scala/jvm-native/test/src/com/tjclp/fastmcp/server/transport/SocketHttpBackendTest.scala
+++ b/fast-mcp-scala/jvm-native/test/src/com/tjclp/fastmcp/server/transport/SocketHttpBackendTest.scala
@@ -432,6 +432,45 @@ class SocketHttpBackendTest extends AnyFunSuite with Matchers:
     }
   }
 
+  test("empty lines before the request line are ignored (RFC 9112 §2.2)") {
+    withServer() { port =>
+      // A stray extra CRLF ahead of the request, as some proxies emit: not an empty head.
+      request(port, "\r\n\r\n" + get(None)).status shouldBe 405
+    }
+  }
+
+  test("header guards answer before the body is read, and the unread body closes the connection") {
+    withServer(baseSettings.copy(allowedHosts = Some(Set("localhost")))) { port =>
+      val client = new RawClient(port)
+      // Spoofed Host with a large declared body that is never sent: the DNS-rebinding guard must
+      // reject on the head alone instead of blocking on (or buffering) the body first.
+      client.send(
+        "POST /mcp HTTP/1.1\r\nHost: evil.example\r\nContent-Type: application/json\r\n" +
+          "Accept: application/json, text/event-stream\r\nContent-Length: 100000\r\n\r\n"
+      )
+      val reply = client.readReply()
+      reply.status shouldBe 403
+      reply.header("connection") shouldBe Some("close")
+      client.atEof() shouldBe true
+      client.close()
+    }
+  }
+
+  test("a chunked body over the cap is rejected with 413 as soon as the chunk size says so") {
+    withServer() { port =>
+      val client = new RawClient(port)
+      client.send(
+        "POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\n" +
+          "Accept: application/json, text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n" +
+          "1000001\r\n" // 16 MiB + 1, no data follows
+      )
+      val reply = client.readReply()
+      reply.status shouldBe 413
+      reply.header("connection") shouldBe Some("close")
+      client.close()
+    }
+  }
+
   test("unknown path → 404; unsupported method → 405 with Allow") {
     withServer() { port =>
       request(port, "GET /other HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n").status shouldBe 404

--- a/fast-mcp-scala/jvm-native/test/src/com/tjclp/fastmcp/server/transport/http/Http1ParserTest.scala
+++ b/fast-mcp-scala/jvm-native/test/src/com/tjclp/fastmcp/server/transport/http/Http1ParserTest.scala
@@ -1,0 +1,105 @@
+package com.tjclp.fastmcp
+package server.transport.http
+
+import java.nio.charset.StandardCharsets
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import com.tjclp.fastmcp.server.transport.http.Http1.{Framing, Version}
+
+/** Pure parsing rules of the socket HTTP layer. Compiled into both the JVM and the Scala Native
+  * test binaries (`jvm-native/test`), so the RE2-free, `Locale`-free string handling is proven on
+  * the platform that lacks them.
+  */
+class Http1ParserTest extends AnyFunSuite with Matchers:
+
+  private def parse(head: String) =
+    Http1.parseHead(head.getBytes(StandardCharsets.ISO_8859_1))
+
+  private def parsed(head: String) =
+    parse(head).getOrElse(fail(s"expected a parsed head for: $head"))
+
+  private def status(head: String): Int =
+    parse(head).left.map(_.status).swap.getOrElse(fail(s"expected a rejection for: $head"))
+
+  private def framingStatus(head: String, max: Int): Int =
+    parsed(head)
+      .bodyFraming(max)
+      .left
+      .map(_.status)
+      .swap
+      .getOrElse(fail(s"expected a framing rejection for: $head"))
+
+  test("request line + headers: names lowercased, values trimmed, first value wins") {
+    val head = parsed(
+      "POST /mcp?x=1 HTTP/1.1\r\nHost: localhost:8000\r\nAccept:  application/json \r\n" +
+        "X-Dup: first\r\nx-dup: second"
+    )
+    head.method shouldBe "POST"
+    head.target shouldBe "/mcp?x=1"
+    head.path shouldBe "/mcp"
+    head.version shouldBe Version.Http11
+    head.header("HOST") shouldBe Some("localhost:8000")
+    head.header("accept") shouldBe Some("application/json")
+    head.header("x-dup") shouldBe Some("first")
+    head.header("missing") shouldBe None
+  }
+
+  test("bare LF line endings and leading empty lines are tolerated") {
+    val head = parsed("\r\nGET /mcp HTTP/1.0\nHost: a\n")
+    head.version shouldBe Version.Http10
+    head.header("host") shouldBe Some("a")
+    head.wantsClose shouldBe true
+  }
+
+  test("absolute-form targets reduce to their path") {
+    parsed("GET http://example.com:8000/mcp?q HTTP/1.1").path shouldBe "/mcp"
+    parsed("GET http://example.com HTTP/1.1").path shouldBe "/"
+  }
+
+  test("malformed request lines, versions and headers are rejected") {
+    status("GARBAGE") shouldBe 400
+    status("GET /mcp") shouldBe 400
+    status("GET /mcp HTTP/2.0") shouldBe 505
+    status("GET /mcp HTTP/1.1\r\nNoColonHere") shouldBe 400
+    status("GET /mcp HTTP/1.1\r\n: empty-name") shouldBe 400
+    status("GET /mcp HTTP/1.1\r\nA: b\r\n  folded") shouldBe 400
+    status("GET /mcp HTTP/1.1\r\nBad Name: x") shouldBe 400
+  }
+
+  test("body framing: none, content-length, chunked, and the contradictory cases") {
+    parsed("GET /mcp HTTP/1.1").bodyFraming(100) shouldBe Right(Framing.Empty)
+    parsed("POST /mcp HTTP/1.1\r\nContent-Length: 42").bodyFraming(100) shouldBe
+      Right(Framing.Length(42))
+    parsed("POST /mcp HTTP/1.1\r\nTransfer-Encoding: Chunked").bodyFraming(100) shouldBe
+      Right(Framing.Chunked)
+    framingStatus("POST /mcp HTTP/1.1\r\nContent-Length: 101", 100) shouldBe 413
+    framingStatus("POST /mcp HTTP/1.1\r\nContent-Length: abc", 100) shouldBe 400
+    framingStatus("POST /mcp HTTP/1.1\r\nContent-Length: 1\r\nContent-Length: 2", 100) shouldBe 400
+    framingStatus(
+      "POST /mcp HTTP/1.1\r\nContent-Length: 1\r\nTransfer-Encoding: chunked",
+      100
+    ) shouldBe 400
+    framingStatus("POST /mcp HTTP/1.1\r\nTransfer-Encoding: gzip", 100) shouldBe 501
+  }
+
+  test("connection semantics: Expect and Connection headers") {
+    val expecting = parsed("POST /mcp HTTP/1.1\r\nExpect: 100-Continue")
+    expecting.expectsContinue shouldBe true
+    expecting.wantsClose shouldBe false
+    parsed("POST /mcp HTTP/1.1\r\nConnection: keep-alive, Close").wantsClose shouldBe true
+    parsed("POST /mcp HTTP/1.1\r\nConnection: keep-alive").wantsClose shouldBe false
+  }
+
+  test("asciiLower folds only A-Z and leaves other characters alone") {
+    Http1.asciiLower("Mcp-Session-Id") shouldBe "mcp-session-id"
+    Http1.asciiLower("already-lower") shouldBe "already-lower"
+    Http1.asciiLower("ÄÖ-Ünchanged") shouldBe "ÄÖ-Ünchanged"
+  }
+
+  test("SseFrame encoding matches the event/data/blank-line wire form") {
+    SseFrame(Some("message"), """{"a":1}""").encode shouldBe "event: message\ndata: {\"a\":1}\n\n"
+    SseFrame(None, "one\ntwo").encode shouldBe "data: one\ndata: two\n\n"
+    SseFrame.Ping.encode shouldBe "event: ping\n\n"
+  }

--- a/fast-mcp-scala/jvm-native/test/src/com/tjclp/fastmcp/server/transport/http/StreamableHttpHandlerTest.scala
+++ b/fast-mcp-scala/jvm-native/test/src/com/tjclp/fastmcp/server/transport/http/StreamableHttpHandlerTest.scala
@@ -1,0 +1,77 @@
+package com.tjclp.fastmcp
+package server.transport.http
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import zio.*
+
+import com.tjclp.fastmcp.{*, given}
+import com.tjclp.fastmcp.server.transport.TransportBackend
+
+/** Contracts of the shared streamable-HTTP handler that the socket backend leans on, run on both
+  * the JVM and Scala Native (`jvm-native/test`). Drives the handler directly through the neutral
+  * model — no port, no zio-http.
+  */
+class StreamableHttpHandlerTest extends AnyFunSuite with Matchers:
+
+  private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
+    Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(effect).getOrThrowFiberFailure())
+
+  private val initFrame =
+    """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"1.0"}}}"""
+
+  private def makeHandler(): StreamableHttpHandler[Any] =
+    val server = McpServer.typed[Any]("HandlerT", "0.1.0", McpServerSettings())
+    runUnsafe(
+      server.buildRouter.flatMap { router =>
+        StreamableHttpHandler.make(router, server.settings, summon[TransportBackend].randomId())
+      }
+    )
+
+  private def request(method: String, headers: Map[String, String], body: String = ""): HttpRequest =
+    HttpRequest(method, "/mcp", name => headers.get(name.toLowerCase), ZIO.succeed(body))
+
+  private def framesOf(reply: HttpReply) =
+    reply match
+      case HttpReply.Sse(_, frames) => frames
+      case other => fail(s"expected an SSE reply, got $other")
+
+  test("a reply stream halted before its first pull still runs the handler's finalizers") {
+    val handler = makeHandler()
+    val init = runUnsafe(
+      handler.post(request("POST", Map("accept" -> "application/json, text/event-stream"), initFrame))
+    )
+    init.status shouldBe 200
+    val sid = init.headers
+      .collectFirst { case (name, value) if name.equalsIgnoreCase("mcp-session-id") => value }
+      .getOrElse(fail("initialize did not mint a session"))
+    runUnsafe(framesOf(init).runDrain)
+
+    val getHeaders = Map("accept" -> "text/event-stream", "mcp-session-id" -> sid)
+    val first = runUnsafe(handler.get(request("GET", getHeaders)))
+    first.status shouldBe 200
+
+    // What the socket layer does when the head write fails: complete `dead` up front and run the
+    // stream through interruptWhen so it halts immediately. Its `ensuring(session.releaseGet)`
+    // must still fire — otherwise this session answers 409 to every later GET, forever.
+    runUnsafe(
+      Promise.make[Nothing, Unit].flatMap { dead =>
+        dead.succeed(()) *> framesOf(first).interruptWhen(dead).runDrain
+      }
+    )
+
+    val second = runUnsafe(handler.get(request("GET", getHeaders)))
+    second.status shouldBe 200
+  }
+
+  test("a request that never forces its body is answered without the body being read") {
+    val handler = makeHandler()
+    val touched = new java.util.concurrent.atomic.AtomicBoolean(false)
+    val body: IO[Throwable, String] = ZIO.succeed { touched.set(true); initFrame }
+    // Accept without text/event-stream: rejected by the guard before the body is needed.
+    val reply = runUnsafe(
+      handler.post(HttpRequest("POST", "/mcp", Map("accept" -> "text/plain").get, body))
+    )
+    reply.status shouldBe 406
+    touched.get shouldBe false
+  }

--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/transport/JvmHttpBackend.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/transport/JvmHttpBackend.scala
@@ -4,29 +4,24 @@ package server.transport
 import zio.*
 import zio.http.*
 import zio.http.netty.{ChannelType, NettyConfig}
-import zio.json.*
-import zio.stream.*
 
-import com.tjclp.fastmcp.core.{ErrorCodes, Protocol}
-import com.tjclp.fastmcp.jsonrpc.{JsonRpcMessage, McpError, RequestId}
 import com.tjclp.fastmcp.server.McpServerSettings
 import com.tjclp.fastmcp.server.router.{McpRouter, Session}
+import com.tjclp.fastmcp.server.transport.http.{HttpReply, HttpRequest, StreamableHttpHandler}
 
 /** JVM [[HttpTransportBackend]] — ZIO HTTP (Netty). Pure ZIO: the native router is ZIO, so `R`
   * flows straight through `Server.serve` and the user's `.provide(...)`. No `Unsafe`, no runtime
   * capture, no Mono.
   *
+  * Every streamable-HTTP decision lives in the shared [[StreamableHttpHandler]]; this object is the
+  * zio-http adapter around it (request → [[HttpRequest]], [[HttpReply]] → `Response`) plus the
+  * Netty channel-type pinning GraalVM native images need. The same handler backs the netty-free
+  * socket backend (`SocketHttpBackend`) over `java.net.ServerSocket`.
+  *
   * Split from [[JvmTransportBackend]] so stdio-only programs (and their GraalVM native images)
   * never reference zio-http or Netty.
-  *
-  * MCP 2026-07-28 always uses one ephemeral request context per POST and an optional request-scoped
-  * SSE response. `settings.stateless` selects whether the older initialize/session/ GET/DELETE
-  * compatibility adapter is sessionless or durable; it does not make modern calls stateful.
   */
 object JvmHttpBackend extends HttpTransportBackend:
-
-  /** Compatibility header for initialization-based Streamable HTTP revisions. */
-  private val SessionIdHeader = "mcp-session-id"
 
   override def serveHttp[R](
       router: McpRouter[R],
@@ -36,60 +31,32 @@ object JvmHttpBackend extends HttpTransportBackend:
     // so Routes stay `Routes[Any]` — Server.serve then needs only `Server`, avoiding the generic-R
     // HasNoScope constraint. No Unsafe, no runtime capture.
     ZIO.environment[R].flatMap { env =>
-      val ep = settings.httpEndpoint.stripPrefix("/")
-      if settings.stateless then serve(statelessRoutes(router, env, settings), settings)
-      else
+      StreamableHttpHandler.make(router, settings, JvmTransportBackend.randomId()).flatMap { mcp =>
         // The idle-session sweeper is forked here (scoped to the server's lifetime), NOT in
         // httpRoutes — tests drive httpRoutes directly and must not leak a sweeper fiber each.
-        Ref.make(Map.empty[String, Session]).flatMap { store =>
-          val routes = streamableRoutes(router, ep, env, store, settings)
-          ZIO.scoped {
-            evictIdleSessions(store, settings).forkScoped *> serve(routes, settings)
-          }
+        ZIO.scoped {
+          mcp.evictIdleSessions.forkScoped *> serve(routes(mcp, env), settings)
         }
+      }
     }
 
-  /** Periodically drop streamable sessions idle past `settings.sessionIdleTimeout` — abandoned
-    * clients would otherwise grow the store forever. Sessions with a live GET stream are exempt
-    * (push-only consumers may never POST). Eviction shuts the outbound queue down; the session's
-    * tasks stay in the TaskManager until their own TTL.
-    */
+  /** The shared idle-session sweeper, kept here as a seam for `JvmHttpTransportTest`. */
   private[fastmcp] def evictIdleSessions(
       store: Ref[Map[String, Session]],
       settings: McpServerSettings
   ): UIO[Unit] =
-    settings.sessionIdleTimeout match
-      case None => ZIO.unit
-      case Some(timeout) =>
-        val timeoutMs = timeout.toMillis
-        val sweep =
-          for
-            now <- ZIO.succeed(java.lang.System.currentTimeMillis())
-            all <- store.get
-            expired <- ZIO.filter(all.values.toList) { s =>
-              (s.lastSeen zip s.hasActiveGet).map((seen, live) => !live && now - seen > timeoutMs)
-            }
-            _ <- store.update(_ -- expired.map(_.sessionId))
-            _ <- ZIO.foreachDiscard(expired)(_.outbound.shutdown)
-          yield ()
-        val interval = Duration.fromMillis(math.max(timeoutMs / 4, 1000L))
-        sweep.repeat(Schedule.spaced(interval)).unit
+    StreamableHttpHandler.evictIdleSessions(store, settings)
 
-  /** Build the HTTP routes, branching on `settings.stateless` and allocating a fresh session store
-    * for the streamable case. Exposed to tests so specs can drive requests through
-    * `routes.runZIO(...)` in-memory, without binding a TCP port.
+  /** Build the HTTP routes, allocating a fresh handler (and, unless stateless, session store).
+    * Exposed to tests so specs can drive requests through `routes.runZIO(...)` in-memory, without
+    * binding a TCP port.
     */
   private[fastmcp] def httpRoutes[R](
       router: McpRouter[R],
       settings: McpServerSettings,
       env: ZEnvironment[R]
   ): UIO[Routes[Any, Response]] =
-    val ep = settings.httpEndpoint.stripPrefix("/")
-    if settings.stateless then ZIO.succeed(statelessRoutes(router, env, settings))
-    else
-      Ref
-        .make(Map.empty[String, Session])
-        .map(store => streamableRoutes(router, ep, env, store, settings))
+    StreamableHttpHandler.make(router, settings, JvmTransportBackend.randomId()).map(routes(_, env))
 
   /** Netty channel type: `AUTO` (epoll/kqueue when available) on a normal JVM — today's zio-http
     * default — but `NIO` inside a GraalVM native image, where `AUTO`'s runtime transport probing
@@ -140,508 +107,48 @@ object JvmHttpBackend extends HttpTransportBackend:
       .unit
 
   // ---------------------------------------------------------------------------
-  // Stateless: request/response, no session state, no SSE.
+  // zio-http adapter: per-method routes on the endpoint, so zio-http keeps answering its own
+  // 404/405 for anything else; each route funnels into the shared handler.
   // ---------------------------------------------------------------------------
 
-  private def statelessRoutes[R](
-      router: McpRouter[R],
-      env: ZEnvironment[R],
-      settings: McpServerSettings
+  private def routes[R](
+      mcp: StreamableHttpHandler[R],
+      env: ZEnvironment[R]
   ): Routes[Any, Response] =
-    val ep = settings.httpEndpoint.stripPrefix("/")
+    val ep = mcp.endpoint.stripPrefix("/")
     Routes(
       Method.POST / ep -> handler { (request: Request) =>
-        handleStatelessPost(router, request, settings).provideEnvironment(env)
-      },
-      Method.GET / ep -> handler((_: Request) =>
-        ZIO.succeed(Response.status(Status.MethodNotAllowed))
-      ),
-      Method.DELETE / ep -> handler((_: Request) =>
-        ZIO.succeed(Response.status(Status.MethodNotAllowed))
-      )
-    )
-
-  /** One stateless POST: fresh ephemeral session, dispatch a single frame, return the reply (or
-    * `202 Accepted` for a notification, which produces no body).
-    */
-  private def handleStatelessPost[R](
-      router: McpRouter[R],
-      request: Request,
-      settings: McpServerSettings
-  ): ZIO[R, Nothing, Response] =
-    postHeaderError(request, settings.allowedHosts.getOrElse(Set.empty), requireSse = false) match
-      case Some(err) => ZIO.succeed(err)
-      case None => statelessDispatch(router, request, settings)
-
-  private def statelessDispatch[R](
-      router: McpRouter[R],
-      request: Request,
-      settings: McpServerSettings
-  ): ZIO[R, Nothing, Response] =
-    val effect =
-      for
-        body <- request.body.asString.mapError(e =>
-          Option(e.getMessage).getOrElse("body read error")
-        )
-        resp <- MessageLoop.parseFrame(body) match
-          case Left(parseFailure) =>
-            ZIO.succeed(Response.json(parseFailure.toJson).status(Status.BadRequest))
-          case Right(message) =>
-            if isModernRequest(request, message) then modernPost(router, request, message, settings)
-            else
-              for
-                session <- Session.make("stateless", supportsTasks = false)
-                // Legacy stateless compatibility mode starts ready without a handshake.
-                _ <- session.markInitialized
-                reply <- router.dispatch(session, message)
-              yield (message, reply) match
-                case (_: JsonRpcMessage.Invalid, Some(r)) =>
-                  Response.json(r.toJson).status(Status.BadRequest)
-                case (_, Some(r)) => Response.json(r.toJson)
-                case (_, None) => Response.status(Status.Accepted)
-      yield resp
-    effect.catchAll(msg => ZIO.succeed(errorResponse(Status.BadRequest, msg)))
-
-  // ---------------------------------------------------------------------------
-  // Streamable: durable sessions + SSE server-push + DELETE termination.
-  // ---------------------------------------------------------------------------
-
-  private def streamableRoutes[R](
-      router: McpRouter[R],
-      ep: String,
-      env: ZEnvironment[R],
-      store: Ref[Map[String, Session]],
-      settings: McpServerSettings
-  ): Routes[Any, Response] =
-    Routes(
-      Method.POST / ep -> handler { (request: Request) =>
-        handleStreamablePost(router, store, request, settings).provideEnvironment(env)
+        mcp.post(toRequest(request)).map(toResponse).provideEnvironment(env)
       },
       Method.GET / ep -> handler { (request: Request) =>
-        handleStreamableGet(store, request, settings)
+        mcp.get(toRequest(request)).map(toResponse)
       },
       Method.DELETE / ep -> handler { (request: Request) =>
-        handleStreamableDelete(
-          store,
-          request,
-          settings.disallowDelete,
-          settings.allowedHosts.getOrElse(Set.empty)
-        )
+        mcp.delete(toRequest(request)).map(toResponse)
       }
     )
 
-  /** POST on the streamable transport.
-    *
-    *   - No `mcp-session-id` header → treat as the opening `initialize`: mint a session, dispatch,
-    *     and echo the new id back in the response header.
-    *   - With the header → look up the durable session (404 if unknown) and dispatch in its context
-    *     (so client info, log level, and in-flight task state persist across requests).
-    *
-    * A request reply is returned as a single JSON body; notifications get `202 Accepted`. Any
-    * server→client messages a handler pushes go out over the session's `GET` SSE channel.
-    */
-  private def handleStreamablePost[R](
-      router: McpRouter[R],
-      store: Ref[Map[String, Session]],
-      request: Request,
-      settings: McpServerSettings
-  ): ZIO[R, Nothing, Response] =
-    postHeaderError(request, settings.allowedHosts.getOrElse(Set.empty), requireSse = true) match
-      case Some(err) => ZIO.succeed(err)
-      case None => streamablePostDispatch(router, store, request, settings)
+  private def toRequest(request: Request): HttpRequest =
+    HttpRequest(
+      method = request.method.name,
+      path = request.url.path.encode,
+      header = name => request.rawHeader(name),
+      body = request.body.asString
+    )
 
-  private def streamablePostDispatch[R](
-      router: McpRouter[R],
-      store: Ref[Map[String, Session]],
-      request: Request,
-      settings: McpServerSettings
-  ): ZIO[R, Nothing, Response] =
-    request.body.asString.either.flatMap {
-      case Left(err) =>
-        ZIO.succeed(
-          errorResponse(Status.BadRequest, Option(err.getMessage).getOrElse("body read error"))
+  private def toResponse(reply: HttpReply): Response =
+    val base = reply match
+      case HttpReply.Empty(status, _) =>
+        Response.status(Status.fromInt(status))
+      case HttpReply.Json(status, body, _) =>
+        Response.json(body).status(Status.fromInt(status))
+      case HttpReply.Sse(_, frames) =>
+        Response.fromServerSentEvents(
+          frames.map(f => ServerSentEvent(f.data, eventType = f.event))
         )
-      case Right(body) =>
-        // Parse BEFORE touching the session store: a malformed or non-initialize body must never
-        // mint a durable session (it used to — an unauthenticated memory leak).
-        MessageLoop.parseFrame(body) match
-          case Left(parseFailure) =>
-            ZIO.succeed(Response.json(parseFailure.toJson).status(Status.BadRequest))
-          case Right(message) =>
-            if isModernRequest(request, message) then modernPost(router, request, message, settings)
-            else
-              request.rawHeader(SessionIdHeader) match
-                case Some(id) =>
-                  store.get.map(_.get(id)).flatMap {
-                    case None =>
-                      ZIO.succeed(errorResponse(Status.NotFound, s"Session not found: $id"))
-                    case Some(session) =>
-                      session.touch *>
-                        respondStreamable(router, session, message, isNew = false, settings)
-                  }
-                case None if MessageLoop.isInitialize(message) =>
-                  for
-                    id <- JvmTransportBackend.randomId()
-                    session <- Session.make(id)
-                    _ <- store.update(_ + (session.sessionId -> session))
-                    resp <- respondStreamable(router, session, message, isNew = true, settings)
-                  yield resp
-                case None =>
-                  ZIO.succeed(
-                    errorResponse(
-                      Status.BadRequest,
-                      s"$SessionIdHeader header is required (only initialize may open a session)"
-                    )
-                  )
+    reply.headers.foldLeft(base) { case (resp, (name, value)) =>
+      resp.addHeader(Header.Custom(name, value))
     }
-
-  /** Dispatch one streamable POST frame. A *request* gets an SSE response that streams the
-    * notifications and sub-requests it emits (progress, sampling, elicitation) followed by its
-    * final JSON-RPC reply — one ordered stream, so a fire-and-forget notification can never race
-    * the reply across two HTTP streams. Notifications / client responses produce no reply (`202`);
-    * a parse error returns a single JSON error.
-    */
-  private def respondStreamable[R](
-      router: McpRouter[R],
-      session: Session,
-      message: JsonRpcMessage,
-      isNew: Boolean,
-      settings: McpServerSettings
-  ): URIO[R, Response] =
-    message match
-      case req: JsonRpcMessage.Request =>
-        streamRequest(router, session, req, isNew, settings)
-      case other =>
-        router.dispatch(session, other).map {
-          // Only structurally-Invalid frames produce a reply here (notifications and inbound
-          // responses are fire-and-forget): answer 400 with the router's -32600 body.
-          case Some(reply) =>
-            withSessionHeader(Response.json(reply.toJson).status(Status.BadRequest), session, isNew)
-          case None => Response.status(Status.Accepted)
-        }
-
-  /** Run a request's dispatch with its server→client messages routed to a per-request queue, and
-    * return an SSE response that emits each and ends right after the request's final reply.
-    */
-  private def streamRequest[R](
-      router: McpRouter[R],
-      session: Session,
-      message: JsonRpcMessage.Request,
-      isNew: Boolean,
-      settings: McpServerSettings,
-      modern: Boolean = false
-  ): URIO[R, Response] =
-    val reqId = message.id
-    for
-      reqQueue <- Queue.unbounded[JsonRpcMessage]
-      // `ensuring` (uninterruptible) offers the close sentinel after the dispatch delivers its
-      // reply — or after it is cancelled / dies replyless — so the SSE stream below always ends.
-      dispatchFiber <- session
-        .runWithSink(reqQueue)(router.dispatch(session, message))
-        .flatMap(reply => ZIO.foreachDiscard(reply)(reqQueue.offer))
-        .ensuring(reqQueue.offer(MessageLoop.CloseSentinel))
-        .forkDaemon
-      response <-
-        if modern then
-          reqQueue.take.onInterrupt(dispatchFiber.interrupt *> reqQueue.shutdown).flatMap { first =>
-            modernErrorStatus(first) match
-              case Some(status) =>
-                (dispatchFiber.interrupt *> reqQueue.shutdown).as(
-                  Response.json(first.toJson).status(status)
-                )
-              case None =>
-                ZIO.succeed(
-                  requestSseResponse(
-                    reqQueue,
-                    reqId,
-                    session,
-                    isNew,
-                    dispatchFiber,
-                    settings,
-                    modern = true,
-                    initial = List(first)
-                  )
-                )
-          }
-        else
-          ZIO.succeed(
-            requestSseResponse(
-              reqQueue,
-              reqId,
-              session,
-              isNew,
-              dispatchFiber,
-              settings,
-              modern = false
-            )
-          )
-    yield response
-
-  private def requestSseResponse(
-      reqQueue: Queue[JsonRpcMessage],
-      reqId: RequestId,
-      session: Session,
-      isNew: Boolean,
-      dispatchFiber: Fiber.Runtime[?, ?],
-      settings: McpServerSettings,
-      modern: Boolean,
-      initial: List[JsonRpcMessage] = Nil
-  ): Response =
-    val messages = ZStream.fromIterable(initial) ++ ZStream.fromQueue(reqQueue)
-    val sse: ZStream[Any, Nothing, ServerSentEvent[String]] =
-      messages
-        .takeUntil(msg => isFinalReply(msg, reqId) || MessageLoop.isCloseSentinel(msg))
-        .filter(!MessageLoop.isCloseSentinel(_))
-        .map(msg => ServerSentEvent(MessageLoop.encodeOutbound(msg), eventType = Some("message")))
-        // Runs on the normal end of stream too, not just client abort. Task fibers are safe: they
-        // are forked under Session.runWithoutSink (TaskRouting), so they never hold this queue.
-        .ensuring(dispatchFiber.interrupt *> reqQueue.shutdown)
-    val response = Response.fromServerSentEvents(withKeepAlive(sse, settings))
-    val unbuffered =
-      if modern then response.addHeader(Header.Custom("X-Accel-Buffering", "no")) else response
-    withSessionHeader(unbuffered, session, isNew)
-
-  private def modernErrorStatus(message: JsonRpcMessage): Option[Status] =
-    ModernHttpValidation.errorStatus(message).map(Status.fromInt)
-
-  /** Dispatch a 2026-07-28 request without consulting or mutating the legacy session store. */
-  private def modernPost[R](
-      router: McpRouter[R],
-      request: Request,
-      message: JsonRpcMessage,
-      settings: McpServerSettings
-  ): URIO[R, Response] =
-    message match
-      case req: JsonRpcMessage.Request =>
-        validateModernRequest(router, request, req) match
-          case Left((status, error)) =>
-            val failure: JsonRpcMessage =
-              JsonRpcMessage.Failure(Some(req.id), error.toErrorObject)
-            ZIO.succeed(
-              Response
-                .json(failure.toJson)
-                .status(status)
-            )
-          case Right(_) =>
-            Session.make(s"request-${req.id.toString}").flatMap { session =>
-              streamRequest(router, session, req, isNew = false, settings, modern = true)
-            }
-      case _: JsonRpcMessage.Invalid =>
-        val failure: JsonRpcMessage = JsonRpcMessage.Failure(
-          None,
-          McpError.invalidRequest("Invalid Request").toErrorObject
-        )
-        ZIO.succeed(
-          Response
-            .json(failure.toJson)
-            .status(Status.BadRequest)
-        )
-      case notification: JsonRpcMessage.Notification =>
-        validateModernNotification(router, request, notification) match
-          case Left((status, error)) =>
-            val failure: JsonRpcMessage = JsonRpcMessage.Failure(None, error.toErrorObject)
-            ZIO.succeed(Response.json(failure.toJson).status(status))
-          case Right(_) =>
-            Session
-              .make("notification")
-              .flatMap(session => router.dispatch(session, notification))
-              .as(Response.status(Status.Accepted))
-      case _ =>
-        val failure: JsonRpcMessage = JsonRpcMessage.Failure(
-          None,
-          McpError
-            .invalidRequest("HTTP POST bodies must be JSON-RPC requests or notifications")
-            .toErrorObject
-        )
-        ZIO.succeed(Response.json(failure.toJson).status(Status.BadRequest))
-
-  private def validateModernNotification[R](
-      router: McpRouter[R],
-      request: Request,
-      notification: JsonRpcMessage.Notification
-  ): Either[(Status, McpError), Unit] =
-    ModernHttpValidation
-      .validateNotification(router, notification, name => request.rawHeader(name))
-      .left
-      .map((code, err) => (Status.fromInt(code), err))
-
-  private def validateModernRequest[R](
-      router: McpRouter[R],
-      request: Request,
-      rpc: JsonRpcMessage.Request
-  ): Either[(Status, McpError), Unit] =
-    ModernHttpValidation
-      .validateRequest(router, rpc, name => request.rawHeader(name))
-      .left
-      .map((code, err) => (Status.fromInt(code), err))
-
-  private def isModernRequest(request: Request, message: JsonRpcMessage): Boolean =
-    ModernHttpValidation.isModern(name => request.rawHeader(name), message)
-
-  /** Merge a heartbeat into an SSE stream so proxies / idle timeouts don't kill long-quiet
-    * connections. The `ping` event type is ignored by conforming clients (the TS SDK only parses
-    * `message` events); zio-http 3.4.0 has no comment-frame support. Halts with the data stream.
-    */
-  private def withKeepAlive(
-      sse: ZStream[Any, Nothing, ServerSentEvent[String]],
-      settings: McpServerSettings
-  ): ZStream[Any, Nothing, ServerSentEvent[String]] =
-    settings.keepAliveInterval match
-      case None => sse
-      case Some(interval) =>
-        val pings = ZStream.repeatWithSchedule(
-          ServerSentEvent[String]("", eventType = Some("ping")),
-          Schedule.spaced(Duration.fromJava(interval))
-        )
-        sse.mergeHaltLeft(pings)
-
-  private def isFinalReply(message: JsonRpcMessage, reqId: RequestId): Boolean =
-    message match
-      case JsonRpcMessage.Success(id, _) => id == reqId
-      case JsonRpcMessage.Failure(Some(id), _) => id == reqId
-      case _ => false
-
-  private def withSessionHeader(resp: Response, session: Session, isNew: Boolean): Response =
-    if isNew then resp.addHeader(Header.Custom(SessionIdHeader, session.sessionId)) else resp
-
-  /** GET opens the server→client SSE channel for a session: each message offered to the session's
-    * outbound queue is emitted as an SSE `message` event. The stream ends when the session is
-    * `DELETE`d (queue shutdown) or the client disconnects.
-    */
-  private def handleStreamableGet(
-      store: Ref[Map[String, Session]],
-      request: Request,
-      settings: McpServerSettings
-  ): ZIO[Any, Nothing, Response] =
-    val allowedHosts = settings.allowedHosts.getOrElse(Set.empty)
-    hostError(request, allowedHosts) match
-      case Some(err) => ZIO.succeed(err)
-      case None if request.rawHeader("mcp-protocol-version").exists(Protocol.isStatelessVersion) =>
-        ZIO.succeed(Response.status(Status.MethodNotAllowed))
-      case None =>
-        getHeaderError(request, allowedHosts) match
-          case Some(err) => ZIO.succeed(err)
-          case None => streamableGetDispatch(store, request, settings)
-
-  private def streamableGetDispatch(
-      store: Ref[Map[String, Session]],
-      request: Request,
-      settings: McpServerSettings
-  ): ZIO[Any, Nothing, Response] =
-    request.rawHeader(SessionIdHeader) match
-      case None =>
-        ZIO.succeed(Response.status(Status.MethodNotAllowed))
-      case Some(id) =>
-        store.get.map(_.get(id)).flatMap {
-          case None => ZIO.succeed(errorResponse(Status.NotFound, s"Session not found: $id"))
-          case Some(session) =>
-            session.touch *> session.tryAcquireGet.map {
-              case false =>
-                // A live GET already drains this session's outbound queue; a second stream would
-                // round-robin-steal its messages (TS SDK answers 409 too).
-                errorResponse(Status.Conflict, "A GET SSE stream is already open for this session")
-              case true =>
-                val sse: ZStream[Any, Nothing, ServerSentEvent[String]] =
-                  ZStream
-                    .fromQueue(session.outbound)
-                    .map(msg =>
-                      ServerSentEvent(MessageLoop.encodeOutbound(msg), eventType = Some("message"))
-                    )
-                    .ensuring(session.releaseGet)
-                Response.fromServerSentEvents(withKeepAlive(sse, settings))
-            }
-        }
-
-  /** DELETE terminates a session: drop it from the store and shut down its outbound queue (which
-    * ends any open `GET` SSE stream). `405` when delete is disallowed by settings.
-    */
-  private def handleStreamableDelete(
-      store: Ref[Map[String, Session]],
-      request: Request,
-      disallowDelete: Boolean,
-      allowedHosts: Set[String]
-  ): ZIO[Any, Nothing, Response] =
-    hostError(request, allowedHosts) match
-      case Some(err) => ZIO.succeed(err)
-      case None if request.rawHeader("mcp-protocol-version").exists(Protocol.isStatelessVersion) =>
-        ZIO.succeed(Response.status(Status.MethodNotAllowed))
-      case None if disallowDelete => ZIO.succeed(Response.status(Status.MethodNotAllowed))
-      case None =>
-        request.rawHeader(SessionIdHeader) match
-          case None =>
-            ZIO.succeed(Response.status(Status.MethodNotAllowed))
-          case Some(id) =>
-            store.modify(sessions => (sessions.get(id), sessions - id)).flatMap {
-              case Some(session) => session.outbound.shutdown.as(Response.status(Status.Ok))
-              case None => ZIO.succeed(errorResponse(Status.NotFound, s"Session not found: $id"))
-            }
-
-  // --- Header validation (validate `Accept` + `mcp-protocol-version`; lenient when absent, so
-  // header-less clients still work while clearly-wrong headers are rejected per spec). ---
-
-  private def acceptsAny(req: Request, types: List[String]): Boolean =
-    req.rawHeader("accept") match
-      case None => true // absent Accept is treated as "accepts anything"
-      case Some(a) =>
-        val lower = a.toLowerCase
-        lower.contains("*/*") || types.exists(lower.contains)
-
-  /** `mcp-protocol-version` header validation. Absent ⇒ assume
-    * [[Protocol.DefaultNegotiatedProtocolVersion]] per the spec's backwards-compatibility rule
-    * (clients predating the header speak 2025-03-26); present ⇒ must be a supported version.
-    */
-  private def protocolVersionOk(req: Request): Boolean =
-    val declared = req
-      .rawHeader("mcp-protocol-version")
-      .getOrElse(Protocol.DefaultNegotiatedProtocolVersion)
-    Protocol.SupportedProtocolVersions.contains(declared)
-
-  /** Reject (403) when DNS-rebinding protection is on and the request's Host/Origin isn't allowed.
-    */
-  private def hostError(req: Request, allowedHosts: Set[String]): Option[Response] =
-    if HostGuard.isAllowed(req.rawHeader("host"), req.rawHeader("origin"), allowedHosts) then None
-    else Some(errorResponse(Status.Forbidden, "Host/Origin not allowed (DNS-rebinding protection)"))
-
-  /** POST guard: `Accept` (if present) must allow `application/json` — and on the streamable
-    * transport (`requireSse`) `text/event-stream` too, since request replies stream as SSE (spec
-    * requires clients to accept both).
-    *
-    * Note this guard does NOT check `mcp-protocol-version`: on POST the version travels in the
-    * initialize payload (legacy) or is validated by [[ModernHttpValidation]] (modern, `-32022`).
-    * The header itself is only enforced on the GET channel — see [[getHeaderError]].
-    */
-  private def postHeaderError(
-      req: Request,
-      allowedHosts: Set[String],
-      requireSse: Boolean
-  ): Option[Response] =
-    hostError(req, allowedHosts).orElse {
-      if !acceptsAny(req, List("application/json", "application/*")) then
-        Some(errorResponse(Status.NotAcceptable, "Accept must allow application/json"))
-      else if requireSse && !acceptsAny(req, List("text/event-stream", "text/*")) then
-        Some(errorResponse(Status.NotAcceptable, "Accept must allow text/event-stream"))
-      else None
-    }
-
-  /** GET guard (SSE channel): `Accept` (if present) must allow `text/event-stream`. */
-  private def getHeaderError(req: Request, allowedHosts: Set[String]): Option[Response] =
-    hostError(req, allowedHosts).orElse {
-      if !protocolVersionOk(req) then
-        Some(errorResponse(Status.BadRequest, "Unsupported mcp-protocol-version header"))
-      else if !acceptsAny(req, List("text/event-stream", "text/*")) then
-        Some(errorResponse(Status.NotAcceptable, "Accept must allow text/event-stream"))
-      else None
-    }
-
-  /** Transport-level rejection as a JSON-RPC error body (TS SDK parity — clients surface
-    * `error.message` uniformly instead of sniffing text/plain bodies).
-    */
-  private def errorResponse(status: Status, message: String): Response =
-    val code =
-      if status == Status.NotFound then ErrorCodes.SessionNotFound else ErrorCodes.TransportError
-    val failure: JsonRpcMessage =
-      JsonRpcMessage.Failure(None, McpError(code, message).toErrorObject)
-    Response.json(failure.toJson).status(status)
 
   /** The JVM HTTP seam, in the impl object so it's exportable. `ExportsJvm` re-exports this so
     * `import com.tjclp.fastmcp.*` puts an `HttpTransportBackend` in scope and `runHttp()` /

--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/transport/JvmSocketHttpBackend.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/transport/JvmSocketHttpBackend.scala
@@ -1,0 +1,28 @@
+package com.tjclp.fastmcp
+package server.transport
+
+/** The netty-free JVM [[HttpTransportBackend]]: the same `java.net.ServerSocket` server that is the
+  * Scala Native HTTP backend, with session ids from `java.util.UUID` (SecureRandom) via
+  * [[JvmTransportBackend]]. Behaviour on the wire matches [[JvmHttpBackend]] because both render
+  * the shared `StreamableHttpHandler`.
+  *
+  * This is an explicit opt-in — the root `import com.tjclp.fastmcp.{*, given}` keeps resolving
+  * [[JvmHttpBackend]] (ZIO HTTP / Netty), and this object deliberately carries no `given` so it can
+  * never make that import ambiguous. To use it, declare a given whose type is this object's
+  * singleton type, which beats the imported `HttpTransportBackend` on specificity:
+  *
+  * {{{
+  * import com.tjclp.fastmcp.{*, given}
+  * import com.tjclp.fastmcp.server.transport.JvmSocketHttpBackend
+  *
+  * given JvmSocketHttpBackend.type = JvmSocketHttpBackend
+  *
+  * object MyServer extends McpServerApp[Http, MyServer.type]:
+  *   @Tool() def add(a: Int, b: Int): Int = a + b
+  * }}}
+  *
+  * Pair it with excluding `dev.zio::zio-http` from your dependencies to drop Netty from the
+  * classpath entirely (and from GraalVM native images, where the seam split already keeps it
+  * unreachable for stdio-only programs).
+  */
+object JvmSocketHttpBackend extends SocketHttpBackend(JvmTransportBackend)

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/surface/JvmSocketHttpBackendSurfaceTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/surface/JvmSocketHttpBackendSurfaceTest.scala
@@ -1,0 +1,33 @@
+package com.tjclp.fastmcp.surface
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import com.tjclp.fastmcp.{given, *}
+import com.tjclp.fastmcp.server.transport.{HttpTransportBackend, JvmHttpBackend, JvmSocketHttpBackend}
+
+/** The JVM keeps ZIO HTTP (Netty) as its default `HttpTransportBackend`; the netty-free socket
+  * backend is an explicit opt-in. This pins both halves of that contract: the root import still
+  * resolves Netty, and the documented opt-in recipe (a given of the object's singleton type, which
+  * wins on specificity over the imported `HttpTransportBackend`) resolves the socket backend for
+  * `McpServerApp[Http]` without any ambiguity.
+  */
+class JvmSocketHttpBackendSurfaceTest extends AnyFunSuite:
+
+  test("the root import resolves the Netty backend by default") {
+    assert(summon[HttpTransportBackend] eq JvmHttpBackend)
+  }
+
+  test("the documented opt-in resolves the socket backend") {
+    assert(OptIn.resolved eq JvmSocketHttpBackend)
+    assert(OptIn.SocketApp.name == "SocketApp")
+  }
+
+  /** The recipe exactly as the README and `JvmSocketHttpBackend`'s scaladoc give it. */
+  object OptIn:
+    given JvmSocketHttpBackend.type = JvmSocketHttpBackend
+
+    val resolved: HttpTransportBackend = summon[HttpTransportBackend]
+
+    object SocketApp extends McpServerApp[Http, SocketApp.type]:
+      @Tool(name = Some("add"), description = Some("Add two numbers"))
+      def add(@Param("First") a: Int, @Param("Second") b: Int): Int = a + b

--- a/fast-mcp-scala/native/src/com/tjclp/fastmcp/ExportsNative.scala
+++ b/fast-mcp-scala/native/src/com/tjclp/fastmcp/ExportsNative.scala
@@ -2,10 +2,13 @@ package com.tjclp.fastmcp
 
 /** Scala Native additions to the shared export surface ([[com.tjclp.fastmcp.Exports]]).
   *
-  * The native module contributes exactly one thing the shared surface can't: the platform
-  * [[com.tjclp.fastmcp.server.transport.TransportBackend]] given (`System.in`/`System.out`). There
-  * is deliberately NO `HttpTransportBackend` — zio-http is not published for Scala Native — so
-  * `McpServerApp[Http]` programs fail to compile on this platform while `McpServerApp[Stdio]` works
-  * unchanged. Everything else — `McpServer`, codecs, schema derivation, macros — is shared.
+  * The native module contributes exactly two things the shared surface can't: the platform
+  * [[com.tjclp.fastmcp.server.transport.TransportBackend]] given (`System.in`/`System.out`) and the
+  * [[com.tjclp.fastmcp.server.transport.HttpTransportBackend]] given — the hand-rolled
+  * `java.net.ServerSocket` backend, since zio-http is not published for Scala Native. They are
+  * separate objects so stdio-only programs never reach the HTTP server stack (see
+  * `HttpTransportBackend`'s scaladoc). Everything else — `McpServer`, codecs, schema derivation,
+  * macros — is shared.
   */
 export server.transport.NativeTransportBackend.given
+export server.transport.NativeHttpBackend.given

--- a/fast-mcp-scala/native/src/com/tjclp/fastmcp/examples/conformance/ConformanceServerNative.scala
+++ b/fast-mcp-scala/native/src/com/tjclp/fastmcp/examples/conformance/ConformanceServerNative.scala
@@ -1,0 +1,32 @@
+package com.tjclp.fastmcp.examples.conformance
+
+import zio.*
+
+import com.tjclp.fastmcp.{*, given}
+
+/** Launches the cross-platform [[ConformanceServer]] over Scala Native streamable HTTP — the
+  * `java.net.ServerSocket` backend — for the official MCP conformance harness (`bunx
+  * \@modelcontextprotocol/conformance server --url …`). Held to the same empty baseline as the JVM:
+  * the two share every MCP decision through the shared handler, so any divergence is a socket-layer
+  * bug, never a new baseline.
+  *
+  * Port from `argv(0)` (default [[ConformanceServer.DefaultPort]]); binds `127.0.0.1` so the
+  * DNS-rebinding scenario's localhost gate engages.
+  *
+  * Linked by `./mill fast-mcp-scala.scalaNative.conformanceLink` and driven by
+  * `scripts/conformance.sh scala-native`.
+  */
+object ConformanceServerNative extends ZIOAppDefault:
+
+  override def run =
+    for
+      args <- getArgs
+      port = args.headOption.flatMap(_.toIntOption).getOrElse(ConformanceServer.DefaultPort)
+      server = McpServer(
+        ConformanceServer.Name,
+        ConformanceServer.Version,
+        ConformanceServer.settings(port)
+      )
+      _ <- ConformanceServer.register(server)
+      _ <- server.runHttp()
+    yield ()

--- a/fast-mcp-scala/native/src/com/tjclp/fastmcp/server/transport/NativeHttpBackend.scala
+++ b/fast-mcp-scala/native/src/com/tjclp/fastmcp/server/transport/NativeHttpBackend.scala
@@ -1,0 +1,21 @@
+package com.tjclp.fastmcp
+package server.transport
+
+/** Scala Native [[HttpTransportBackend]] — streamable HTTP over `java.net.ServerSocket`
+  * ([[SocketHttpBackend]]) with session ids from `/dev/urandom` via [[NativeTransportBackend]].
+  * zio-http has no Scala Native artifacts (upstream support is 4.x-milestoned, zio-http#2526), so
+  * this hand-rolled backend is what makes `McpServerApp[Http]` and `runHttp()` compile and link on
+  * this platform. Plaintext HTTP/1.1 only (`javax.net.ssl` is absent from the javalib): terminate
+  * TLS at a proxy.
+  *
+  * ZIO signal handlers and shutdown hooks are silent no-ops on Scala Native, so a long-running
+  * listener has no graceful SIGTERM path: the OS default action ends the process, which is fine for
+  * a stateless-on-the-wire MCP server.
+  */
+object NativeHttpBackend extends SocketHttpBackend(NativeTransportBackend):
+
+  /** The Scala Native HTTP seam, in the impl object so it's exportable. `ExportsNative` re-exports
+    * this so `import com.tjclp.fastmcp.*` puts an `HttpTransportBackend` in scope and `runHttp()` /
+    * `McpServerApp[Http, ...]` resolve.
+    */
+  given httpInstance: HttpTransportBackend = this

--- a/fast-mcp-scala/native/src/com/tjclp/fastmcp/server/transport/NativeTransportBackend.scala
+++ b/fast-mcp-scala/native/src/com/tjclp/fastmcp/server/transport/NativeTransportBackend.scala
@@ -10,10 +10,8 @@ import com.tjclp.fastmcp.server.McpServerSettings
 import com.tjclp.fastmcp.server.router.McpRouter
 
 /** Scala Native [[TransportBackend]] — pure ZIO over `System.in`/`System.out`, compiled to a
-  * standalone binary via LLVM. Stdio only: zio-http is not published for Scala Native, so this
-  * platform provides no [[HttpTransportBackend]] given and `McpServerApp[Http]` programs fail to
-  * compile at the declaration site (by design — the same seam that keeps netty out of GraalVM stdio
-  * images).
+  * standalone binary via LLVM. The HTTP half of the seam is [[NativeHttpBackend]]: zio-http is not
+  * published for Scala Native, so streamable HTTP runs on the hand-rolled socket backend instead.
   *
   * The serving lifecycle is shared with the JVM ([[StdioLoop]]); only the two pieces that genuinely
   * differ on this platform live here:

--- a/fast-mcp-scala/native/test/src/com/tjclp/fastmcp/surface/NativeHttpSurfaceTest.scala
+++ b/fast-mcp-scala/native/test/src/com/tjclp/fastmcp/surface/NativeHttpSurfaceTest.scala
@@ -1,0 +1,35 @@
+package com.tjclp.fastmcp.surface
+
+import org.scalatest.funsuite.AnyFunSuite
+import zio.*
+
+import com.tjclp.fastmcp.{given, *}
+import com.tjclp.fastmcp.server.transport.{HttpTransportBackend, NativeHttpBackend}
+
+/** The Scala Native HTTP surface: with the root import, `McpServerApp[Http]` now compiles and
+  * resolves the `java.net.ServerSocket` backend (before #81 it failed at the declaration site by
+  * design — zio-http has no Native artifacts). Compile-time resolution is the contract; building
+  * the core proves the wiring without binding a port.
+  */
+class NativeHttpSurfaceTest extends AnyFunSuite:
+
+  object HttpApp extends McpServerApp[Http, HttpApp.type]:
+    override def settings: McpServerSettings = McpServerSettings(port = 0)
+
+    @Tool(name = Some("add"), description = Some("Add two numbers"))
+    def add(@Param("First") a: Int, @Param("Second") b: Int): Int = a + b
+
+  private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
+    Unsafe.unsafe { implicit unsafe =>
+      Runtime.default.unsafe.run(effect).getOrThrowFiberFailure()
+    }
+
+  test("the root import resolves the socket backend as the HttpTransportBackend") {
+    assert(summon[HttpTransportBackend] eq NativeHttpBackend)
+  }
+
+  test("McpServerApp[Http] compiles and builds its core on Scala Native") {
+    assert(HttpApp.name == "HttpApp")
+    runUnsafe(HttpApp.buildCore.unit)
+    succeed
+  }

--- a/fast-mcp-scala/package.mill
+++ b/fast-mcp-scala/package.mill
@@ -11,8 +11,8 @@ import mill.scalajslib._
 import mill.scalajslib.api._
 import mill.scalajslib.bun._
 import mill.scalanativelib._
-import build.{BuildConfig, FastMCPModule, FastMCPPublishingBase, FastMCPTestModule, Versions,
-  scala3Version}
+import build.{BuildConfig, CrossPlatformTests, FastMCPModule, FastMCPPublishingBase,
+  FastMCPTestModule, Versions, scala3Version}
 
 // Namespace module. Aggregate tasks at this level fan out to all three platform children so
 // `./mill fast-mcp-scala.compile` and `./mill fast-mcp-scala.test` cover the whole project
@@ -53,8 +53,14 @@ object `package` extends Module {
 
   object jvm extends FastMCPModule {
 
-    // JVM module reads from both shared/ and jvm/src/ (its own JVM-specific code)
-    override def sources = Task.Sources(moduleDir / "src", moduleDir / os.up / "shared" / "src")
+    // JVM module reads from shared/ (the MCP core), jvm/src/ (ZIO HTTP + System.in/out), and
+    // jvm-native/src/ (the socket HTTP layer shared with Scala Native — it must satisfy the JVM
+    // WartRemover tiers, which is why it is compiled here under the full flag set).
+    override def sources = Task.Sources(
+      moduleDir / "src",
+      moduleDir / os.up / "shared" / "src",
+      moduleDir / os.up / "jvm-native" / "src"
+    )
 
     override def mvnDeps = Seq(
       // ZIO Core
@@ -64,7 +70,9 @@ object `package` extends Module {
       mvn"dev.zio::zio-http:${Versions.zioHttp}"
     )
 
-    object test extends ScalaTests with FastMCPTestModule {
+    // jvm/test/src plus the socket-HTTP tests in jvm-native/test/src (CrossPlatformTests), which the
+    // Scala Native test module compiles too — the same suite runs on both platforms.
+    object test extends ScalaTests with FastMCPTestModule with CrossPlatformTests {
       override def mvnDeps = Seq(
         mvn"org.scalatest::scalatest:${Versions.scalaTest}",
         mvn"org.scalacheck::scalacheck:${Versions.scalaCheck}",
@@ -143,12 +151,11 @@ object `package` extends Module {
     }
   }
 
-  // Scala Native target (EXPERIMENTAL) — stdio transport over System.in/System.out compiled to
-  // a standalone binary via LLVM. HTTP is excluded BY DESIGN: zio-http is not published for
-  // Scala Native (upstream support is 4.x-milestoned, zio-http#2526), so this module provides
-  // only the `TransportBackend` given; `McpServerApp[Stdio]` programs compile and link while
-  // `McpServerApp[Http]` fails at the user's declaration site — the same seam that keeps netty
-  // out of GraalVM stdio images. Cross-published as `com.tjclp:fast-mcp-scala_native0.5_3`.
+  // Scala Native target (EXPERIMENTAL) — stdio over System.in/System.out plus streamable HTTP
+  // over java.net.ServerSocket (jvm-native/), compiled to a standalone binary via LLVM. zio-http
+  // is not published for Scala Native (upstream support is 4.x-milestoned, zio-http#2526), so
+  // the HTTP given here is the hand-rolled socket backend around the shared
+  // StreamableHttpHandler. Cross-published as `com.tjclp:fast-mcp-scala_native0.5_3`.
   object scalaNative extends ScalaNativeModule with ScalafmtModule with FastMCPPublishingBase {
     def scalaVersion = scala3Version
     def scalaNativeVersion = Versions.scalaNative
@@ -157,9 +164,14 @@ object `package` extends Module {
     // nativeSmoke pipeline); the source directory follows the jvm/js sibling convention.
     override def moduleDir = super.moduleDir / os.up / "native"
 
-    // Native module reads from native/src/ (the stdio backend) and shared/ — which carries the
-    // whole MCP core, the schema-derivation macros, and the platform-pure examples.
-    override def sources = Task.Sources(moduleDir / "src", moduleDir / os.up / "shared" / "src")
+    // Native module reads from native/src/ (the platform backends), shared/ — the whole MCP core,
+    // the schema-derivation macros, and the platform-pure examples — and jvm-native/src/ (the
+    // socket HTTP layer shared with the JVM).
+    override def sources = Task.Sources(
+      moduleDir / "src",
+      moduleDir / os.up / "shared" / "src",
+      moduleDir / os.up / "jvm-native" / "src"
+    )
 
     // `::` resolves the _native0.5_3 artifacts. zio-json transitively brings
     // io.github.cquiroz:scala-java-time (compile scope), which links the java.time.Duration
@@ -176,7 +188,10 @@ object `package` extends Module {
     // WartRemover is a JVM-only compiler plugin (same rationale as the js module).
     override def scalacOptions = BuildConfig.crossScalacOptions
 
-    object test extends ScalaNativeTests with TestModule.ScalaTest {
+    // native/test/src plus the socket-HTTP tests shared with the JVM test module
+    // (CrossPlatformTests) — running them inside the linked native test binary is what proves the
+    // socket layer on SN's threads.
+    object test extends ScalaNativeTests with TestModule.ScalaTest with CrossPlatformTests {
       override def mvnDeps = Seq(
         mvn"org.scalatest::scalatest::${Versions.scalaTest}"
       )

--- a/fast-mcp-scala/package.mill
+++ b/fast-mcp-scala/package.mill
@@ -185,6 +185,14 @@ object `package` extends Module {
     // one scripts/native-smoke.sh drives in CI.
     override def mainClass = Some("com.tjclp.fastmcp.examples.AnnotatedServer")
 
+    /** The HTTP conformance binary (`scripts/conformance.sh scala-native`): this module's compiled
+      * NIR re-linked with `ConformanceServerNative` as the entry point — no second module, nothing
+      * published. Debug mode like `nativeLink`; `SCALANATIVE_MODE=release-fast` switches both.
+      */
+    def conformanceLink: T[PathRef] = Task {
+      nativeLinkOtherMain("com.tjclp.fastmcp.examples.conformance.ConformanceServerNative")()
+    }
+
     // WartRemover is a JVM-only compiler plugin (same rationale as the js module).
     override def scalacOptions = BuildConfig.crossScalacOptions
 

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/http/HttpModel.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/http/HttpModel.scala
@@ -1,0 +1,80 @@
+package com.tjclp.fastmcp
+package server.transport.http
+
+import zio.*
+import zio.stream.*
+
+import com.tjclp.fastmcp.jsonrpc.JsonRpcMessage
+import com.tjclp.fastmcp.server.transport.MessageLoop
+
+/** The platform-neutral view of one HTTP request that [[StreamableHttpHandler]] consumes. Each HTTP
+  * backend adapts its own request type into this (zio-http `Request`, a parsed socket request, …)
+  * so the streamable-HTTP MCP semantics are written exactly once.
+  *
+  * @param method
+  *   upper-case HTTP method token (`POST`, `GET`, `DELETE`, …)
+  * @param path
+  *   the request-target path with any query string stripped
+  * @param header
+  *   case-insensitive header lookup by name, first value wins (the same seam
+  *   [[com.tjclp.fastmcp.server.transport.ModernHttpValidation]] already uses)
+  * @param body
+  *   reads the request body as UTF-8 text; failures surface as a `400` transport error
+  */
+private[fastmcp] final case class HttpRequest(
+    method: String,
+    path: String,
+    header: String => Option[String],
+    body: IO[Throwable, String]
+)
+
+/** One server-sent event: an optional `event:` type and the `data:` payload. */
+private[fastmcp] final case class SseFrame(event: Option[String], data: String):
+
+  /** Wire form per the SSE spec: `event: <type>` (when present), one `data:` line per payload line,
+    * then the blank line that dispatches the event. Mirrors zio-http's `ServerSentEvent` encoding
+    * so the socket and Netty backends emit identical bytes.
+    */
+  def encode: String =
+    val sb = new StringBuilder
+    event.foreach(e => sb.append("event: ").append(e).append('\n'))
+    // `linesIterator` yields nothing for "", so an empty payload produces no data line — exactly
+    // what zio-http emits for its keepalive ping.
+    data.linesIterator.foreach(line => sb.append("data: ").append(line).append('\n'))
+    sb.append('\n')
+    sb.toString
+
+private[fastmcp] object SseFrame:
+
+  /** A JSON-RPC message as the `message` event every MCP client parses. */
+  def message(m: JsonRpcMessage): SseFrame =
+    SseFrame(Some("message"), MessageLoop.encodeOutbound(m))
+
+  /** Keepalive heartbeat. The `ping` event type is ignored by conforming clients (the TS SDK only
+    * parses `message` events).
+    */
+  val Ping: SseFrame = SseFrame(Some("ping"), "")
+
+/** The platform-neutral reply [[StreamableHttpHandler]] produces. Backends render it onto their own
+  * response type. Header names are given in their canonical wire form; HTTP header matching is
+  * case-insensitive.
+  */
+private[fastmcp] sealed trait HttpReply:
+  def status: Int
+  def headers: List[(String, String)]
+
+private[fastmcp] object HttpReply:
+
+  /** Headers only — `202 Accepted`, `405`, `200` on DELETE, … */
+  final case class Empty(status: Int, headers: List[(String, String)] = Nil) extends HttpReply
+
+  /** An `application/json` body (a JSON-RPC reply or a transport-level JSON-RPC error). */
+  final case class Json(status: Int, body: String, headers: List[(String, String)] = Nil)
+      extends HttpReply
+
+  /** A `200 text/event-stream` response whose body is the frame stream; the response ends when the
+    * stream does (or the client disconnects, which runs the stream's finalizers).
+    */
+  final case class Sse(headers: List[(String, String)], frames: ZStream[Any, Nothing, SseFrame])
+      extends HttpReply:
+    def status: Int = 200

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/http/StreamableHttpHandler.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/http/StreamableHttpHandler.scala
@@ -1,0 +1,462 @@
+package com.tjclp.fastmcp
+package server.transport.http
+
+import zio.*
+import zio.json.*
+import zio.stream.*
+
+import com.tjclp.fastmcp.core.{ErrorCodes, Protocol}
+import com.tjclp.fastmcp.jsonrpc.{JsonRpcMessage, McpError, RequestId}
+import com.tjclp.fastmcp.server.McpServerSettings
+import com.tjclp.fastmcp.server.router.{McpRouter, Session}
+import com.tjclp.fastmcp.server.transport.{HostGuard, MessageLoop, ModernHttpValidation}
+
+/** The streamable-HTTP MCP semantics, written once against the platform-neutral [[HttpRequest]] /
+  * [[HttpReply]] model: the session store and its idle sweeper, the rule that only `initialize` may
+  * mint a session, request replies streamed as SSE with the request's own server→client messages,
+  * the standalone GET push channel, DELETE termination, the 2026-07-28 stateless path, and the
+  * transport-level JSON-RPC error bodies (TS SDK parity).
+  *
+  * Backends are thin adapters: they turn their request type into an [[HttpRequest]], call [[post]]
+  * / [[get]] / [[delete]] (or [[handle]] when they also delegate method/path routing), render the
+  * [[HttpReply]], and fork [[evictIdleSessions]] for the server's lifetime.
+  *
+  * MCP 2026-07-28 always uses one ephemeral request context per POST and an optional request-scoped
+  * SSE response. `settings.stateless` selects whether the older initialize/session/GET/DELETE
+  * compatibility adapter is sessionless or durable; it does not make modern calls stateful.
+  */
+private[fastmcp] final class StreamableHttpHandler[R] private (
+    router: McpRouter[R],
+    settings: McpServerSettings,
+    randomId: UIO[String],
+    // `None` iff `settings.stateless`: the legacy adapter then has no durable sessions at all.
+    store: Option[Ref[Map[String, Session]]]
+):
+  import StreamableHttpHandler.*
+
+  /** The MCP endpoint path, always with a leading slash (`/mcp` by default). */
+  val endpoint: String = "/" + settings.httpEndpoint.stripPrefix("/")
+
+  private val allowedHosts: Set[String] = settings.allowedHosts.getOrElse(Set.empty)
+
+  /** Full routing for backends without their own router: anything off the endpoint is `404`,
+    * methods other than POST/GET/DELETE are `405`.
+    */
+  def handle(req: HttpRequest): URIO[R, HttpReply] =
+    if req.path.stripSuffix("/") != endpoint.stripSuffix("/") then ZIO.succeed(HttpReply.Empty(404))
+    else
+      req.method match
+        case "POST" => post(req)
+        case "GET" => get(req)
+        case "DELETE" => delete(req)
+        case _ => ZIO.succeed(HttpReply.Empty(405, List("allow" -> "POST, GET, DELETE")))
+
+  /** POST: one JSON-RPC frame.
+    *
+    * Stateless: a fresh ephemeral session per request, a single JSON reply (or `202` for a
+    * notification). Streamable: no `mcp-session-id` header → must be the opening `initialize` (mint
+    * a session, echo the id back); with the header → look up the durable session (`404` if unknown)
+    * and dispatch in its context. A *request* gets an SSE response streaming the notifications and
+    * sub-requests it emits followed by its final reply; notifications / client responses get `202`.
+    */
+  def post(req: HttpRequest): URIO[R, HttpReply] =
+    store match
+      case None =>
+        postHeaderError(req, requireSse = false) match
+          case Some(err) => ZIO.succeed(err)
+          case None => statelessDispatch(req)
+      case Some(sessions) =>
+        postHeaderError(req, requireSse = true) match
+          case Some(err) => ZIO.succeed(err)
+          case None => streamablePostDispatch(sessions, req)
+
+  /** GET opens the server→client SSE channel for a session: each message offered to the session's
+    * outbound queue is emitted as an SSE `message` event. The stream ends when the session is
+    * `DELETE`d (queue shutdown) or the client disconnects. `405` on the stateless adapter and for
+    * 2026-07-28 clients (which have no session to stream).
+    */
+  def get(req: HttpRequest): UIO[HttpReply] =
+    store match
+      case None => ZIO.succeed(HttpReply.Empty(405))
+      case Some(sessions) =>
+        hostError(req) match
+          case Some(err) => ZIO.succeed(err)
+          case None if req.header("mcp-protocol-version").exists(Protocol.isStatelessVersion) =>
+            ZIO.succeed(HttpReply.Empty(405))
+          case None =>
+            getHeaderError(req) match
+              case Some(err) => ZIO.succeed(err)
+              case None => streamableGetDispatch(sessions, req)
+
+  /** DELETE terminates a session: drop it from the store and shut down its outbound queue (which
+    * ends any open GET SSE stream). `405` when delete is disallowed by settings, on the stateless
+    * adapter, or for 2026-07-28 clients.
+    */
+  def delete(req: HttpRequest): UIO[HttpReply] =
+    store match
+      case None => ZIO.succeed(HttpReply.Empty(405))
+      case Some(sessions) =>
+        hostError(req) match
+          case Some(err) => ZIO.succeed(err)
+          case None if req.header("mcp-protocol-version").exists(Protocol.isStatelessVersion) =>
+            ZIO.succeed(HttpReply.Empty(405))
+          case None if settings.disallowDelete => ZIO.succeed(HttpReply.Empty(405))
+          case None =>
+            req.header(SessionIdHeader) match
+              case None => ZIO.succeed(HttpReply.Empty(405))
+              case Some(id) =>
+                sessions.modify(all => (all.get(id), all - id)).flatMap {
+                  case Some(session) => session.outbound.shutdown.as(HttpReply.Empty(200))
+                  case None => ZIO.succeed(transportError(404, s"Session not found: $id"))
+                }
+
+  /** The idle-session sweeper for this handler's store — a no-op on the stateless adapter. Fork it
+    * scoped to the server's lifetime (never per request).
+    */
+  def evictIdleSessions: UIO[Unit] =
+    store match
+      case None => ZIO.unit
+      case Some(sessions) => StreamableHttpHandler.evictIdleSessions(sessions, settings)
+
+  // ---------------------------------------------------------------------------
+  // Stateless: request/response, no session state, no SSE.
+  // ---------------------------------------------------------------------------
+
+  private def statelessDispatch(req: HttpRequest): URIO[R, HttpReply] =
+    val effect =
+      for
+        body <- req.body.mapError(e => Option(e.getMessage).getOrElse("body read error"))
+        resp <- MessageLoop.parseFrame(body) match
+          case Left(parseFailure) =>
+            ZIO.succeed(HttpReply.Json(400, parseFailure.toJson))
+          case Right(message) =>
+            if isModernRequest(req, message) then modernPost(req, message)
+            else
+              for
+                session <- Session.make("stateless", supportsTasks = false)
+                // Legacy stateless compatibility mode starts ready without a handshake.
+                _ <- session.markInitialized
+                reply <- router.dispatch(session, message)
+              yield (message, reply) match
+                case (_: JsonRpcMessage.Invalid, Some(r)) => HttpReply.Json(400, r.toJson)
+                case (_, Some(r)) => HttpReply.Json(200, r.toJson)
+                case (_, None) => HttpReply.Empty(202)
+      yield resp
+    effect.catchAll(msg => ZIO.succeed(transportError(400, msg)))
+
+  // ---------------------------------------------------------------------------
+  // Streamable: durable sessions + SSE server-push + DELETE termination.
+  // ---------------------------------------------------------------------------
+
+  private def streamablePostDispatch(
+      sessions: Ref[Map[String, Session]],
+      req: HttpRequest
+  ): URIO[R, HttpReply] =
+    req.body.either.flatMap {
+      case Left(err) =>
+        ZIO.succeed(transportError(400, Option(err.getMessage).getOrElse("body read error")))
+      case Right(body) =>
+        // Parse BEFORE touching the session store: a malformed or non-initialize body must never
+        // mint a durable session (it used to — an unauthenticated memory leak).
+        MessageLoop.parseFrame(body) match
+          case Left(parseFailure) =>
+            ZIO.succeed(HttpReply.Json(400, parseFailure.toJson))
+          case Right(message) =>
+            if isModernRequest(req, message) then modernPost(req, message)
+            else
+              req.header(SessionIdHeader) match
+                case Some(id) =>
+                  sessions.get.map(_.get(id)).flatMap {
+                    case None =>
+                      ZIO.succeed(transportError(404, s"Session not found: $id"))
+                    case Some(session) =>
+                      session.touch *> respondStreamable(session, message, isNew = false)
+                  }
+                case None if MessageLoop.isInitialize(message) =>
+                  for
+                    id <- randomId
+                    session <- Session.make(id)
+                    _ <- sessions.update(_ + (session.sessionId -> session))
+                    resp <- respondStreamable(session, message, isNew = true)
+                  yield resp
+                case None =>
+                  ZIO.succeed(
+                    transportError(
+                      400,
+                      s"$SessionIdHeader header is required (only initialize may open a session)"
+                    )
+                  )
+    }
+
+  /** Dispatch one streamable POST frame. A *request* gets an SSE response that streams the
+    * notifications and sub-requests it emits (progress, sampling, elicitation) followed by its
+    * final JSON-RPC reply — one ordered stream, so a fire-and-forget notification can never race
+    * the reply across two HTTP streams. Notifications / client responses produce no reply (`202`);
+    * a parse error returns a single JSON error.
+    */
+  private def respondStreamable(
+      session: Session,
+      message: JsonRpcMessage,
+      isNew: Boolean
+  ): URIO[R, HttpReply] =
+    message match
+      case rpc: JsonRpcMessage.Request =>
+        streamRequest(session, rpc, isNew, modern = false)
+      case other =>
+        router.dispatch(session, other).map {
+          // Only structurally-Invalid frames produce a reply here (notifications and inbound
+          // responses are fire-and-forget): answer 400 with the router's -32600 body.
+          case Some(reply) => HttpReply.Json(400, reply.toJson, sessionHeader(session, isNew))
+          case None => HttpReply.Empty(202)
+        }
+
+  /** Run a request's dispatch with its server→client messages routed to a per-request queue, and
+    * return an SSE reply that emits each and ends right after the request's final reply.
+    */
+  private def streamRequest(
+      session: Session,
+      message: JsonRpcMessage.Request,
+      isNew: Boolean,
+      modern: Boolean
+  ): URIO[R, HttpReply] =
+    val reqId = message.id
+    for
+      reqQueue <- Queue.unbounded[JsonRpcMessage]
+      // `ensuring` (uninterruptible) offers the close sentinel after the dispatch delivers its
+      // reply — or after it is cancelled / dies replyless — so the SSE stream below always ends.
+      dispatchFiber <- session
+        .runWithSink(reqQueue)(router.dispatch(session, message))
+        .flatMap(reply => ZIO.foreachDiscard(reply)(reqQueue.offer))
+        .ensuring(reqQueue.offer(MessageLoop.CloseSentinel))
+        .forkDaemon
+      response <-
+        if modern then
+          reqQueue.take.onInterrupt(dispatchFiber.interrupt *> reqQueue.shutdown).flatMap { first =>
+            ModernHttpValidation.errorStatus(first) match
+              case Some(status) =>
+                (dispatchFiber.interrupt *> reqQueue.shutdown)
+                  .as(HttpReply.Json(status, first.toJson))
+              case None =>
+                ZIO.succeed(
+                  requestSse(reqQueue, reqId, session, isNew, dispatchFiber, modern, List(first))
+                )
+          }
+        else ZIO.succeed(requestSse(reqQueue, reqId, session, isNew, dispatchFiber, modern, Nil))
+    yield response
+
+  private def requestSse(
+      reqQueue: Queue[JsonRpcMessage],
+      reqId: RequestId,
+      session: Session,
+      isNew: Boolean,
+      dispatchFiber: Fiber.Runtime[?, ?],
+      modern: Boolean,
+      initial: List[JsonRpcMessage]
+  ): HttpReply =
+    val messages = ZStream.fromIterable(initial) ++ ZStream.fromQueue(reqQueue)
+    val frames: ZStream[Any, Nothing, SseFrame] =
+      messages
+        .takeUntil(msg => isFinalReply(msg, reqId) || MessageLoop.isCloseSentinel(msg))
+        .filter(!MessageLoop.isCloseSentinel(_))
+        .map(SseFrame.message)
+        // Runs on the normal end of stream too, not just client abort. Task fibers are safe: they
+        // are forked under Session.runWithoutSink (TaskRouting), so they never hold this queue.
+        .ensuring(dispatchFiber.interrupt *> reqQueue.shutdown)
+    val unbuffered = if modern then List("X-Accel-Buffering" -> "no") else Nil
+    HttpReply.Sse(unbuffered ++ sessionHeader(session, isNew), withKeepAlive(frames))
+
+  /** Dispatch a 2026-07-28 request without consulting or mutating the legacy session store. */
+  private def modernPost(req: HttpRequest, message: JsonRpcMessage): URIO[R, HttpReply] =
+    message match
+      case rpc: JsonRpcMessage.Request =>
+        ModernHttpValidation.validateRequest(router, rpc, req.header) match
+          case Left((status, error)) =>
+            val failure: JsonRpcMessage =
+              JsonRpcMessage.Failure(Some(rpc.id), error.toErrorObject)
+            ZIO.succeed(HttpReply.Json(status, failure.toJson))
+          case Right(_) =>
+            Session.make(s"request-${rpc.id.toString}").flatMap { session =>
+              streamRequest(session, rpc, isNew = false, modern = true)
+            }
+      case _: JsonRpcMessage.Invalid =>
+        val failure: JsonRpcMessage = JsonRpcMessage.Failure(
+          None,
+          McpError.invalidRequest("Invalid Request").toErrorObject
+        )
+        ZIO.succeed(HttpReply.Json(400, failure.toJson))
+      case notification: JsonRpcMessage.Notification =>
+        ModernHttpValidation.validateNotification(router, notification, req.header) match
+          case Left((status, error)) =>
+            val failure: JsonRpcMessage = JsonRpcMessage.Failure(None, error.toErrorObject)
+            ZIO.succeed(HttpReply.Json(status, failure.toJson))
+          case Right(_) =>
+            Session
+              .make("notification")
+              .flatMap(session => router.dispatch(session, notification))
+              .as(HttpReply.Empty(202))
+      case _ =>
+        val failure: JsonRpcMessage = JsonRpcMessage.Failure(
+          None,
+          McpError
+            .invalidRequest("HTTP POST bodies must be JSON-RPC requests or notifications")
+            .toErrorObject
+        )
+        ZIO.succeed(HttpReply.Json(400, failure.toJson))
+
+  private def isModernRequest(req: HttpRequest, message: JsonRpcMessage): Boolean =
+    ModernHttpValidation.isModern(req.header, message)
+
+  /** Merge a heartbeat into an SSE stream so proxies / idle timeouts don't kill long-quiet
+    * connections. Halts with the data stream.
+    */
+  private def withKeepAlive(
+      frames: ZStream[Any, Nothing, SseFrame]
+  ): ZStream[Any, Nothing, SseFrame] =
+    settings.keepAliveInterval match
+      case None => frames
+      case Some(interval) =>
+        val pings =
+          ZStream.repeatWithSchedule(SseFrame.Ping, Schedule.spaced(Duration.fromJava(interval)))
+        frames.mergeHaltLeft(pings)
+
+  private def isFinalReply(message: JsonRpcMessage, reqId: RequestId): Boolean =
+    message match
+      case JsonRpcMessage.Success(id, _) => id == reqId
+      case JsonRpcMessage.Failure(Some(id), _) => id == reqId
+      case _ => false
+
+  private def sessionHeader(session: Session, isNew: Boolean): List[(String, String)] =
+    if isNew then List(SessionIdHeader -> session.sessionId) else Nil
+
+  private def streamableGetDispatch(
+      sessions: Ref[Map[String, Session]],
+      req: HttpRequest
+  ): UIO[HttpReply] =
+    req.header(SessionIdHeader) match
+      case None => ZIO.succeed(HttpReply.Empty(405))
+      case Some(id) =>
+        sessions.get.map(_.get(id)).flatMap {
+          case None => ZIO.succeed(transportError(404, s"Session not found: $id"))
+          case Some(session) =>
+            session.touch *> session.tryAcquireGet.map {
+              case false =>
+                // A live GET already drains this session's outbound queue; a second stream would
+                // round-robin-steal its messages (TS SDK answers 409 too).
+                transportError(409, "A GET SSE stream is already open for this session")
+              case true =>
+                val frames = ZStream
+                  .fromQueue(session.outbound)
+                  .map(SseFrame.message)
+                  .ensuring(session.releaseGet)
+                HttpReply.Sse(Nil, withKeepAlive(frames))
+            }
+        }
+
+  // --- Header validation (validate `Accept` + `mcp-protocol-version`; lenient when absent, so
+  // header-less clients still work while clearly-wrong headers are rejected per spec). ---
+
+  private def acceptsAny(req: HttpRequest, types: List[String]): Boolean =
+    req.header("accept") match
+      case None => true // absent Accept is treated as "accepts anything"
+      case Some(a) =>
+        val lower = a.toLowerCase
+        lower.contains("*/*") || types.exists(lower.contains)
+
+  /** `mcp-protocol-version` header validation. Absent ⇒ assume
+    * [[Protocol.DefaultNegotiatedProtocolVersion]] per the spec's backwards-compatibility rule
+    * (clients predating the header speak 2025-03-26); present ⇒ must be a supported version.
+    */
+  private def protocolVersionOk(req: HttpRequest): Boolean =
+    val declared =
+      req.header("mcp-protocol-version").getOrElse(Protocol.DefaultNegotiatedProtocolVersion)
+    Protocol.SupportedProtocolVersions.contains(declared)
+
+  /** Reject (403) when DNS-rebinding protection is on and the request's Host/Origin isn't allowed.
+    */
+  private def hostError(req: HttpRequest): Option[HttpReply] =
+    if HostGuard.isAllowed(req.header("host"), req.header("origin"), allowedHosts) then None
+    else Some(transportError(403, "Host/Origin not allowed (DNS-rebinding protection)"))
+
+  /** POST guard: `Accept` (if present) must allow `application/json` — and on the streamable
+    * transport (`requireSse`) `text/event-stream` too, since request replies stream as SSE (spec
+    * requires clients to accept both).
+    *
+    * Note this guard does NOT check `mcp-protocol-version`: on POST the version travels in the
+    * initialize payload (legacy) or is validated by [[ModernHttpValidation]] (modern, `-32022`).
+    * The header itself is only enforced on the GET channel — see [[getHeaderError]].
+    */
+  private def postHeaderError(req: HttpRequest, requireSse: Boolean): Option[HttpReply] =
+    hostError(req).orElse {
+      if !acceptsAny(req, List("application/json", "application/*")) then
+        Some(transportError(406, "Accept must allow application/json"))
+      else if requireSse && !acceptsAny(req, List("text/event-stream", "text/*")) then
+        Some(transportError(406, "Accept must allow text/event-stream"))
+      else None
+    }
+
+  /** GET guard (SSE channel): `Accept` (if present) must allow `text/event-stream`. */
+  private def getHeaderError(req: HttpRequest): Option[HttpReply] =
+    hostError(req).orElse {
+      if !protocolVersionOk(req) then
+        Some(transportError(400, "Unsupported mcp-protocol-version header"))
+      else if !acceptsAny(req, List("text/event-stream", "text/*")) then
+        Some(transportError(406, "Accept must allow text/event-stream"))
+      else None
+    }
+
+private[fastmcp] object StreamableHttpHandler:
+
+  /** Compatibility header for initialization-based Streamable HTTP revisions. */
+  val SessionIdHeader = "mcp-session-id"
+
+  /** Build a handler, allocating the durable session store unless `settings.stateless`. `randomId`
+    * is the platform CSPRNG (`TransportBackend.randomId()`): session ids are bearer handles and
+    * must be unguessable.
+    */
+  def make[R](
+      router: McpRouter[R],
+      settings: McpServerSettings,
+      randomId: UIO[String]
+  ): UIO[StreamableHttpHandler[R]] =
+    if settings.stateless then
+      ZIO.succeed(new StreamableHttpHandler[R](router, settings, randomId, None))
+    else
+      Ref
+        .make(Map.empty[String, Session])
+        .map(store => new StreamableHttpHandler[R](router, settings, randomId, Some(store)))
+
+  /** Periodically drop streamable sessions idle past `settings.sessionIdleTimeout` — abandoned
+    * clients would otherwise grow the store forever. Sessions with a live GET stream are exempt
+    * (push-only consumers may never POST). Eviction shuts the outbound queue down; the session's
+    * tasks stay in the TaskManager until their own TTL.
+    */
+  def evictIdleSessions(
+      store: Ref[Map[String, Session]],
+      settings: McpServerSettings
+  ): UIO[Unit] =
+    settings.sessionIdleTimeout match
+      case None => ZIO.unit
+      case Some(timeout) =>
+        val timeoutMs = timeout.toMillis
+        val sweep =
+          for
+            now <- ZIO.succeed(java.lang.System.currentTimeMillis())
+            all <- store.get
+            expired <- ZIO.filter(all.values.toList) { s =>
+              (s.lastSeen zip s.hasActiveGet).map((seen, live) => !live && now - seen > timeoutMs)
+            }
+            _ <- store.update(_ -- expired.map(_.sessionId))
+            _ <- ZIO.foreachDiscard(expired)(_.outbound.shutdown)
+          yield ()
+        val interval = Duration.fromMillis(math.max(timeoutMs / 4, 1000L))
+        sweep.repeat(Schedule.spaced(interval)).unit
+
+  /** Transport-level rejection as a JSON-RPC error body (TS SDK parity — clients surface
+    * `error.message` uniformly instead of sniffing text/plain bodies). `404` carries
+    * [[ErrorCodes.SessionNotFound]]; every other status [[ErrorCodes.TransportError]].
+    */
+  def transportError(status: Int, message: String): HttpReply.Json =
+    val code = if status == 404 then ErrorCodes.SessionNotFound else ErrorCodes.TransportError
+    val failure: JsonRpcMessage =
+      JsonRpcMessage.Failure(None, McpError(code, message).toErrorObject)
+    HttpReply.Json(status, failure.toJson)

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/http/StreamableHttpHandler.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/http/StreamableHttpHandler.scala
@@ -306,8 +306,17 @@ private[fastmcp] final class StreamableHttpHandler[R] private (
   private def isModernRequest(req: HttpRequest, message: JsonRpcMessage): Boolean =
     ModernHttpValidation.isModern(req.header, message)
 
-  /** Merge a heartbeat into an SSE stream so proxies / idle timeouts don't kill long-quiet
-    * connections. Halts with the data stream.
+  /** Add a heartbeat to an SSE stream so proxies / idle timeouts don't kill long-quiet connections:
+    * a `ping` frame is emitted whenever the stream has been quiet for `keepAliveInterval`, and the
+    * result ends exactly when the data stream does.
+    *
+    * Deliberately NOT `frames.mergeHaltLeft(ZStream.repeatWithSchedule(...))`: the merge's
+    * halt-and-interrupt path — a data stream that ends at once (an `initialize` reply) while the
+    * schedule-driven side is being pulled — nests ZIO's run loop deeply enough to overflow a Scala
+    * Native thread stack (ZIO trampolines only at depth 300; Native frames are large). Feeding a
+    * queue from one producer fiber and pulling it with a timeout is shallow, costs one fiber
+    * instead of the merge machinery, and — because `Queue.take` is atomic — never drops a frame
+    * when the timeout races an arrival.
     */
   private def withKeepAlive(
       frames: ZStream[Any, Nothing, SseFrame]
@@ -315,9 +324,25 @@ private[fastmcp] final class StreamableHttpHandler[R] private (
     settings.keepAliveInterval match
       case None => frames
       case Some(interval) =>
-        val pings =
-          ZStream.repeatWithSchedule(SseFrame.Ping, Schedule.spaced(Duration.fromJava(interval)))
-        frames.mergeHaltLeft(pings)
+        val quiet = Duration.fromJava(interval)
+        ZStream.unwrapScoped {
+          for
+            // `None` marks the end of the data stream.
+            buffer <- Queue.unbounded[Option[SseFrame]]
+            // The producer runs the data stream (and its finalizers) inside this scope: when the
+            // consumer stops pulling — stream end, client disconnect — the scope closes and the
+            // producer is interrupted, so `ensuring` hooks upstream still run.
+            _ <- (frames.runForeach(frame => buffer.offer(Some(frame))) *> buffer.offer(
+              None
+            )).forkScoped
+          yield ZStream.repeatZIOOption(
+            buffer.take.timeout(quiet).flatMap {
+              case Some(Some(frame)) => ZIO.succeed(frame)
+              case Some(None) => ZIO.fail(None)
+              case None => ZIO.succeed(SseFrame.Ping)
+            }
+          )
+        }
 
   private def isFinalReply(message: JsonRpcMessage, reqId: RequestId): Boolean =
     message match

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -2,7 +2,7 @@
 #
 # Run the official MCP conformance server suites against fast-mcp-scala.
 #
-#   scripts/conformance.sh [jvm|js|native] [port] [active|2026]
+#   scripts/conformance.sh [jvm|js|native|scala-native] [port] [active|2026]
 #
 # Boots the cross-platform ConformanceServer (com.tjclp.fastmcp.examples.conformance.*) over
 # streamable HTTP, then drives it with the official harness via `bunx`. Exit code follows the harness
@@ -18,6 +18,11 @@
 # (fast-mcp-scala.nativeSmoke.http.nativeImage; override with FAST_MCP_NATIVE_BIN) against the
 # UNCHANGED jvm baseline — the binary is behaviorally the same server, so any divergence is a
 # native-image bug to fix, never a new baseline.
+#
+# "scala-native" runs it as a Scala Native (LLVM) binary over the java.net.ServerSocket HTTP
+# backend (fast-mcp-scala.scalaNative.conformanceLink; override with FAST_MCP_SCALA_NATIVE_BIN),
+# again against the jvm baseline: the MCP semantics are the shared handler's, so any divergence is
+# a socket-layer bug, never a new baseline.
 set -euo pipefail
 
 PLATFORM="${1:-jvm}"
@@ -28,7 +33,11 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 URL="http://127.0.0.1:${PORT}/mcp"
 BASELINE="$ROOT/conformance/baseline-${PLATFORM}.yml"
-[ "$PLATFORM" = "native" ] && BASELINE="$ROOT/conformance/baseline-jvm.yml"
+# The GraalVM image (native) and the Scala Native binary (scala-native) serve the SAME shared
+# router and streamable-HTTP handler as the JVM, so both are held to the JVM's empty baseline.
+case "$PLATFORM" in
+  native|scala-native) BASELINE="$ROOT/conformance/baseline-jvm.yml" ;;
+esac
 LOG="$(mktemp -t fmcp-conf-log.XXXXXX)"
 SRV_PID=""
 SRV_STOPPED=""
@@ -105,11 +114,26 @@ start_native() {
   SRV_PID=$!
 }
 
+start_scala_native() {
+  local bin="${FAST_MCP_SCALA_NATIVE_BIN:-}"
+  if [ -z "$bin" ]; then
+    echo "→ linking Scala Native ConformanceServer (LLVM)" >&2
+    ./mill --no-server fast-mcp-scala.scalaNative.conformanceLink >/dev/null 2>&1
+    bin="$(./mill --no-server show fast-mcp-scala.scalaNative.conformanceLink 2>/dev/null |
+      python3 -c "import sys,json,re; print(re.sub(r'^q?ref:v\\d+:[0-9a-f]+:','',json.load(sys.stdin)))")"
+  fi
+  [ -x "$bin" ] || { echo "scala-native binary not found/executable: $bin" >&2; exit 1; }
+  echo "→ launching Scala Native ConformanceServer on :$PORT ($bin)" >&2
+  "$bin" "$PORT" >"$LOG" 2>&1 &
+  SRV_PID=$!
+}
+
 case "$PLATFORM" in
   jvm) start_jvm ;;
   js) start_js ;;
   native) start_native ;;
-  *) echo "usage: $0 [jvm|js|native] [port]" >&2; exit 2 ;;
+  scala-native) start_scala_native ;;
+  *) echo "usage: $0 [jvm|js|native|scala-native] [port] [active|2026]" >&2; exit 2 ;;
 esac
 
 echo "→ waiting for $URL" >&2
@@ -136,20 +160,25 @@ case "$MODE" in
     bunx "@modelcontextprotocol/conformance@${CONF_VERSION}" \
       server --url "$URL" --requirements 2026-07-28
     ;;
-  *) echo "usage: $0 [jvm|js|native] [port] [active|2026]" >&2; exit 2 ;;
+  *) echo "usage: $0 [jvm|js|native|scala-native] [port] [active|2026]" >&2; exit 2 ;;
 esac
 RC=$?
 set -e
 # Terminate BEFORE inspecting the log, so teardown-time failures are gated too.
 stop_server
 echo "→ server log: $LOG" >&2
+case "$PLATFORM" in
+  native|scala-native)
+    # Shutdown must actually work: a binary that survives 15s of SIGTERM is a bug. GraalVM needs
+    # --install-exit-handlers for this (dead event loops deadlocking shutdown was exactly the
+    # failure SharedArenaSupport fixed); Scala Native relies on the OS default action.
+    if [ "$SRV_STOPPED" = "hang" ]; then
+      echo "$PLATFORM FAIL: server did not exit within 15s of SIGTERM (suite verdict: $RC)" >&2
+      exit 1
+    fi
+    ;;
+esac
 if [ "$PLATFORM" = "native" ]; then
-  # --install-exit-handlers must actually work: a binary that survives 15s of SIGTERM is a bug
-  # (dead event loops deadlocking shutdown was exactly the failure SharedArenaSupport fixed).
-  if [ "$SRV_STOPPED" = "hang" ]; then
-    echo "native FAIL: server did not exit within 15s of SIGTERM (suite verdict: $RC)" >&2
-    exit 1
-  fi
   # Native binaries can shed threads on GraalVM UnsupportedFeatureError while the suite still
   # passes on the surviving event loops — treat any such error as a failure.
   if grep -q "UnsupportedFeatureError" "$LOG"; then


### PR DESCRIPTION
Closes #81. Closes [TJC-2223](https://linear.app/tjc-technologies/issue/TJC-2223).

Brings **streamable HTTP to Scala Native** — sessions, per-request SSE, the standalone GET push channel, DELETE, keepalive — over a hand-rolled HTTP/1.1 + SSE server on `java.net.ServerSocket`, since zio-http has no Native artifacts (zio-http#2526). The same server ships on the JVM as the explicit opt-in **`JvmSocketHttpBackend`** (the `JdkHttpBackend` scoped in TJC-2114). Held to the JVM's **empty** conformance baseline.

## What #81 got half right

The issue assumed "everything protocol-shaped already lives in `shared/`". `HostGuard`, `ModernHttpValidation`, `MessageLoop`, `Session` and the router do — but the streamable-HTTP *semantics* (session store + idle sweeper, only-`initialize`-mints, request→SSE with the per-request sink and close sentinel, the 2026-07-28 stateless path, GET push with 409, DELETE, keepalive, JSON-RPC transport error bodies) were ~500 lines welded to zio-http types in `JvmHttpBackend`, duplicated against `js.Dynamic` on JS. A socket backend written the same way would have been a third copy.

## Commits (read in order)

1. **`refactor(http)`** — lift those semantics into a platform-neutral `StreamableHttpHandler` over a small `HttpRequest` / `HttpReply` / `SseFrame` model in `shared/`. `JvmHttpBackend` shrinks to the zio-http adapter + Netty channel-type pinning; `httpRoutes` / `evictIdleSessions` stay as the in-memory test seams. **Pure refactor**: all existing HTTP tests pass unchanged; conformance active (73/0) and the 2026 requirements scenario set are byte-identical before/after.
2. **`build`** — new `fast-mcp-scala/jvm-native/` tree compiled by **both** `jvm` and `scalaNative`: `SocketHttpServer` (blocking accept loop + per-connection fibers on ZIO's blocking executor via `attemptBlockingCancelable`, gated at 256 connections; keep-alive; `Content-Length` + chunked bodies; `Expect: 100-continue`; HTTP/1.0 close-delimited; chunked SSE with per-event flush and a reader-side disconnect watcher; caps 8 KiB head → 431, 16 MiB body → 413, 60 s idle) and the pure `Http1` parser. Test modules share `jvm-native/test/src` through a top-level `CrossPlatformTests` trait — an inline `override def sources` in a nested test object trips Mill's code-signature tracking on this dash-named package module.
3. **`feat(http)`** — `SocketHttpBackend`, `NativeHttpBackend` (exported: `McpServerApp[Http]` now compiles on Native), `JvmSocketHttpBackend` (no `given`, not exported; opt in with `given JvmSocketHttpBackend.type = JvmSocketHttpBackend`, which wins on specificity — pinned by a surface test).
4. **`fix(http)`** — keepalive as a queue-fed timed pull instead of `mergeHaltLeft(repeatWithSchedule(...))`. The merge's halt path on a stream that ends at once (an `initialize` reply) nested ZIO's run loop past a 1 MiB Scala Native thread stack (ZIO trampolines at depth 300; Native frames are large) → fatal `StackOverflowError` on a `ZScheduler-Worker`, connection hung forever. Deterministic; reproduced down to the exact stream shape. Quiet-stream behaviour is identical; every keepalive test passes unchanged.
5. **`test(http)`** — 18 wire tests over a raw `java.net.Socket` client (with a watchdog so a silent server fails instead of hangs), compiled into **both** the JVM and the linked Scala Native test binary; parser unit tests; platform surface tests (Native resolves the socket given; JVM root import still resolves Netty and the opt-in resolves the socket backend without ambiguity).
6. **`feat(conformance)`** — `ConformanceServerNative` + `scalaNative.conformanceLink` (Mill's `nativeLinkOtherMain`, no second module) + `scripts/conformance.sh scala-native` + a `conformance.yml` matrix lane, all held to `baseline-jvm.yml`.
7. **`docs`** — README (matrix, footnote, seam, opt-in recipe, Native section), architecture, CLAUDE.md, parity audit, native-image, CHANGELOG.

## Verification (local, macOS arm64)

| Gate | Result |
|---|---|
| `./mill fast-mcp-scala.test` (JVM + Bun + Native aggregate) | 502/502, 17 suites, 422 tests |
| `scalaNative.test` alone | 36/36 in ~10 s incl. all 18 socket wire tests |
| `conformance.sh scala-native` active / 2026 | **73 passed, 0 failed** / scenario set identical to JVM |
| `conformance.sh jvm` active / 2026 (after commits 1 and 4) | identical to the pre-refactor baseline |
| `checkFormat`, `resolve __.publishArtifacts` | clean / exactly `jvm`, `js`, `scalaNative` |
| `scripts/native-smoke.sh` on the AnnotatedServer LLVM binary | OK, netty-shed check ok |

CI adds the `scala-native` conformance lane on linux; the GraalVM `native.yml` smoke is unaffected.

## Follow-ups (not in scope)

- Migrate `JsTransportBackend` onto `StreamableHttpHandler` (dedupes `evictIdleSessions`; needs variance knobs for its GET-405 and comment-frame pings).
- GraalVM netty-free HTTP image job using `JvmSocketHttpBackend` (docs mark it "not yet CI-verified").
- Cross-SDK benchmark harness (Go SDK v1.4.0, Java SDK 1.1.1, JVM netty/socket, GraalVM, Bun) — separate issue + PR, as decided.
- TLS: none on Native (`javax.net.ssl` absent) — terminate at a proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
