### PR TITLE
Scala 3.9.0 LTS, mill-bun 0.3.1 + Scala.js 1.22.0, LTS-only JDK matrix (TJC-2273)

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -32,7 +32,7 @@ runs:
       if: inputs.bun == 'true'
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: 1.4.0 # same Bun the mill-bun plugin manages for the Scala.js tests
+        bun-version: 1.4.1 # same Bun the mill-bun plugin manages for the Scala.js tests
 
     # Keys hash every *.mill file (build.mill plus each package.mill) and .mill-version — the
     # latter selects the Mill distribution that lands in the Mill cache. A key hashing only

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -32,7 +32,7 @@ runs:
       if: inputs.bun == 'true'
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: 1.3.14
+        bun-version: 1.4.0 # same Bun the mill-bun plugin manages for the Scala.js tests
 
     # Keys hash every *.mill file (build.mill plus each package.mill) and .mill-version — the
     # latter selects the Mill distribution that lands in the Mill cache. A key hashing only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        java: [17, 21, 24]
+        java: [17, 21, 25] # LTS releases only
     runs-on: ubuntu-latest
 
     steps:
@@ -35,7 +35,7 @@ jobs:
         run: ./mill -i fast-mcp-scala.jvm.test
 
       - name: Test (Scala.js on Bun)
-        run: ./mill -i fast-mcp-scala.js.test.bunTest
+        run: ./mill -i fast-mcp-scala.js.test
 
   scala-native:
     name: Scala Native (linux-x64)

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ build/
 node_modules/
 bun.lockb
 bun.lock
+# The js module's lock is source-controlled: mill-bun 0.3 installs with --frozen-lockfile.
+!fast-mcp-scala/js/bun.lock
 *.class
 *.tasty
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and installs are frozen (regenerate via `./mill fast-mcp-scala.js.bunLock`);
   the test-only TS SDK moved from `bunDeps` to `bunDevDeps`, so the published
   `_sjs1_3` JAR no longer advertises it in a bun dependency manifest; the
-  plugin manages Bun 1.4.0 itself (CI's system Bun moves to 1.4.0 to match);
+  plugin manages Bun 1.4.1 itself (CI's system Bun moves to 1.4.1 to match);
   `js.test.bunTest` is replaced by the inherited `js.test` (`testForked`).
   The js test module also drops the Scala 2.13 `scalajs-scalalib` that Mill's
   isolated test-bridge resolution prepends to the test link on Scala 3.8+ —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Scala 3.9.0 LTS** (TJC-2273): all three platforms now build with Scala 3.9.0
+  (LTS, released 2026-09-03), up from 3.8.3. Companion bumps: WartRemover
+  3.5.6 → 3.6.1 (first release for the 3.9.0 compiler) and the Scala.js
+  linker to 1.22.0 (Scala 3.9.0 emits 1.22 IR); Scala Native stays on 0.5.12.
+  CI now tests LTS JDKs only (17, 21, 25 — the non-LTS 24 is dropped).
+- **mill-bun-plugin 0.2.1 → 0.3.1** (TJC-2274): Mill 1.1.x's bundled Scala.js
+  linker stops at IR 1.20 and cannot link Scala 3.9 output, so the js module
+  now pins `scalaJSVersion` explicitly (1.22.0) through the plugin's 0.3
+  `ScalaJSModule` path. With it: `fast-mcp-scala/js/bun.lock` is committed
+  and installs are frozen (regenerate via `./mill fast-mcp-scala.js.bunLock`);
+  the test-only TS SDK moved from `bunDeps` to `bunDevDeps`, so the published
+  `_sjs1_3` JAR no longer advertises it in a bun dependency manifest; the
+  plugin manages Bun 1.4.0 itself (CI's system Bun moves to 1.4.0 to match);
+  `js.test.bunTest` is replaced by the inherited `js.test` (`testForked`).
+  The js test module also drops the Scala 2.13 `scalajs-scalalib` that Mill's
+  isolated test-bridge resolution prepends to the test link on Scala 3.8+ —
+  it shadowed the 3.9.0 stdlib and made the linker report the new
+  `Option.orNull()` as non-existent.
 - **Build and source layout modularized** (TJC-2198): Mill 1.1.5 → 1.1.8;
   module definitions moved out of the monolithic `build.mill` into
   `fast-mcp-scala/package.mill`, next to the code they build (task paths such

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Three platforms: **JVM** (stdio + HTTP), **Scala.js/Bun** (stdio + HTTP), and **
 
 **Build tool**: Mill 1.1.8 (configured in `.mill-version`)
 **Scala**: 3.9.0 (LTS)
-**Plugins**: mill-bun-plugin 0.3.1 (Scala.js + Bun integration; explicit `scalaJSVersion`, managed Bun 1.4.0, frozen `js/bun.lock`)
+**Plugins**: mill-bun-plugin 0.3.1 (Scala.js + Bun integration; explicit `scalaJSVersion`, managed Bun 1.4.1, frozen `js/bun.lock`)
 
 ### Common Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,8 @@ Three platforms: **JVM** (stdio + HTTP), **Scala.js/Bun** (stdio + HTTP), and **
 ## Build System
 
 **Build tool**: Mill 1.1.8 (configured in `.mill-version`)
-**Scala**: 3.8.3
-**Plugins**: mill-bun-plugin 0.2.1 (Scala.js + Bun integration)
+**Scala**: 3.9.0 (LTS)
+**Plugins**: mill-bun-plugin 0.3.1 (Scala.js + Bun integration; explicit `scalaJSVersion`, managed Bun 1.4.0, frozen `js/bun.lock`)
 
 ### Common Commands
 
@@ -28,7 +28,8 @@ Three platforms: **JVM** (stdio + HTTP), **Scala.js/Bun** (stdio + HTTP), and **
 
 # Single-platform
 ./mill fast-mcp-scala.jvm.test                      # JVM tests only
-./mill fast-mcp-scala.js.test.bunTest               # Scala.js conformance tests only
+./mill fast-mcp-scala.js.test                       # Scala.js conformance tests only (Bun)
+./mill fast-mcp-scala.js.bunLock                    # Regenerate js/bun.lock after changing bunDevDeps
 ./mill fast-mcp-scala.scalaNative.test              # Scala Native tests (links a native binary)
 ./mill fast-mcp-scala.scalaNative.nativeLink        # Standalone LLVM binary of AnnotatedServer
 ./mill fast-mcp-scala.jvm.test com.tjclp.fastmcp.macros.ToolProcessorTest
@@ -250,7 +251,7 @@ Each platform provides exactly one `given TransportBackend` (`JvmTransportBacken
 
 ### WartRemover
 
-Configured in `build.mill` (v3.5.6):
+Configured in `build.mill` (v3.6.1):
 - **Errors** (fail build): `Null`, `TryPartial`, `TripleQuestionMark`, `ArrayEquals`
 - **Warnings**: `Var`, `Return`, `AsInstanceOf`, `IsInstanceOf`
 
@@ -278,7 +279,7 @@ Key test classes:
 
 ## CI/CD
 
-- **CI** (`.github/workflows/ci.yml`): Runs on PRs and main pushes, tests on JDK 17, 21, 24
+- **CI** (`.github/workflows/ci.yml`): Runs on PRs and main pushes, tests on the LTS JDKs 17, 21, 25
 - **Conformance** (`.github/workflows/conformance.yml`): official `@modelcontextprotocol/conformance` suite against both platforms — 42/42, with expected-failure baselines at `conformance/baseline-{jvm,js}.yml` kept EMPTY (any regression fails the gate). Run locally via `scripts/conformance.sh {jvm|js}`.
 - **Release** (`.github/workflows/release.yml`): Triggered by `v*` tags, publishes to Maven Central
 
@@ -314,12 +315,12 @@ Then in your project use version `1.0.0-RC4-SNAPSHOT`.
 ## Dependencies
 
 Key dependencies (versions in `build.mill`):
-- Scala 3.8.3
+- Scala 3.9.0 LTS
 - ZIO 2.1.20 - Effect system
 - ZIO JSON 0.7.44 - JSON codecs (shared)
 - ZIO HTTP 3.4.0 - HTTP transport
 - Native Scala 3 macros - Compile-time JSON Schema derivation
-- mill-bun-plugin 0.2.1 - Scala.js + Bun build integration
-- `@modelcontextprotocol/sdk` 1.29.0 - TS MCP SDK, pinned in the js module's `bunDeps`; consumed only by the `js.test` conformance client (zero production `@JSImport`s)
-- WartRemover 3.5.6 - Code quality
+- mill-bun-plugin 0.3.1 - Scala.js + Bun build integration (Scala.js 1.22.0 pinned via `Versions.scalaJs`)
+- `@modelcontextprotocol/sdk` 1.29.0 - TS MCP SDK, pinned in the js module's `bunDevDeps` and frozen by the committed `fast-mcp-scala/js/bun.lock`; consumed only by the `js.test` conformance client (zero production `@JSImport`s, absent from the published bun manifest)
+- WartRemover 3.6.1 - Code quality
 - ScalaTest 3.2.19 - Testing

--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ libraryDependencies += "com.tjclp" %% "fast-mcp-scala" % "1.0.0-RC3"
 libraryDependencies += "com.tjclp" %%% "fast-mcp-scala" % "1.0.0-RC3"
 ```
 
-Built against Scala 3.8.3. JVM requires JDK 17+. Scala.js artifact is published for `sjs1_3` (Scala.js 1.x); runs on Bun (first-class) and Node 18+.
+Built against Scala 3.9.0 LTS. JVM requires JDK 17+ (CI tests the LTS releases 17, 21, and 25). Scala.js artifact is published for `sjs1_3` (Scala.js 1.x); runs on Bun (first-class) and Node 18+.
 
 ## Quickstart
 
 A single-file server with one tool — the same code lives in [`HelloWorld.scala`](fast-mcp-scala/shared/src/com/tjclp/fastmcp/examples/HelloWorld.scala):
 
 ```scala 3 raw
-//> using scala 3.8.3
+//> using scala 3.9.0
 //> using dep com.tjclp::fast-mcp-scala:1.0.0-RC3
 //> using options "-Xcheck-macros" "-experimental"
 
@@ -249,7 +249,7 @@ stdio-only images entirely (~35 MB, instant startup, no JVM in the container):
 
 ```scala
 object server extends ScalaModule with mill.javalib.NativeImageModule {
-  def scalaVersion = "3.8.3"
+  def scalaVersion = "3.9.0"
   def scalacOptions = Seq("-experimental")   // the annotation macros require it
   def mvnDeps = Seq(mvn"com.tjclp::fast-mcp-scala:1.0.0-RC3".exclude("dev.zio" -> "zio-http_3"))
   def mainClass = Some("com.example.MyServer")
@@ -392,7 +392,7 @@ Proof: the official **MCP conformance suite** runs against both platforms in CI 
 ### Running on Bun
 
 ```scala 3 raw
-//> using scala 3.8.3
+//> using scala 3.9.0
 //> using dep com.tjclp::fast-mcp-scala_sjs1:1.0.0-RC3
 
 import com.tjclp.fastmcp.{*, given}
@@ -411,7 +411,7 @@ Link with `./mill fast-mcp-scala.js.fastLinkJS`, then `bun run out/fast-mcp-scal
 The same shared core compiles to a standalone LLVM binary — no JVM, no JS runtime (~21 MB in a debug link, single-digit-second link times):
 
 ```scala 3 raw
-//> using scala 3.8.3
+//> using scala 3.9.0
 //> using platform native
 //> using nativeVersion 0.5.12
 //> using dep com.tjclp::fast-mcp-scala::1.0.0-RC4
@@ -532,7 +532,7 @@ For architectural detail, see [`docs/architecture.md`](docs/architecture.md).
 ./mill fast-mcp-scala.checkFormat                               # Scalafmt check (all sources)
 ./mill fast-mcp-scala.reformat                                  # Auto-format (all sources)
 ./mill fast-mcp-scala.jvm.test                                  # JVM tests only
-./mill fast-mcp-scala.js.test.bunTest                           # Scala.js conformance tests only
+./mill fast-mcp-scala.js.test                                   # Scala.js conformance tests only
 ./mill fast-mcp-scala.jvm.publishLocal                          # Publish JVM artifact to ~/.ivy2/local
 ```
 
@@ -555,7 +555,7 @@ def ivyDeps = Agg(
 Or point `scala-cli` at a built JAR directly:
 
 ```scala 3 ignore
-//> using scala 3.8.3
+//> using scala 3.9.0
 //> using jar "/absolute/path/to/out/fast-mcp-scala/jvm/jar.dest/out.jar"
 //> using options "-Xcheck-macros" "-experimental"
 ```

--- a/build.mill
+++ b/build.mill
@@ -1,5 +1,5 @@
-//| mvnDeps: ["com.lihaoyi::mill-contrib-scoverage:$MILL_VERSION", "com.tjclp::mill-bun_mill1:0.2.1"]
-// Mill 1.1.8 (latest stable) — Scala 3.8.x support and mill-bun-plugin compatibility.
+//| mvnDeps: ["com.lihaoyi::mill-contrib-scoverage:$MILL_VERSION", "com.tjclp::mill-bun_mill1:0.3.1"]
+// Mill 1.1.8 (latest stable) — Scala 3.9.x support and mill-bun-plugin compatibility.
 // Version is controlled via .mill-version file.
 //
 // This file holds only cross-cutting build vocabulary: versions, compiler flags, and the module
@@ -13,9 +13,10 @@ import mill._
 import mill.scalalib._
 import mill.scalalib.publish._
 import mill.scalalib.scalafmt._
+import mill.scalajslib.TestScalaJSModule
 import contrib.scoverage.ScoverageModule
 
-val scala3Version = "3.8.3"
+val scala3Version = "3.9.0" // Scala 3.9 LTS
 val organization = "com.tjclp"
 
 /** Version constants - centralized for maintenance */
@@ -24,7 +25,11 @@ object Versions {
   val zioJson = "0.7.44"
   val zioHttp = "3.4.0"
   val scalaTest = "3.2.19"
-  val scalaNative = "0.5.12" // officially supports Scala 3.8.3
+  // Scala 3.9.0 emits Scala.js 1.22 IR, so the linker must be at least 1.22. mill-bun 0.3.x
+  // delegates to Mill's standard ScalaJSModule and makes this pin explicit (Mill 1.1.x's own
+  // bundled linker stops at IR 1.20 and cannot link Scala 3.9 output).
+  val scalaJs = "1.22.0"
+  val scalaNative = "0.5.12" // publishes scala3lib for Scala 3.9.0 (3.9.0+0.5.12)
   val scalaCheck = "1.18.1"
 }
 
@@ -83,7 +88,7 @@ trait FastMCPModuleBase extends ScalaModule with ScalafmtModule with ScoverageMo
 
   // WartRemover compiler plugin for enhanced code quality
   def scalacPluginMvnDeps = Seq(
-    mvn"org.wartremover:::wartremover:3.5.6"
+    mvn"org.wartremover:::wartremover:3.6.1"
   )
 
   override def scalacOptions = BuildConfig.crossScalacOptions ++ BuildConfig.wartRemoverOptions
@@ -127,4 +132,20 @@ trait FastMCPModule extends FastMCPModuleBase with FastMCPPublishingBase
 /** Test module trait */
 trait FastMCPTestModule extends TestModule.ScalaTest {
   override def forkArgs: T[Seq[String]] = BuildConfig.lazyValsJvmArgs
+}
+
+/** Scala.js test-link fix for Scala 3.8+. Mill's `TestScalaJSModule.scalaJSTestDeps` resolves the
+  * test bridge in isolation; with nothing there to pin `scalajs-scalalib` to the Scala 3 stdlib,
+  * that resolution drags in the *Scala 2.13* one and prepends it to the test link inputs, where it
+  * shadows the real `scalajs-scalalib_2.13:<scala version>` (on 3.9.0 the linker then reports the
+  * new parameterless `Option.orNull()` as non-existent). Keep the bridge, drop the stray stdlib —
+  * the module classpath already carries the right one. Only the test link was ever affected.
+  *
+  * A top-level trait, not an inline override: a `super.<task>()` override inside a nested test
+  * object under the dash-named package aborts Mill with "Could not detect the parent class".
+  */
+trait ScalaJSTestDepsFix extends TestScalaJSModule {
+  override def scalaJSTestDeps = Task {
+    super.scalaJSTestDeps().filterNot(_.path.last.startsWith("scalajs-scalalib_2.13-2.13"))
+  }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,11 +152,11 @@ Tool handlers return `ZIO[Any, Throwable, Out]`. Handler failures surface in-ban
 
 Pinned in `build.mill`:
 
-- **Scala** 3.8.3
+- **Scala** 3.9.0 LTS
 - **ZIO** 2.1.20, **zio-json** 0.7.44 (the wire codec on both platforms), **zio-http** 3.4.0
 - **Native Scala 3 macros** for JSON Schema derivation, emitted as `zio-json` ASTs
-- **mill-bun-plugin** 0.2.1 (Scala.js + Bun integration)
-- **WartRemover** 3.5.6 (linting)
+- **mill-bun-plugin** 0.3.1 (Scala.js + Bun integration)
+- **WartRemover** 3.6.1 (linting)
 - Test-time only: **`@modelcontextprotocol/sdk` 1.29.0** (conformance client), **ScalaTest** 3.2.19
 
 ## Further reading

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -22,7 +22,7 @@ reflection need, the smoke goes red on the PR that introduces it, and only then 
 
 ```scala
 object server extends ScalaModule with mill.javalib.NativeImageModule {
-  def scalaVersion = "3.8.3"
+  def scalaVersion = "3.9.0"
   // fast-mcp-scala's annotation macros are @experimental; consumers compile with -experimental
   // (same requirement as the scala-cli quickstart in the README)
   def scalacOptions = Seq("-experimental")
@@ -119,7 +119,7 @@ build override and four extra flags:
 
 ```scala
 object server extends ScalaModule with mill.javalib.NativeImageModule {
-  def scalaVersion = "3.8.3"
+  def scalaVersion = "3.9.0"
   def scalacOptions = Seq("-experimental")                      // annotation macros require it
   def mainClass = Some("com.example.MyHttpServer")
   def mvnDeps = Seq(mvn"com.tjclp::fast-mcp-scala:1.0.0-RC3")   // zio-http stays

--- a/fast-mcp-scala/js/bun.lock
+++ b/fast-mcp-scala/js/bun.lock
@@ -1,0 +1,201 @@
+{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "js",
+      "devDependencies": {
+        "@modelcontextprotocol/sdk": "1.29.0",
+      },
+    },
+  },
+  "packages": {
+    "@hono/node-server": ["@hono/node-server@1.19.17", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.1", "", {}, "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.7.0", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.13.5", "", {}, "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.7.0", "", {}, "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.11", "", {}, "sha512-A5NPn7g8EAzGU3IzRs+Yiq8K5n3ypYS75M5+KKiVHdUexfpWK1kP4ZMq7QnTGDoMj6TJ1dtcEJjW60yZDXS4hg=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.1", "", {}, "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.1.0", "", { "dependencies": { "content-type": "^2.1.0" } }, "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.16.0", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.5.4", "", {}, "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "body-parser/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
+
+    "negotiator/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
+
+    "type-is/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
+  }
+}

--- a/fast-mcp-scala/package.mill
+++ b/fast-mcp-scala/package.mill
@@ -11,8 +11,8 @@ import mill.scalajslib._
 import mill.scalajslib.api._
 import mill.scalajslib.bun._
 import mill.scalanativelib._
-import build.{BuildConfig, FastMCPModule, FastMCPPublishingBase, FastMCPTestModule, Versions,
-  scala3Version}
+import build.{BuildConfig, FastMCPModule, FastMCPPublishingBase, FastMCPTestModule,
+  ScalaJSTestDepsFix, Versions, scala3Version}
 
 // Namespace module. Aggregate tasks at this level fan out to all three platform children so
 // `./mill fast-mcp-scala.compile` and `./mill fast-mcp-scala.test` cover the whole project
@@ -30,7 +30,7 @@ object `package` extends Module {
   /** Run the JVM test suite, the Scala.js/Bun conformance tests, and the Scala Native tests. */
   def test: T[Unit] = Task {
     jvm.test.testForked()()
-    js.test.bunTest(mill.api.Args())()
+    js.test.testForked()()
     scalaNative.test.testForked()()
     ()
   }
@@ -81,6 +81,7 @@ object `package` extends Module {
   object js extends BunScalaJSModule with BunPublishModule with ScalafmtModule
       with FastMCPPublishingBase {
     def scalaVersion = scala3Version
+    def scalaJSVersion = Versions.scalaJs
 
     override def moduleKind = Task { ModuleKind.ESModule }
 
@@ -98,14 +99,16 @@ object `package` extends Module {
     // without the wart traversers.
     override def scalacOptions = BuildConfig.crossScalacOptions
 
-    override def bunDeps = Task {
-      // The TS MCP SDK is NOT a production dependency — no production source `@JSImport`s it and
-      // the published Maven artifact is unaffected. It is declared (pinned) here because the bun
-      // test workspace links this module's node_modules (the plugin has no test-scoped deps yet):
-      // `js.test`'s conformance client resolves `@modelcontextprotocol/sdk` from it. Without the
-      // pin, Bun's runtime auto-install fetched *latest at test time* — a CI time bomb now that
-      // post-2026-07-28 SDK releases change initialize semantics. Production boundary = the
-      // import graph, enforced by RootImportSurface tests, not node_modules.
+    override def bunDevDeps = Task {
+      // The TS MCP SDK is NOT a production dependency — no production source `@JSImport`s it, and
+      // as a dev dependency it stays out of the published bun dependency manifest (mill-bun 0.3
+      // schema v2). It is declared (pinned) here because the bun test workspace links this
+      // module's node_modules: `js.test`'s conformance client resolves `@modelcontextprotocol/sdk`
+      // from it. Without the pin, Bun's runtime auto-install fetched *latest at test time* — a CI
+      // time bomb now that post-2026-07-28 SDK releases change initialize semantics. Resolution is
+      // frozen by the committed `js/bun.lock` (regenerate with `./mill fast-mcp-scala.js.bunLock`).
+      // Production boundary = the import graph, enforced by RootImportSurface tests, not
+      // node_modules.
       Seq("@modelcontextprotocol/sdk@1.29.0")
     }
 
@@ -127,7 +130,8 @@ object `package` extends Module {
       )
     }
 
-    object test extends BunScalaJSTests with TestModule.ScalaTest {
+    // ScalaJSTestDepsFix: see build.mill — keeps the Scala 2.13 stdlib out of the test link.
+    object test extends BunScalaJSTests with TestModule.ScalaTest with ScalaJSTestDepsFix {
       override def mvnDeps = Seq(
         mvn"org.scalatest::scalatest::${Versions.scalaTest}"
       )

--- a/scripts/examples.sc
+++ b/scripts/examples.sc
@@ -1,4 +1,4 @@
-//> using scala 3.8.3
+//> using scala 3.9.0
 //> using dep com.tjclp::fast-mcp-scala:0.3.0-rc4
 //> using options "-Xcheck-macros" "-experimental"
 

--- a/scripts/quickstart.sc
+++ b/scripts/quickstart.sc
@@ -1,4 +1,4 @@
-//> using scala 3.8.3
+//> using scala 3.9.0
 //> using dep com.tjclp::fast-mcp-scala:0.5.0
 //> using options "-Xcheck-macros" "-experimental"
 


### PR DESCRIPTION
## Summary

- **Scala 3.9.0 LTS** (released 2026-09-03) on all three platforms, up from 3.8.3. Companion bumps: WartRemover 3.5.6 → 3.6.1 (the only build published for the `wartremover_3.9.0` compiler plugin); Scala Native stays 0.5.12 (`scala3lib_native0.5_3:3.9.0+0.5.12` exists).
- **Scala.js 1.22.0, pinned explicitly** via `Versions.scalaJs`. Scala 3.9.0 emits Scala.js 1.22 IR and Mill 1.1.x's bundled `ScalaJSConfigModule` linker (IR ≤ 1.20) cannot link it, so the js module moves to **mill-bun-plugin 0.3.1** (TJC-2274), whose `ScalaJSModule` path takes the version from the build. With that: `fast-mcp-scala/js/bun.lock` is committed and installs are frozen (`./mill fast-mcp-scala.js.bunLock` regenerates); the test-only TS SDK moves from `bunDeps` to `bunDevDeps`, so the published `_sjs1_3` JAR no longer advertises it in a bun dependency manifest; the plugin manages Bun 1.4.1 itself and CI's system Bun moves to 1.4.1 to match; `js.test.bunTest` → inherited `js.test`.
- **Mill quirk on Scala 3.8+, worked around in `js.test`**: Mill's `TestScalaJSModule.scalaJSTestDeps` resolves the test bridge in isolation, which drags in the *Scala 2.13* `scalajs-scalalib` and prepends it to the test link — shadowing the 3.9.0 stdlib (`Referring to non-existent method scala.Option.orNull()`, the new parameterless `orNull`). The override drops that stray jar; only the test link was ever affected, never the published artifact.
- **CI tests LTS JDKs only**: matrix `[17, 21, 24]` → `[17, 21, 25]`.
- Docs/scripts/README `3.8.3` → `3.9.0`; CHANGELOG entries under Unreleased.

## Verification (local, JDK 25)

- `fast-mcp-scala.compile` (JVM + JS + Native): green
- `fast-mcp-scala.js.test` (managed Bun 1.4.1, real TS SDK conformance client): 42/42; `js/bun.lock` regenerated under 1.4.1 is byte-identical
- `fast-mcp-scala.jvm.test`: green (all suites); `fast-mcp-scala.scalaNative.test`: 8/8; `checkFormat`: green
- JDK 17 and 21 legs: CI matrix

> mill-bun-plugin **0.3.1** is on Maven Central as of 2026-09-04 (TJC-2274, [release v0.3.1](https://github.com/TJC-LP/mill-bun-plugin/releases/tag/v0.3.1)); the earlier red CI runs failed only on resolving it before publication and were re-run once it synced.

Linear: TJC-2273

🤖 Generated with [Claude Code](https://claude.com/claude-code)
