### PR TITLE
Freeze conformance harness lock, verify Mill dist, SHA-pin actions, split release (TJC-2299)

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -109,7 +109,9 @@ runs:
           ${{ runner.os }}-mill-${{ inputs.cache-prefix }}-
 
     # Always last, before any `./mill` in the caller: the launcher skips its own unverified download
-    # whenever the final path is non-empty, so after this step every ./mill execs verified bytes.
+    # whenever the final path is non-empty, so after this step every ./mill execs a verified LAUNCHER.
+    # Mill's own jars still come from coursier: SHA-1-checked on download, trusted from the restored
+    # ~/.cache/coursier on a cache hit (non-release jobs only — release.yml passes cache: "false").
     - name: Install Mill (checksum-verified)
       shell: bash
       working-directory: ${{ github.workspace }}

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,7 +1,12 @@
 name: Set up build
 description: >-
-  JDK, optional Bun, and the coursier/Mill caches every fast-mcp-scala workflow needs.
-  Replaces the setup block that was copy-pasted across ci/release/native/conformance.
+  JDK, optional Bun, the coursier/Mill caches, and a checksum-verified Mill distribution for every
+  fast-mcp-scala workflow. Replaces the setup block that was copy-pasted across
+  ci/release/native/conformance. `cache: "false"` registers no cache step at all (the release
+  workflow); `cache-write: "false"` restores read-only (jobs that execute the npm conformance
+  harness). The last step pre-installs the exact Mill distribution the ./mill launcher would
+  download and verifies it against .github/mill-dist.sha256 — a cache-restored binary that does
+  not match the pin fails the job instead of running.
 
 inputs:
   java-version:
@@ -19,26 +24,58 @@ inputs:
       the main cache.
     required: false
     default: ""
+  cache:
+    description: >-
+      "false" registers NO actions/cache step (no restore, no post-job save). The release workflow
+      passes it so the credentialed jobs never consume a cache written by main-scope jobs.
+    required: false
+    default: "true"
+  cache-write:
+    description: >-
+      "false" swaps actions/cache for actions/cache/restore (restore-only, no post-job save). Set on
+      jobs that execute third-party run-time code (the npm conformance harness) so that code can
+      never write into the shared Mill/coursier cache.
+    required: false
+    default: "true"
 
 runs:
   using: composite
   steps:
     - name: Set up JDK ${{ inputs.java-version }}
-      uses: coursier/setup-action@v1
+      uses: coursier/setup-action@039f736548afa5411c1382f40a5bd9c2d30e0383 # v1.3.9
       with:
         jvm: temurin:${{ inputs.java-version }}
 
+    # no-cache: setup-bun's post step would otherwise save ~/.bun/bin/bun to the shared cache after
+    # the job's own code ran (and restore an unverified binary before it); the download is ~2s.
     - name: Set up Bun
       if: inputs.bun == 'true'
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
         bun-version: 1.4.1 # same Bun the mill-bun plugin manages for the Scala.js tests
+        no-cache: true
 
     # Keys hash every *.mill file (build.mill plus each package.mill) and .mill-version — the
     # latter selects the Mill distribution that lands in the Mill cache. A key hashing only
     # build.mill would go stale silently now that modules live in package.mill files.
+    #
+    # NEVER add ~/.bun/install/cache to a cache path: Bun verifies lockfile sha512 only when
+    # extracting a tarball, so a warm install cache bypasses the frozen-lockfile integrity check
+    # that scripts/conformance.sh relies on.
     - name: Cache Coursier
-      uses: actions/cache@v4
+      if: inputs.cache == 'true' && inputs.cache-write == 'true'
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: |
+          ~/.cache/coursier
+          ~/.ivy2/cache
+        key: ${{ runner.os }}-coursier-${{ inputs.cache-prefix }}-${{ hashFiles('**/*.mill', '.mill-version') }}
+        restore-keys: |
+          ${{ runner.os }}-coursier-${{ inputs.cache-prefix }}-
+
+    - name: Restore Coursier (read-only)
+      if: inputs.cache == 'true' && inputs.cache-write != 'true'
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.cache/coursier
@@ -50,7 +87,8 @@ runs:
     # Both locations: Mill 1.x resolves its distribution under ~/.cache/mill (XDG), while older
     # launchers used ~/.mill. Caching both keeps every job on one warm path.
     - name: Cache Mill
-      uses: actions/cache@v4
+      if: inputs.cache == 'true' && inputs.cache-write == 'true'
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.cache/mill
@@ -58,3 +96,23 @@ runs:
         key: ${{ runner.os }}-mill-${{ inputs.cache-prefix }}-${{ hashFiles('**/*.mill', '.mill-version') }}
         restore-keys: |
           ${{ runner.os }}-mill-${{ inputs.cache-prefix }}-
+
+    - name: Restore Mill (read-only)
+      if: inputs.cache == 'true' && inputs.cache-write != 'true'
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: |
+          ~/.cache/mill
+          ~/.mill
+        key: ${{ runner.os }}-mill-${{ inputs.cache-prefix }}-${{ hashFiles('**/*.mill', '.mill-version') }}
+        restore-keys: |
+          ${{ runner.os }}-mill-${{ inputs.cache-prefix }}-
+
+    # Always last, before any `./mill` in the caller: the launcher skips its own unverified download
+    # whenever the final path is non-empty, so after this step every ./mill execs verified bytes.
+    - name: Install Mill (checksum-verified)
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        MILL_CACHE_KEY_HINT: ${{ runner.os }}-mill-${{ inputs.cache-prefix }}-
+      run: bash "$GITHUB_ACTION_PATH/../../scripts/install-mill.sh"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Keeps the full-SHA action pins (and the pinned conformance harness) current through reviewed PRs.
+# Every `uses:` is pinned to a 40-hex commit with a same-line `# vX.Y.Z` comment; Dependabot
+# rewrites both. The cooldown delays adoption of a freshly moved/hijacked upstream release.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directories:
+      - "/"                    # .github/workflows/*.yml
+      - "/.github/actions/*"   # the setup-build composite ("/" alone covers only a root action.yml)
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7          # let upstream detect a hijacked release before we adopt it
+    groups:
+      github-actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci"
+  - package-ecosystem: bun
+    directory: "/conformance"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,10 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directories:
-      - "/"                    # .github/workflows/*.yml
-      - "/.github/actions/*"   # the setup-build composite ("/" alone covers only a root action.yml)
+      - "/"                            # .github/workflows/*.yml
+      - "/.github/actions/setup-build" # the composite ("/" alone covers only a root action.yml);
+                                       # listed explicitly — no reliance on glob support for this
+                                       # ecosystem. Add a line per new composite action.
     schedule:
       interval: weekly
     cooldown:

--- a/.github/mill-dist.sha256
+++ b/.github/mill-dist.sha256
@@ -1,0 +1,9 @@
+# SHA-256 of the Mill distributions the ./mill launcher downloads (keyed by URL basename).
+# Verified by .github/scripts/install-mill.sh in every CI job before the first ./mill.
+# Provenance: computed 2026-09-04 from repo1.maven.org downloads whose SHA-1 matched the published .sha1
+# (amd64 e3b9ec419f3895c46f8d531613c34a79ab8f52ef, aarch64 ee249579afe8fd6077e6cfd40383652e74bc41f9,
+# jvm 1e9f6f6f7279e6bc20f43b2a929481df4cb85b32). Maven Central publishes no .sha256 for these artifacts.
+# After bumping .mill-version, CI prints the exact line to add here.
+ba60d03577380a906c2273cca7656828705e25fef519a1e927656ae167e8f644  mill-dist-native-linux-amd64-1.1.8.exe
+773206f1b3b4bd6b42ffbf7c2c8d168c6210e4f075ae06089ddcf6e0fe5d7db8  mill-dist-native-linux-aarch64-1.1.8.exe
+19d92383f50b373502d94ceb9b1f14280224ee508632641157aad5f4fa66866d  mill-dist-1.1.8.exe

--- a/.github/scripts/install-mill.sh
+++ b/.github/scripts/install-mill.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Pre-install the exact Mill distribution the ./mill launcher would download, verified against the
+# SHA-256 pinned in .github/mill-dist.sha256. The launcher skips its own unverified download
+# whenever the final path is non-empty (`[ ! -s "$MILL" ]`), so after this step every `./mill`
+# execs verified bytes — and a restored cache whose Mill binary does not match the pin fails the
+# job instead of running.
+#
+# Runs as the last step of .github/actions/setup-build in every CI job. Portable to bash 3.2
+# (macOS /bin/bash) — no mapfile, no associative arrays.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+SUMS="$ROOT/.github/mill-dist.sha256"
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+# The launcher's dry-run mode prints exactly two lines — the download URL and the final path — and
+# exits 0 even when the file already exists.
+DRY="$(MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT=1 ./mill)"
+LINES="$(printf '%s\n' "$DRY" | wc -l | tr -d ' ')"
+URL="$(printf '%s\n' "$DRY" | sed -n 1p)"
+DEST="$(printf '%s\n' "$DRY" | sed -n 2p)"
+if [ "$LINES" != "2" ] || [ -z "$URL" ] || [ -z "$DEST" ]; then
+  echo "::error::install-mill: launcher dry-run printed $LINES line(s), expected URL then path — the mill launcher format changed; re-check .github/scripts/install-mill.sh"
+  printf '%s\n' "$DRY"
+  exit 1
+fi
+NAME="$(basename "$URL")"
+EXPECTED="$(awk -v n="$NAME" '$1 !~ /^#/ && $2 == n { print $1 }' "$SUMS")"
+if [ -z "$EXPECTED" ]; then
+  echo "::error::install-mill: no pinned SHA-256 for $NAME in .github/mill-dist.sha256. After bumping .mill-version: curl -fsSL $URL -o /tmp/m; test \"\$(curl -fsSL $URL.sha1)\" = \"\$(shasum -a 1 /tmp/m | cut -d' ' -f1)\"; shasum -a 256 /tmp/m — then add the line '<sha256>  $NAME'."
+  exit 1
+fi
+
+if [ -s "$DEST" ]; then
+  ACTUAL="$(sha256_of "$DEST")"
+  if [ "$ACTUAL" = "$EXPECTED" ]; then
+    echo "install-mill: $DEST matches pinned SHA-256 ($EXPECTED)"
+    exit 0
+  fi
+  # A mismatch is a poisoned cache or a wrong pin — both need a human. An exact-key cache hit is
+  # never re-saved, so the entry persists until deleted.
+  echo "::error::install-mill: $DEST (restored from cache) has SHA-256 $ACTUAL, pinned $EXPECTED — refusing to run it. A cache hit is never re-saved, so this entry persists: investigate, then purge it with 'gh cache list --key ${MILL_CACHE_KEY_HINT:-<os>-mill-<prefix>-}' and 'gh cache delete <id>' (or 'gh cache delete --all')."
+  exit 1
+fi
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+echo "install-mill: downloading $URL"
+curl -fsSL --retry 3 --retry-all-errors -o "$TMP" "$URL"
+ACTUAL="$(sha256_of "$TMP")"
+if [ "$ACTUAL" != "$EXPECTED" ]; then
+  echo "::error::install-mill: SHA-256 mismatch for $URL: got $ACTUAL, pinned $EXPECTED"
+  exit 1
+fi
+chmod +x "$TMP"
+mkdir -p "$(dirname "$DEST")"
+mv "$TMP" "$DEST"
+trap - EXIT
+echo "install-mill: installed verified Mill at $DEST"

--- a/.github/scripts/install-mill.sh
+++ b/.github/scripts/install-mill.sh
@@ -2,8 +2,10 @@
 # Pre-install the exact Mill distribution the ./mill launcher would download, verified against the
 # SHA-256 pinned in .github/mill-dist.sha256. The launcher skips its own unverified download
 # whenever the final path is non-empty (`[ ! -s "$MILL" ]`), so after this step every `./mill`
-# execs verified bytes — and a restored cache whose Mill binary does not match the pin fails the
-# job instead of running.
+# execs a verified launcher — and a restored cache whose Mill binary does not match the pin fails
+# the job instead of running. Scope: the launcher distribution only. Mill's own jars are resolved
+# by coursier (SHA-1-checked on download; trusted from the restored cache in non-release CI jobs —
+# the release workflow restores no cache).
 #
 # Runs as the last step of .github/actions/setup-build in every CI job. Portable to bash 3.2
 # (macOS /bin/bash) — no mapfile, no associative arrays.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -17,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up build
         uses: ./.github/actions/setup-build
@@ -42,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest # clang + jq preinstalled; SN 0.5 recommends LLVM >= 17
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       # Separate cache prefix from the JDK-matrix builds so the Scala Native toolchain artifacts
       # (nativelib/javalib/clib NIR jars) don't churn the main cache.

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,11 +1,15 @@
 name: Conformance
 
-# Runs the official MCP conformance "active" server suite (via `bunx @modelcontextprotocol/conformance`)
-# against the fast-mcp-scala ConformanceServer over streamable HTTP, on both platforms.
+# Runs the official MCP conformance "active" server suite (via the pinned harness in
+# conformance/package.json + bun.lock, installed with bun install --frozen-lockfile) against the
+# fast-mcp-scala ConformanceServer over streamable HTTP, on both platforms.
 on:
   pull_request:
   push:
     branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   conformance:
@@ -17,12 +21,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up build
         uses: ./.github/actions/setup-build
         with:
           bun: "true"
+          cache-write: "false" # this job executes the npm harness: restore the shared cache read-only
 
       # Boots the server, drives it with the pinned conformance harness, and checks the result against
       # conformance/baseline-${platform}.yml (both baselines are empty — full active-suite green).

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -13,8 +13,8 @@ on:
   push:
     branches: [main]
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+permissions:
+  contents: read
 
 jobs:
   native-smoke:
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up build
         uses: ./.github/actions/setup-build
@@ -31,6 +31,8 @@ jobs:
 
       - name: Build native stdio smoke binary
         run: ./mill fast-mcp-scala.nativeSmoke.stdio.nativeImage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # coursier JVM-index / GraalVM provisioning by Mill; kept off the harness steps
 
       - name: Exercise binary over stdio JSON-RPC
         run: ./scripts/native-smoke.sh
@@ -40,16 +42,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up build
         uses: ./.github/actions/setup-build
         with:
           bun: "true"          # conformance harness
           cache-prefix: native
+          cache-write: "false" # this job executes the npm harness: restore the shared cache read-only
 
       - name: Build native HTTP conformance binary
         run: ./mill fast-mcp-scala.nativeSmoke.http.nativeImage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # coursier JVM-index / GraalVM provisioning by Mill; kept off the harness steps
 
       # The official MCP conformance suite against the native binary, held to the SAME
       # (empty) baseline as the JVM: any divergence is a native-image bug, never a new baseline.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,30 +10,60 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
-permissions:
-  contents: write
+# Every job declares exactly what it needs. Only github-release may write, and it holds no
+# publishing secret; publish holds the publishing secrets and may not write.
+permissions: {}
 
 jobs:
-  release:
-    name: Publish to Maven Central
+  verify:
+    name: Test
     runs-on: ubuntu-latest
     # Only run on the main repository, not forks
     if: github.repository == 'TJC-LP/fast-mcp-scala'
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      # cache "false": the release workflow never restores (or saves) a cache written by main-scope
+      # jobs; everything comes fresh from Maven Central with coursier's checksum check and the Mill
+      # distribution is verified against .github/mill-dist.sha256. bun stays at its default "false":
+      # js.test uses the mill-bun managed, SHA-256-verified Bun.
+      - name: Set up build
+        uses: ./.github/actions/setup-build
+        with:
+          cache: "false"
+
+      - name: Run Tests
+        run: ./mill -i fast-mcp-scala.test
+
+  publish:
+    name: Publish to Maven Central
+    needs: verify
+    runs-on: ubuntu-latest
+    if: github.repository == 'TJC-LP/fast-mcp-scala'
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Set up build
         uses: ./.github/actions/setup-build
         with:
-          bun: "true"
+          cache: "false"   # never restore a cache written by main-scope jobs; fresh Maven Central downloads only
 
       - name: Fetch annotated tags
-        run: git fetch --tags --force
+        run: git fetch --tags --force   # unauthenticated: public repo
 
       - name: Extract version
         id: version
@@ -45,10 +75,7 @@ jobs:
             echo "Error: Tag must be a valid semver version (e.g., v0.1.0, v1.0.0-RC1)"
             exit 1
           fi
-          echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Run Tests
-        run: ./mill -i fast-mcp-scala.test
+          echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Verify Publishing Setup
         run: |
@@ -57,6 +84,9 @@ jobs:
         env:
           PUBLISH_VERSION: ${{ steps.version.outputs.version }}
 
+      # LAST step of the job. The only code that runs after the secrets appear is actions/checkout's
+      # GitHub-owned, SHA-pinned post step (credential cleanup — a no-op with persist-credentials:
+      # false); coursier/setup-action has no post hook and setup-bun is not used in this job.
       - name: Publish to Maven Central
         run: ./mill -i mill.javalib.SonatypeCentralPublishModule/
         env:
@@ -66,13 +96,29 @@ jobs:
           MILL_PGP_SECRET_BASE64: ${{ secrets.PGP_SECRET }}
           MILL_PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
 
+  github-release:
+    name: Create GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    if: github.repository == 'TJC-LP/fast-mcp-scala'
+    permissions:
+      contents: write   # the ONLY write grant in the workflow
+
+    steps:
+      # No checkout, no third-party action: gh is preinstalled and GitHub-owned. References no
+      # Sonatype/PGP secret — only the job token.
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          generate_release_notes: true
-          draft: false
-          # Any tag with a qualifier (v0.3.0-rc1, v0.3.0-beta2) is flagged as a prerelease;
-          # final tags like v0.3.0 are treated as regular releases.
-          prerelease: ${{ contains(github.ref_name, '-') }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG already exists"
+            exit 0
+          fi
+          # Any tag with a qualifier (v1.0.0-RC4, v0.3.0-beta2) is flagged as a prerelease;
+          # final tags like v1.0.0 are treated as regular releases.
+          PRE=()
+          [[ "$TAG" == *-* ]] && PRE=(--prerelease)
+          gh release create "$TAG" --verify-tag --generate-notes "${PRE[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ bun.lockb
 bun.lock
 # The js module's lock is source-controlled: mill-bun 0.3 installs with --frozen-lockfile.
 !fast-mcp-scala/js/bun.lock
+!conformance/bun.lock
 *.class
 *.tasty
 

--- a/conformance/bun.lock
+++ b/conformance/bun.lock
@@ -1,0 +1,249 @@
+{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "fast-mcp-scala-conformance-harness",
+      "dependencies": {
+        "@modelcontextprotocol/conformance": "0.2.0-alpha.11",
+      },
+    },
+  },
+  "packages": {
+    "@hono/node-server": ["@hono/node-server@2.1.1", "", { "peerDependencies": { "hono": "^4" } }, "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg=="],
+
+    "@modelcontextprotocol/conformance": ["@modelcontextprotocol/conformance@0.2.0-alpha.11", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "@octokit/rest": "^22.0.0", "ajv": "^8.20.0", "ajv-formats": "^3.0.1", "commander": "^14.0.2", "eventsource-parser": "^3.0.8", "express": "^5.1.0", "jose": "^6.1.2", "undici": "^7.25.0", "yaml": "^2.8.2", "zod": "^4.3.6" }, "bin": { "conformance": "dist/index.js" } }, "sha512-imPK9tx5gQsL6ZKQq4MrsyDYfSaIwpRmX6+ogjbeAXs9LGvxkBxWcY7KcS7TvwaBk/ZiVWl6b/naF4q83UwDRA=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
+
+    "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
+
+    "@octokit/core": ["@octokit/core@7.0.8", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.5", "@octokit/request": "^10.0.16", "@octokit/request-error": "^7.1.2", "@octokit/types": "^18.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-L7y8eYc+AwxGr2PWI4WFt1VG4TiJ66c26BD16mXpYIlXxG0SMigM1+m4aTSlYyBr5BlQsGAlz8uDCoZN4SEMcg=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.5", "", { "dependencies": { "@octokit/types": "^18.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-iXa654H3yFafF/ieHkukfbgWo2rmXD2ceD0ZOtrPhw1bc3FDch1d9N/TNs0FQ1/cIbwb7kspUX8jzIs8nzb9DQ=="],
+
+    "@octokit/graphql": ["@octokit/graphql@9.0.5", "", { "dependencies": { "@octokit/request": "^10.0.16", "@octokit/types": "^18.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-bt/hm03LeU6Vy7FwTrkkC9p3XGT/lBwClglMqxBSe5/q0E5CdJTXeAqEI0vlw89/LF/G6tryTIH8HirZ3prMVg=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@29.0.1", "", {}, "sha512-9qWOMFNxxLokERcms42rU0PTLqQmVs7g5E41TI4mCOxmpFayD1rfC7XxOL55cG9MBZLFlC31BrR37myMKardwg=="],
+
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@14.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw=="],
+
+    "@octokit/plugin-request-log": ["@octokit/plugin-request-log@6.0.0", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q=="],
+
+    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
+
+    "@octokit/request": ["@octokit/request@10.0.16", "", { "dependencies": { "@octokit/endpoint": "^11.0.5", "@octokit/request-error": "^7.1.2", "@octokit/types": "^18.0.0", "content-type": "^3.0.0", "json-with-bigint": "^3.5.12", "universal-user-agent": "^7.0.2" } }, "sha512-A0zWGjHzISIb+9ccG8s0dq7LKO5zVpJLRICjgUb+sJxEWqn8RUHB1rD3AE51+PECvXHIxqZ1VVvs4fHTSD9nUQ=="],
+
+    "@octokit/request-error": ["@octokit/request-error@7.1.2", "", { "dependencies": { "@octokit/types": "^18.0.0" } }, "sha512-XZRuT3xZ84D3gYErI1DZvhJ33dCWVV6uzBtWkaBB4TvA/L6eOeTZodxLFVB44bBEEo3vEx7y00UfX1tBLrtLRg=="],
+
+    "@octokit/rest": ["@octokit/rest@22.0.1", "", { "dependencies": { "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-request-log": "^6.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0" } }, "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw=="],
+
+    "@octokit/types": ["@octokit/types@18.0.0", "", { "dependencies": { "@octokit/openapi-types": "^29.0.1" } }, "sha512-l6bAF43PNxkJp6g+W4PjoUSSkxHomXw2nOum5CTftJz1NlV3vu93NImgOYtLf6CbBUb5j+fiuzW0PPQ5JTSvZA=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
+
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.1", "", {}, "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.7.0", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.13.7", "", {}, "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.7.0", "", {}, "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.11", "", {}, "sha512-A5NPn7g8EAzGU3IzRs+Yiq8K5n3ypYS75M5+KKiVHdUexfpWK1kP4ZMq7QnTGDoMj6TJ1dtcEJjW60yZDXS4hg=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "json-with-bigint": ["json-with-bigint@3.5.12", "", {}, "sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.1", "", {}, "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.1.0", "", { "dependencies": { "content-type": "^2.1.0" } }, "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.16.0", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
+    "undici": ["undici@7.29.1", "", {}, "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q=="],
+
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "zod": ["zod@4.5.4", "", {}, "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@octokit/plugin-paginate-rest/@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
+    "@octokit/plugin-rest-endpoint-methods/@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
+    "@octokit/request/content-type": ["content-type@3.0.0", "", {}, "sha512-AIi5H6p0xk5uknXcN3/rmhP8jgp69OfSe/JuKiQAFprJ7UGw7mwj7m4XcmDzlrnJDG+cGpphAINGdU3g3g7kDw=="],
+
+    "body-parser/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
+
+    "negotiator/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
+
+    "type-is/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
+
+    "@octokit/plugin-paginate-rest/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+
+    "@octokit/plugin-rest-endpoint-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+  }
+}

--- a/conformance/package.json
+++ b/conformance/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "fast-mcp-scala-conformance-harness",
+  "private": true,
+  "description": "Pinned @modelcontextprotocol/conformance harness driven by scripts/conformance.sh. Bump deliberately; regenerate bun.lock with the Mill-managed Bun (see scripts/conformance.sh header). Review the bun.lock diff, not this file: --frozen-lockfile treats the lock as authoritative.",
+  "type": "module",
+  "dependencies": {
+    "@modelcontextprotocol/conformance": "0.2.0-alpha.11"
+  }
+}

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -75,6 +75,11 @@ trap cleanup EXIT
 # gate the fallbacks on version.
 resolve_bun() {
   local b="${FAST_MCP_BUN:-}"
+  if [ -n "$b" ] && [ ! -x "$b" ]; then
+    # An explicit pin that does not resolve is an error, never a silent fallback to another Bun.
+    echo "FAST_MCP_BUN=$b is not executable" >&2
+    exit 2
+  fi
   if [ -z "$b" ]; then
     b="$(./mill --no-server show fast-mcp-scala.js.bunExecutable 2>/dev/null | tr -d '"' || true)"
   fi
@@ -100,17 +105,25 @@ install_harness() {
     echo "conformance/bun.lock is missing — refusing to resolve the harness from the registry" >&2
     exit 2
   fi
-  local want; want="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["dependencies"]["@modelcontextprotocol/conformance"])' "$HARNESS_DIR/package.json")"
+  # Informational only (the lock is authoritative); best-effort so a box without python3 still installs.
+  local want; want="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["dependencies"]["@modelcontextprotocol/conformance"])' "$HARNESS_DIR/package.json" 2>/dev/null || echo '?')"
   echo "→ installing conformance harness @${want} (frozen lockfile, fresh install cache)" >&2
   BUN_CACHE="$(mktemp -d -t fmcp-bun-cache.XXXXXX)"
   rm -rf "$HARNESS_DIR/node_modules"
   ( cd "$HARNESS_DIR" && BUN_INSTALL_CACHE_DIR="$BUN_CACHE" "$BUN" install --frozen-lockfile --ignore-scripts --no-summary )
 }
 
-# `bun run` only executes what the frozen install put in node_modules/.bin (rc=1 'Script not
-# found' otherwise); `bunx` would auto-install a same-named package from the registry.
+# Exec the bin the frozen install put in node_modules/.bin — deterministically that file. `bun run
+# conformance` would fall back to a same-named executable on PATH when no package bin matches, and
+# `bunx` would auto-install a same-named package from the registry; neither is an acceptable sink.
+# The bin's shebang is `#!/usr/bin/env node`, so the harness runs under Node exactly as before.
 run_harness() {
-  ( cd "$HARNESS_DIR" && exec "$BUN" run conformance "$@" )
+  local bin="$HARNESS_DIR/node_modules/.bin/conformance"
+  if [ ! -x "$bin" ]; then
+    echo "conformance harness bin missing after frozen install ($bin)" >&2
+    exit 2
+  fi
+  ( cd "$HARNESS_DIR" && exec "$bin" "$@" )
 }
 
 # Refuse to run if ANYTHING already listens on the port — the readiness poll below would

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -5,14 +5,22 @@
 #   scripts/conformance.sh [jvm|js|native] [port] [active|2026]
 #
 # Boots the cross-platform ConformanceServer (com.tjclp.fastmcp.examples.conformance.*) over
-# streamable HTTP, then drives it with the official harness via `bunx`. Exit code follows the harness
-# (0 = all scored scenarios pass or match the platform baseline; 1 = regression / stale baseline).
+# streamable HTTP, then drives it with the official harness installed from the committed,
+# integrity-hashed lockfile in conformance/ (bun install --frozen-lockfile — never bunx). Exit code
+# follows the harness (0 = all scored scenarios pass or match the platform baseline; 1 = regression /
+# stale baseline).
 #
 # Modes: "active" (default) runs the active suite across both protocol eras with the per-platform
 # baseline; "2026" runs `--requirements 2026-07-28` — exactly the scenarios that revision requires,
 # frozen at its release (extension/pending scenarios are reported but not scored by the harness).
 #
-# Requires: a JDK (jvm), bun (both). No vendored conformance checkout — the engine is fetched by bunx.
+# Requires: a JDK (jvm) and Bun >= 1.4 (every platform). The script prefers the Mill-managed Bun
+# (fast-mcp-scala.js.bunExecutable — the same SHA-256-verified 1.4.1 that generated conformance/bun.lock),
+# then $FAST_MCP_BUN, then PATH. The harness is resolved ONLY from conformance/package.json +
+# conformance/bun.lock: a run whose resolution differs from the committed lock fails before the suite
+# starts. To bump: edit the version in conformance/package.json, then
+#   "$(./mill --no-server show fast-mcp-scala.js.bunExecutable | tr -d '"')" install --cwd conformance
+# and review the bun.lock diff (it, not package.json, is what --frozen-lockfile enforces).
 #
 # "native" runs the SAME conformance server compiled to a GraalVM native image
 # (fast-mcp-scala.nativeSmoke.http.nativeImage; override with FAST_MCP_NATIVE_BIN) against the
@@ -23,9 +31,11 @@ set -euo pipefail
 PLATFORM="${1:-jvm}"
 PORT="${2:-8077}"
 MODE="${3:-active}"
-CONF_VERSION="0.2.0-alpha.11" # RC1 oracle: first release with the 2026-07-28 scenario set; bump deliberately
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
+HARNESS_DIR="$ROOT/conformance"   # committed package.json + bun.lock: the ONLY source of the harness
+BUN=""                            # resolved by resolve_bun
+BUN_CACHE=""                      # fresh per-run Bun install cache, removed in cleanup
 URL="http://127.0.0.1:${PORT}/mcp"
 BASELINE="$ROOT/conformance/baseline-${PLATFORM}.yml"
 [ "$PLATFORM" = "native" ] && BASELINE="$ROOT/conformance/baseline-jvm.yml"
@@ -55,8 +65,53 @@ stop_server() {
 cleanup() {
   stop_server
   [ -n "$ENTRY" ] && rm -f "$ENTRY" 2>/dev/null || true
+  [ -n "$BUN_CACHE" ] && rm -rf "$BUN_CACHE" 2>/dev/null || true
 }
 trap cleanup EXIT
+
+# Pick the Bun that runs the harness (and the JS server). conformance/bun.lock is lockfileVersion 2,
+# which Bun < 1.4 cannot read (it prints UnknownLockfileVersion and then 'lockfile had changes'), so
+# prefer the Mill-managed 1.4.1 — the binary that generated the lock and that js.test uses — and
+# gate the fallbacks on version.
+resolve_bun() {
+  local b="${FAST_MCP_BUN:-}"
+  if [ -z "$b" ]; then
+    b="$(./mill --no-server show fast-mcp-scala.js.bunExecutable 2>/dev/null | tr -d '"' || true)"
+  fi
+  if [ -z "$b" ] || [ ! -x "$b" ]; then b="$(command -v bun || true)"; fi
+  [ -n "$b" ] || { echo "bun not found (Mill-managed, \$FAST_MCP_BUN, or PATH) — cannot install the conformance harness" >&2; exit 2; }
+  local v; v="$("$b" --version)"
+  case "$v" in
+    0.*|1.[0-3].*) echo "bun $v at $b is too old for conformance/bun.lock (lockfileVersion 2 needs Bun >= 1.4); use the Mill-managed Bun or set FAST_MCP_BUN" >&2; exit 2 ;;
+  esac
+  BUN="$b"
+  echo "→ bun $v ($BUN)" >&2
+}
+
+# Install the harness from the committed lockfile — never from a floating registry resolution.
+#  * --frozen-lockfile does NOT fail when bun.lock is absent: Bun resolves from the registry and
+#    installs anyway (rc=0, no lock written). The lock's presence is therefore asserted first.
+#  * Bun verifies sha512 only when it EXTRACTS a tarball; a warm ~/.bun/install/cache entry for
+#    name@version is reused unverified. A fresh, empty cache per run forces every tarball through
+#    the integrity check (~118 small packages; a few seconds).
+#  * node_modules is wiped first: a failed install leaves a partial tree behind.
+install_harness() {
+  if [ ! -s "$HARNESS_DIR/bun.lock" ]; then
+    echo "conformance/bun.lock is missing — refusing to resolve the harness from the registry" >&2
+    exit 2
+  fi
+  local want; want="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["dependencies"]["@modelcontextprotocol/conformance"])' "$HARNESS_DIR/package.json")"
+  echo "→ installing conformance harness @${want} (frozen lockfile, fresh install cache)" >&2
+  BUN_CACHE="$(mktemp -d -t fmcp-bun-cache.XXXXXX)"
+  rm -rf "$HARNESS_DIR/node_modules"
+  ( cd "$HARNESS_DIR" && BUN_INSTALL_CACHE_DIR="$BUN_CACHE" "$BUN" install --frozen-lockfile --ignore-scripts --no-summary )
+}
+
+# `bun run` only executes what the frozen install put in node_modules/.bin (rc=1 'Script not
+# found' otherwise); `bunx` would auto-install a same-named package from the registry.
+run_harness() {
+  ( cd "$HARNESS_DIR" && exec "$BUN" run conformance "$@" )
+}
 
 # Refuse to run if ANYTHING already listens on the port — the readiness poll below would
 # otherwise happily bless a foreign server and the suite would test the wrong process.
@@ -65,6 +120,11 @@ if (exec 3<>"/dev/tcp/127.0.0.1/$PORT") 2>/dev/null; then
   echo "port $PORT is already in use — refusing to test an unknown server" >&2
   exit 2
 fi
+
+# Resolve Bun and install the pinned harness BEFORE any server starts: a lock/Bun failure then needs
+# no teardown and cannot be confused with a server failure.
+resolve_bun
+install_harness
 
 jvm_classpath() {
   ./mill --no-server show fast-mcp-scala.jvm.runClasspath 2>/dev/null |
@@ -87,7 +147,7 @@ start_js() {
   ENTRY="$(mktemp -t fmcp-conf-entry.XXXXXX).mjs"
   printf 'import { startConformance } from "%s/main.js";\nstartConformance(Number(process.argv[2] ?? %s));\n' "$dest" "$PORT" >"$ENTRY"
   echo "→ launching ConformanceServerJs on :$PORT (Bun)" >&2
-  bun run "$ENTRY" "$PORT" >"$LOG" 2>&1 &
+  "$BUN" run "$ENTRY" "$PORT" >"$LOG" 2>&1 &
   SRV_PID=$!
 }
 
@@ -128,13 +188,11 @@ set +e
 case "$MODE" in
   active)
     echo "→ conformance active suite ($PLATFORM, baseline $(basename "$BASELINE"))" >&2
-    bunx "@modelcontextprotocol/conformance@${CONF_VERSION}" \
-      server --url "$URL" --suite active --expected-failures "$BASELINE"
+    run_harness server --url "$URL" --suite active --expected-failures "$BASELINE"
     ;;
   2026)
     echo "→ conformance 2026-07-28 requirements ($PLATFORM)" >&2
-    bunx "@modelcontextprotocol/conformance@${CONF_VERSION}" \
-      server --url "$URL" --requirements 2026-07-28
+    run_harness server --url "$URL" --requirements 2026-07-28
     ;;
   *) echo "usage: $0 [jvm|js|native] [port] [active|2026]" >&2; exit 2 ;;
 esac


### PR DESCRIPTION
## Summary

Hardens the CI/release supply chain against two related attacks found by the 2026-09-04 security scan. **F6**: `scripts/conformance.sh` ran `bunx @modelcontextprotocol/conformance@…` with only the top-level version pinned, so every push to `main` executed a run-time-resolved npm dependency tree with write access to `~/.cache/mill` / `~/.cache/coursier` — a cache that the tag-triggered release job then restored and `exec`'d unverified, with the Sonatype and PGP secrets in its environment. **F7**: the one job holding publishing credentials referenced every third-party action by mutable tag (`@v1`, `@v2`, `@v4`) and ran `softprops/action-gh-release` with a `contents: write` token after the publish step, on the same runner. This PR freezes the harness behind a committed, integrity-hashed lockfile executed from its installed bin, verifies the Mill launcher distribution against pinned SHA-256s in every job, removes cache restores from the release workflow, SHA-pins every action with Dependabot upkeep, and splits release into `verify -> publish -> github-release` with least-privilege tokens.

Part 1/6 of the TJC-2294 security stack; base: `main`. Linear: TJC-2299 (umbrella TJC-2294). No Scala source changes.

## Findings addressed

| Finding | Severity | CWE | Title | Status |
|---|---|---|---|---|
| F6 | MEDIUM | CWE-494 | Release job restores the Mill/coursier toolchain from a default-branch cache that push:main conformance jobs write after executing unlocked run-time npm code | Fixed |
| F7 | MEDIUM | CWE-829 | Release job executes third-party actions by mutable tag with a contents:write token, before and after the Maven Central publish step | Fixed |

Independent verification (merge-verify pass): both findings **fixed**, no bypasses found; residuals listed below.

## What changed

**Conformance harness pinned and frozen (F6.1)**
- `conformance/package.json` (new, `private`) — exact pin `"@modelcontextprotocol/conformance": "0.2.0-alpha.11"`; the description says to review the `bun.lock` diff, not this file.
- `conformance/bun.lock` (new; Bun 1.4.1, lockfileVersion 2, 118 `sha512` integrity entries) — the only source of harness resolution. `.gitignore` gains `!conformance/bun.lock` (mirrors the existing `!fast-mcp-scala/js/bun.lock` exception).
- `scripts/conformance.sh`
  - `resolve_bun()` — prefers the Mill-managed, SHA-256-verified Bun (`fast-mcp-scala.js.bunExecutable`), then `$FAST_MCP_BUN`, then `PATH`; a non-executable `FAST_MCP_BUN` is an error (exit 2, no silent fallback); Bun < 1.4 is rejected (exit 2) because it cannot read lockfileVersion 2.
  - `install_harness()` — refuses to run when `conformance/bun.lock` is absent (exit 2; `--frozen-lockfile` alone does *not* fail on a missing lock — it resolves from the registry), `rm -rf node_modules`, then `bun install --frozen-lockfile --ignore-scripts --no-summary` into a **fresh per-run** `BUN_INSTALL_CACHE_DIR` (Bun only re-verifies tarball hashes on a cold cache; a warm cache installs a tampered lock with rc=0).
  - `run_harness()` — `exec`s `conformance/node_modules/.bin/conformance` directly (exit 2 if missing). Neither `bunx` (auto-installs from the registry) nor `bun run` (falls back to a same-named `PATH` executable in Bun 1.4.x) is used anywhere; `grep bunx` over `*.sh`/`*.yml`/`*.mill` is empty.
  - Both guards run before any server process starts; the `CONF_VERSION` literal is gone.

**Mill launcher distribution verified; release restores no cache (F6.2)**
- `.github/mill-dist.sha256` (new) — SHA-256 pins for `mill-dist-native-linux-amd64-1.1.8.exe`, `mill-dist-native-linux-aarch64-1.1.8.exe` and the JVM fallback `mill-dist-1.1.8.exe`, with provenance (SHA-1 cross-checked against Maven Central's published `.sha1`; Central publishes no `.sha256`).
- `.github/scripts/install-mill.sh` (new, 100755) — parses the launcher's dry-run (`MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT=1 ./mill` -> URL, dest), refuses an unpinned dist name (exit 1, prints the exact line to add plus the `.sha1` cross-check recipe), hashes an already-present (cache-restored) binary and exits 1 on mismatch with a `gh cache delete` hint, otherwise downloads to a temp file and moves it into place only after the SHA-256 matches. Runs as the **last** step of the composite, so every job's first `./mill` execs a verified launcher.
- `.github/actions/setup-build/action.yml` — new inputs `cache` (default `"true"`; `"false"` registers no cache step at all) and `cache-write` (default `"true"`; `"false"` switches to `actions/cache/restore` — read-only); `setup-bun` gets `no-cache: true` so its post step cannot write `~/.bun/bin/bun` into the shared cache; a comment forbids ever adding `~/.bun/install/cache` to a cache path.
- `.github/workflows/release.yml` — both `verify` and `publish` pass `cache: "false"`; `bun` stays at its default `"false"` (js.test uses the Mill-managed Bun).
- `.github/workflows/conformance.yml`, `.github/workflows/native.yml` (native-http job) — the jobs that execute the npm harness pass `cache-write: "false"`.

**Every action SHA-pinned, Dependabot upkeep (F7.1)**
- All `uses:` across `ci.yml`, `conformance.yml`, `native.yml`, `release.yml` and the composite are full 40-hex commit SHAs with a same-line `# vX.Y.Z` comment: `actions/checkout@11d5960a… # v4.4.0`, `actions/cache[/restore]@0057852b… # v4.3.0`, `coursier/setup-action@039f7365… # v1.3.9`, `oven-sh/setup-bun@0c5077e5… # v2.2.0`. `softprops/action-gh-release@v1` is removed.
- `.github/dependabot.yml` (new) — `github-actions` for `"/"` and the explicit `"/.github/actions/setup-build"` directory, plus `bun` for `/conformance`; weekly, `cooldown.default-days: 7`, grouped, `ci` commit prefix.

**Release split into least-privilege jobs (F7.2)**
- `.github/workflows/release.yml` — workflow-level `permissions: {}`; `verify` (`contents: read`, runs `fast-mcp-scala.test`) -> `publish` (`contents: read`, checkout `persist-credentials: false`, `cache: "false"`, Sonatype publish is the **last** step; the only post-secret code is `actions/checkout`'s GitHub-owned SHA-pinned post hook, a no-op with `persist-credentials: false`; `coursier/setup-action` has no post hook; `setup-bun` and `actions/cache` do not run) -> `github-release` (the **only** `contents: write`; no checkout, no `uses:`; `gh release create "$TAG" --verify-tag --generate-notes [--prerelease]` with `GH_TOKEN: ${{ github.token }}`; idempotent via `gh release view`; references no Sonatype/PGP secret). Each job is gated `if: github.repository == 'TJC-LP/fast-mcp-scala'`.
- `ci.yml`, `conformance.yml`, `native.yml` — top-level `permissions: contents: read`. `native.yml` drops the workflow-level `GITHUB_TOKEN` env and scopes it to the two Mill steps that need it (coursier JVM-index / GraalVM provisioning), keeping it off the harness steps.

## Behaviour changes (pre-1.0)

No library or runtime behaviour changes — this PR touches only CI, scripts and lockfiles. Developer/CI-facing changes:

- `scripts/conformance.sh` now **requires Bun >= 1.4** (prefers the Mill-managed 1.4.1) and a present `conformance/bun.lock`; it exits 2 before starting any server if either is missing, and exits 1 if the resolution drifts from the lock or a tarball hash mismatches. `FAST_MCP_BUN` pointing at a non-executable path is an error rather than a silent fallback.
- Every invocation performs a fresh-cache install of ~118 tarballs from `registry.npmjs.org` (three times per `native-http` CI run) — the deliberate price of an unconditional integrity check. Local runs see `→ installing conformance harness @0.2.0-alpha.11 (frozen lockfile, fresh install cache)`.
- `scripts/conformance.sh` runs `./mill --no-server show fast-mcp-scala.js.bunExecutable` once per invocation (~15 s warm) also for `jvm`/`native`.
- Bumping `.mill-version` now requires adding the new dists' SHA-256 lines to `.github/mill-dist.sha256` in the same PR, or CI fails with the exact line to add. Bumping the harness means editing `conformance/package.json` and regenerating `conformance/bun.lock` with the Mill-managed Bun (`"$(./mill --no-server show fast-mcp-scala.js.bunExecutable | tr -d '"')" install --cwd conformance`).
- Release runs as three sequential jobs; a re-run after a successful publish is safe (`github-release` is idempotent). Release notes are still auto-generated; prerelease detection (tag contains `-`) is unchanged.
- Harness-running CI jobs no longer *write* the shared Mill/coursier cache; the `ci.yml` matrix jobs remain the cache writers. Release jobs download everything fresh from Maven Central (coursier checksums + verified launcher), so release runs are somewhat slower.
- Running `.github/scripts/install-mill.sh` directly on macOS fails with `no pinned SHA-256 for mill-dist-native-mac-*` — it is CI-only; `scripts/conformance.sh` does not call it.

## Fix criteria -> evidence

Line numbers are on `tjc-2299-ci-supply-chain`.

**F6.1** — harness + entire dependency tree resolved from a committed lockfile with integrity hashes, frozen-lockfile install; any resolved package differing from the lock fails instead of executing.
- `conformance/package.json:7` exact pin; `conformance/bun.lock` 118 `sha512` entries, tracked (`.gitignore:69`).
- `scripts/conformance.sh:104-106` lock-presence guard (exit 2); `:112` `rm -rf node_modules`; `:113` `bun install --frozen-lockfile --ignore-scripts --no-summary` with fresh `BUN_INSTALL_CACHE_DIR`; `:120-124` `run_harness` execs `node_modules/.bin/conformance` (exit 2 if absent); `:76-91` `resolve_bun` (non-executable `FAST_MCP_BUN` -> exit 2 at `:80-81`; Bun < 1.4 -> exit 2 at `:90`); `:139-140` both guards before any server; `:204`/`:208` the only harness invocations.
- Evidence (local, Bun 1.4.1, fresh cache): committed lock -> rc=0, lock byte-identical after install, `--version` = 0.2.0-alpha.11; `package.json` drift to alpha.10 -> rc=1 `lockfile had changes, but lockfile is frozen`; tampered `sha512` for `@hono/node-server` -> rc=1 `Integrity check failed for tarball` (also with the user's warm `~/.bun` cache, because the run uses a fresh cache); lock entry re-pointed `commander@14.0.3 -> 12.1.0` with the old hash -> rc=1; integrity field removed -> rc=1; extra dep in `package.json` -> rc=1; lock moved away -> rc=2 `refusing to resolve the harness from the registry`; `FAST_MCP_BUN=<bun 1.3.14>` -> rc=2 `too old`; `FAST_MCP_BUN=/nonexistent/bun` -> rc=2; `node_modules` absent + decoy `conformance` first on `PATH` -> `run_harness` exits 2 without executing the decoy (whereas `bun run conformance` in the same setup *did* execute it — the reason for the direct exec).
- No Scala test applies (CI-only change); the proof is the negative-path probes above plus the green end-to-end runs under Verification.

**F6.2** — release does not consume caches written by jobs that execute unreviewed run-time code, and/or the Mill distribution is verified against known checksums before execution.
- No cache in release: `.github/workflows/release.yml:39` and `:63` `cache: "false"`; every cache step in the composite is guarded `if: inputs.cache == 'true' && …` (`action.yml:66,77,90,101`), so neither release job registers `actions/cache` or `actions/cache/restore`; `setup-bun` is off (`action.yml:52`, default `"false"`); `publish` is a separate fresh runner (`needs: verify`, `release.yml:46`).
- Harness jobs restore read-only: `conformance.yml:30`, `native.yml:52` `cache-write: "false"` -> `actions/cache/restore` (`action.yml:77-78,101-102`); `setup-bun` `no-cache: true` (`action.yml:56`).
- Verified launcher: `action.yml:120` runs `install-mill.sh` as the last composite step; `install-mill.sh:27-34` dry-run parse + format guard; `:36-40` unpinned dist -> exit 1; `:44-52` cache-restored binary hashed, mismatch -> exit 1; `:59-66` fresh download verified before `mv` into place.
- Evidence: pins independently reproduced — re-downloaded all three dists from `repo1.maven.org`, SHA-1 equals the published `.sha1` (`e3b9ec41…`, `ee249579…`, `1e9f6f6f…`) and SHA-256 equals `.github/mill-dist.sha256:7-9`. Scratch `ROOT`/`HOME` runs of the committed script: missing pin -> rc=1 nothing installed; fresh download+verify -> rc=0; cache-hit match -> rc=0; cached binary with one appended byte -> rc=1 `refusing to run it` (the unmodified launcher would have exec'd it — it checks only `[ ! -s ]`); wrong pin on fresh download -> rc=1 nothing installed; bash 3.2 parses and runs it.

**F7.1** — every third-party action on the release path resolves to an immutable full-length commit SHA reviewed in this repository, with automated update PRs; no `uses:` is a tag or branch.
- `release.yml:28,54`; `action.yml:45,53,67,78,91,102`; `ci.yml:23,48`; `conformance.yml:24`; `native.yml:25,45` — all 40-hex SHAs with `# vX.Y.Z`.
- `grep -rnE 'uses:\s*[^./ ][^ ]*@' .github | grep -vE '@[0-9a-f]{40}'` -> empty. Each pin resolved against upstream with `gh api repos/<owner>/<repo>/git/matching-refs/tags/<tag>`: checkout v4.4.0 -> `11d5960a…`, cache v4.3.0 -> `0057852b…`, coursier/setup-action v1.3.9 -> `039f7365…`, setup-bun v2.2.0 -> `0c5077e5…` — all match. `actionlint` rc=0.
- Automated updates: `.github/dependabot.yml:6-20` (`github-actions`, both directories, weekly, 7-day cooldown, grouped); YAML parsed, `directories == ['/', '/.github/actions/setup-build']`.

**F7.2** — GitHub-release creation in a separate job that never references Sonatype/PGP secrets; `contents: write` only there; publish checkout `persist-credentials: false`; no third-party action runs in the publish job after the secrets are introduced.
- `release.yml:15` `permissions: {}`; `:23-24` verify `contents: read`; `:49-50` publish `contents: read`; `:104-105` github-release `contents: write` (the only write grant — confirmed by parsing the YAML); `:30` and `:58` `persist-credentials: false`; the only `secrets.` references are the four `MILL_*` vars on the final `Publish to Maven Central` step (`:94-97`); `github-release` has zero `secrets.` references and zero `uses:` (`:110-124`).
- Post-secret code in `publish`: checked the pinned SHAs upstream — `actions/checkout@11d5960a…` declares a `post:` (GitHub-owned, credential cleanup, no-op here); `coursier/setup-action@039f7365…` declares **no** post hook; `setup-bun` (which has a post step) is not invoked; cache steps are skipped, so no post-save runs.

## Tests

No Scala tests — this arc touches no Scala source. Coverage is shell/CI-level:

- `scripts/conformance.sh` negative paths (drift, hash tamper, version re-point, integrity removal, missing lock, old Bun, non-executable `FAST_MCP_BUN`, missing bin, `PATH` decoy) — all exit non-zero before any server starts; details under Fix criteria.
- `.github/scripts/install-mill.sh` scenarios — fresh download+verify, launcher reuse, cache-hit match, tampered cached binary, unknown `.mill-version`, wrong pin on fresh download, 3-line dry-run format guard, bash 3.2 compatibility.
- Static: `actionlint` on all four workflows + the composite; unpinned-`uses:` grep empty; `dependabot.yml` YAML parse; upstream tag->SHA resolution for the four pinned actions.
- End-to-end: `scripts/conformance.sh jvm` and `js` against the frozen harness (see Verification).

## Verification

Run on this branch in isolation (results as reported by the implementation report; CI results are not claimed here):

- `bash -n scripts/conformance.sh && bash -n .github/scripts/install-mill.sh` under bash 5 and macOS `/bin/bash` 3.2 — pass.
- `actionlint` — rc=0, no findings on all four workflows + the composite.
- `grep -rnE 'uses:\s*[^./ ][^ ]*@' .github | grep -vE '@[0-9a-f]{40}'` — empty.
- `./mill fast-mcp-scala.reformat && ./mill fast-mcp-scala.checkFormat` — reformat changed nothing; checkFormat 16/16 SUCCESS. No Scala changed, so the earlier clean rebuild (`rm -rf out && ./mill fast-mcp-scala.compile`, 168/168, all platforms) stands.
- `./mill fast-mcp-scala.test` — **532/532 SUCCESS**; every suite "All tests passed" (JVM, Bun conformance, Scala Native).
- `scripts/conformance.sh jvm 8185` — rc=0; `→ bun 1.4.1 (~/.cache/mill-bun/…/bun)`, `→ installing conformance harness @0.2.0-alpha.11 (frozen lockfile, fresh install cache)`, harness exec'd from `node_modules/.bin`; **Total: 73 passed, 0 failed**; Baseline check passed against the EMPTY `conformance/baseline-jvm.yml`.
- `scripts/conformance.sh js 8185` — rc=0; ConformanceServerJs launched with the Mill-managed Bun; **73 passed, 0 failed**; baseline check passed (empty `baseline-js.yml`).
- Mill dist SHA-256 recomputation vs Maven Central `.sha1`; `gh api` tag->SHA resolution for the four pinned actions; `bun.lock` regeneration check (byte-identical) — pass.
- `git diff --name-only main` — exactly the 12 files in the diff stat; working tree clean after all gates.

## Residual risk / follow-ups

Documented residuals (accepted, stated in-tree comments):
- **Only the Mill launcher distribution is checksum-verified.** Mill's own jars, the Scala compiler and the mill-bun plugin arrive via coursier (SHA-1-checked on download) and are trusted from the restored cache in non-release CI jobs. Acceptable because those jobs hold no publishing secrets and the release workflow restores no cache; revisit if a cache-restoring job ever gains secrets.
- **`--frozen-lockfile` does not detect a range widening in `package.json`** (e.g. `^0.2.0-alpha.11` installs rc=0 with the lock byte-identical). Resolution still comes exclusively from the committed lock, so no unreviewed code runs; the `bun.lock` diff is the review surface. Likewise a reviewed PR that bumps `.mill-version` and edits `mill-dist.sha256` to an attacker-chosen value passes the technical gate — the checksum diff is the review surface. Optional follow-up: a CI grep asserting the pin is an exact version.
- **The hardening is not yet guarded by an in-tree CI lint.** A future edit reverting `cache: "false"`, reintroducing `bunx`, or adding a `@vN` reference would not turn CI red; `actionlint` was run locally only. Suggested follow-up: a small `ci-guard` step (actionlint + `bunx` grep empty + 40-hex `uses:` assertion + no cache step in `release.yml`).
- The harness bin runs under the runner image's preinstalled Node (`#!/usr/bin/env node`) — runner-image trust boundary, unpinned.
- Fresh-cache install of ~118 tarballs per invocation is a hard dependency on registry availability; add retry resilience only if CI shows flakes. Any future "optimisation" must not reintroduce a shared `~/.bun/install/cache` (the `action.yml` comment forbids it).
- Pre-existing hygiene, not on the release path: `ci.yml` still exports `GITHUB_TOKEN` (`contents: read`) at workflow level, visible to the setup actions; `native.yml` now scopes it per step — `ci.yml` could follow.

Post-merge checks (observable only on GitHub):
- Confirm on Insights -> Dependency graph -> Dependabot that the `github-actions` manifest for `/.github/actions/setup-build` is discovered and the `bun` ecosystem block is accepted; if the composite entry is missing, adjust `directories` (the four composite pins would otherwise lack automated update PRs); if GitHub rejects `bun`, drop that block.
- Confirm CI observables: restore-only cache steps (no "Post Cache" / "Post Set up Bun" lines on harness jobs), `install-mill: downloading …` on first run, three fresh-cache harness installs in `native-http`, three-job release ordering, idempotent `github-release` re-run.

Out-of-tree repository/org settings (not part of this diff; the workflow file alone cannot enforce them):
- Create a GitHub `release` environment holding `SONATYPE_USERNAME/PASSWORD` + `PGP_SECRET/PGP_PASSPHRASE` with required reviewers and add `environment: release` to `jobs.publish`.
- Add a `v*` tag ruleset; enable the repository setting requiring SHA-pinned actions (`sha_pinning_required`); consider restricting `allowed_actions` to GitHub-owned + the four pinned third parties.

Docs for this arc (CHANGELOG **Security / CI** entry, CLAUDE.md CI/CD bullets, `docs/parity-audit.md` "via `bunx`" wording, release-checklist "Harness pin" item) land in the integration PR #92.

## Stack & merge order

| # | Branch | Base | Scope |
|---|---|---|---|
| 1/6 | `tjc-2299-ci-supply-chain` (**this PR**) | `main` | TJC-2299 — CI supply chain: F6, F7 |
| 2/6 | `tjc-2298-macro-overload-binding` #88 | `tjc-2299-ci-supply-chain` | TJC-2298 — macros: F4 |
| 3/6 | `tjc-2297-tasks-hardening` #89 | `tjc-2298-macro-overload-binding` | TJC-2297 — tasks: F8, F9, F11 |
| 4/6 | `tjc-2295-core-input-limits` #90 | `tjc-2297-tasks-hardening` | TJC-2295 — core input limits: F1, F2, F3 |
| 5/6 | `tjc-2296-http-transport-hardening` #91 | `tjc-2295-core-input-limits` | TJC-2296 — HTTP transports: F1, F5, F10, F12 |
| 6/6 | `tjc-2294-security-hardening` #92 | `tjc-2296-http-transport-hardening` | TJC-2294 — cross-arc integration + docs |

**Merge discipline.** Review and merge bottom-up, starting with this PR. Merge each PR with a **merge commit — not squash** (squashing the bottom of a stack orphans the PRs above it, see TJC-2114). After each merge, retarget the next PR to `main` (GitHub does this automatically when the merged base branch is deleted). The stack tip (#92) is byte-identical to a fully verified integrated tree: 532/532 Mill test tasks including the JVM, Bun and Scala Native suites; official MCP conformance 73/73 checks on both JVM and Bun with empty baselines; scalafmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
