### PR TITLE
Bind annotation macros to the exact annotated overload, reject duplicate registrations (TJC-2298)

### DIFF
--- a/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/macros/OverloadBindingJsTest.scala
+++ b/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/macros/OverloadBindingJsTest.scala
@@ -1,0 +1,52 @@
+package com.tjclp.fastmcp.macros
+
+import org.scalatest.funsuite.AnyFunSuite
+import zio.*
+
+import com.tjclp.fastmcp.{given, *}
+
+/** Scala.js mirror of the `@Tool` cases of the JVM `OverloadBindingTest` (F4 / TJC-2298): the same
+  * macro expansion must link and dispatch through `RefResolver` under Bun, binding to the ANNOTATED
+  * overload even when a same-named method is declared before it (class-nested fixture object, the
+  * `Outer.this.Nested` qualifier path).
+  */
+class OverloadBindingJsTest extends AnyFunSuite:
+
+  object OverloadedJsTools:
+    def echo(a: Int): String = s"int:$a"
+
+    @Tool(name = Some("echo"), description = Some("Echo a string"))
+    def echo(@Param("Text to echo") a: String): String = s"string:$a"
+
+    def raw(a: String, unsafe: Boolean): String = s"raw:$a:$unsafe"
+
+    @Tool(name = Some("safe"))
+    def raw(@Param("Text") a: String): String = s"safe:$a"
+
+  private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
+    Unsafe.unsafe { implicit unsafe =>
+      Runtime.default.unsafe.run(effect).getOrThrowFiberFailure()
+    }
+
+  test("@Tool binds to the annotated String overload under Scala.js") {
+    val server = McpServer("OverloadJs")
+    val _ = server.scanAnnotations[OverloadedJsTools.type]
+
+    val echoDef = server.toolManager.getToolDefinition("echo")
+    assert(echoDef.isDefined)
+    val schema = echoDef.get.inputSchema.toJsonString
+    assert(schema.contains("\"type\":\"string\""), s"expected a string schema for `a`, got $schema")
+    assert(!schema.contains("\"type\":\"integer\""), s"Int overload leaked into schema: $schema")
+    assert(schema.contains("Text to echo"))
+
+    assert(runUnsafe(server.toolManager.callTool("echo", Map("a" -> "hi"), None)) == "string:hi")
+  }
+
+  test("the un-annotated raw helper's extra parameter is not registered under Scala.js") {
+    val server = McpServer("OverloadJsRaw")
+    val _ = server.scanAnnotations[OverloadedJsTools.type]
+
+    val schema = server.toolManager.getToolDefinition("safe").get.inputSchema.toJsonString
+    assert(!schema.contains("unsafe"), s"un-annotated overload's parameter leaked: $schema")
+    assert(runUnsafe(server.toolManager.callTool("safe", Map("a" -> "x"), None)) == "safe:x")
+  }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/OverloadBindingTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/OverloadBindingTest.scala
@@ -68,6 +68,42 @@ object OverloadedPrompts:
   @Prompt(name = Some("ask"))
   def ask(@Param("Topic") topic: String): String = s"Tell me about $topic"
 
+object NameConsts:
+  final val Const = "constx"
+  final val Title = "Const title"
+
+/** Every literal `Option[String]` spelling must be honoured as the registered name — never dropped
+  * in favour of the method name (review finding on the exact-binding fix: only `Some("...")` with
+  * an unqualified `Some` used to parse).
+  */
+object SpelledNames:
+  @Tool(name = scala.Some("qualx")) def q1(@Param("a") a: Int): Int = a
+  @Tool(name = Option("optx")) def q2(@Param("a") a: Int): Int = a
+  @Tool(name = Some[String]("typedx")) def q3(@Param("a") a: Int): Int = a
+  @Tool(name = Some.apply("applyx")) def q4(@Param("a") a: Int): Int = a
+  @Tool(name = new Some("newx")) def q5(@Param("a") a: Int): Int = a
+  @Tool(name = Some(NameConsts.Const), readOnlyHint = scala.Some(true), title = Option(NameConsts.Title))
+  def q6(@Param("a") a: Int): Int = a
+  @Tool(Some("positionalx"), Some("positional description")) def q7(@Param("a") a: Int): Int = a
+  @Prompt(name = Option("promptx")) def p1(@Param("t") t: String): String = t
+  @Resource("res://named", Some("Positional resource name"), Option("positional desc"))
+  def r1(): String = "r1"
+
+/** A genuine primary-constructor default must still satisfy `required = false` on a case-class field
+  * (the companion-`apply`-overload lookup was replaced by the ctor param's `HasDefault` flag).
+  */
+case class CaseWithCtorDefault(
+    @Param("a") a: Int,
+    @Param(description = "flag", required = false) flag: Boolean = true
+)
+
+/** A static URI containing a literal `{}` is keyed apart from a single-placeholder template on the
+  * same stem: they never conflict at runtime, so they must not collide at compile time either.
+  */
+object StaticBraceAndTemplate:
+  @Resource("x://{}") def literal(): String = "static"
+  @Resource("x://{id}") def template(id: String): String = s"tpl:$id"
+
 /** Positive coverage for F4 (TJC-2298): the registered handler, its schema and its `@Param`
   * metadata must all come from the ANNOTATED declaration even when a same-named overload is
   * declared before it.
@@ -159,6 +195,41 @@ class OverloadBindingTest extends AnyFunSuite:
       .find(_.uri == "users://{userId}")
       .flatMap(_.arguments)
     assert(templateArgs == Some(List(ResourceArgument("userId", Some("The user id"), true))))
+  }
+
+  test("every literal Option[String] spelling of `name` is honoured, never the method name") {
+    val server = new McpServer[Any]("SpelledNamesServer", "0.1.0")
+    server.scanAnnotations[SpelledNames.type]
+
+    assert(
+      server.toolManager.listDefinitions().map(_.name).toSet ==
+        Set("qualx", "optx", "typedx", "applyx", "newx", "constx", "positionalx")
+    )
+    val q6 = server.toolManager.getToolDefinition("constx").get
+    assert(q6.annotations.flatMap(_.readOnlyHint) == Some(true))
+    assert(q6.annotations.flatMap(_.title) == Some("Const title"))
+    assert(
+      server.toolManager.getToolDefinition("positionalx").get.description ==
+        Some("positional description")
+    )
+    assert(server.promptManager.getPromptDefinition("promptx").isDefined)
+    val res = server.resourceManager.getResourceDefinition("res://named").get
+    assert(res.name == Some("Positional resource name"))
+    assert(res.description == Some("positional desc"))
+    assert(run(server.toolManager.callTool("qualx", Map("a" -> 7), None)) == 7)
+  }
+
+  test("required=false is satisfied by a genuine primary-constructor default on a case-class field") {
+    val schema = parse(ToolInputSchema.derived[CaseWithCtorDefault].toJsonString).toOption.get
+    assert(schema.hcursor.downField("required").as[List[String]] == Right(List("a")))
+    assert(schema.hcursor.downField("properties").keys.map(_.toSet) == Some(Set("a", "flag")))
+  }
+
+  test("a static uri with a literal `{}` does not collide with a single-placeholder template") {
+    val server = new McpServer[Any]("StaticBraceServer", "0.1.0")
+    server.scanAnnotations[StaticBraceAndTemplate.type]
+    assert(run(server.resourceManager.readResource("x://{}", None)) == "static")
+    assert(run(server.resourceManager.readResource("x://42", None)) == "tpl:42")
   }
 
   test("@Prompt binds to the annotated String overload") {

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/OverloadBindingTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/OverloadBindingTest.scala
@@ -1,0 +1,174 @@
+package com.tjclp.fastmcp
+package macros
+
+import org.scalatest.funsuite.AnyFunSuite
+import zio.*
+
+import com.tjclp.fastmcp.JsonTestSupport.*
+import com.tjclp.fastmcp.core.*
+import com.tjclp.fastmcp.macros.RegistrationMacro.scanAnnotations
+import com.tjclp.fastmcp.server.*
+import com.tjclp.fastmcp.server.transport.JvmTransportBackend.given
+
+// ---------------------------------------------------------------------------------------------
+// Fixtures are TOP-LEVEL so OverloadNegativeTest can reference them from a typeCheckErrors
+// snippet. In every fixture the UN-annotated overload is declared FIRST: at HEAD (F4 / TJC-2298)
+// `MacroUtils.getMethodRefExpr` re-resolved the method by name and bound the registration to that
+// first declaration instead of the annotated one.
+// ---------------------------------------------------------------------------------------------
+
+object OverloadedTools:
+
+  // (a) same arity, different parameter type; same (pure) effect shape
+  def echo(a: Int): String = s"int:$a"
+
+  @Tool(name = Some("echo"), description = Some("Echo a string"))
+  def echo(@Param("Text to echo") a: String): String = s"string:$a"
+
+  // (b) raw helper with an extra `unsafe` parameter declared before the validated wrapper
+  def raw(a: String, unsafe: Boolean): String = s"raw:$a:$unsafe"
+
+  @Tool(name = Some("safe"))
+  def raw(@Param("Text") a: String): String = s"safe:$a"
+
+  // (c) effect shapes differ: HEAD cast the pure Int result to ZIO and failed at call time
+  def eff(a: String): ZIO[Any, Throwable, String] = ZIO.succeed(s"zio:$a")
+
+  @Tool(name = Some("eff"))
+  def eff(@Param("Number") a: Int): Int = a * 2
+
+  // (d) two ANNOTATED overloads with distinct explicit names both register
+  @Tool(name = Some("sum-ints"))
+  def sum(@Param("a") a: Int, @Param("b") b: Int): Int = a + b
+
+  @Tool(name = Some("sum-strings"))
+  def sum(@Param("a") a: String, @Param("b") b: String): String = a + b
+
+object DescriptionOnlyTools:
+
+  @Tool(description = Some("Adds two numbers"))
+  def add(@Param("a") a: Int, @Param("b") b: Int): Int = a + b
+
+object OverloadedResources:
+
+  def greeting(x: Int): String = s"greeting:$x"
+
+  @Resource("static://greeting")
+  def greeting(): String = "hello"
+
+  def profile(userId: Int): String = s"int-user:$userId"
+
+  @Resource("users://{userId}")
+  def profile(@Param("The user id") userId: String): String = s"user:$userId"
+
+object OverloadedPrompts:
+
+  def ask(topic: Int): String = s"int-topic:$topic"
+
+  @Prompt(name = Some("ask"))
+  def ask(@Param("Topic") topic: String): String = s"Tell me about $topic"
+
+/** Positive coverage for F4 (TJC-2298): the registered handler, its schema and its `@Param`
+  * metadata must all come from the ANNOTATED declaration even when a same-named overload is
+  * declared before it.
+  */
+class OverloadBindingTest extends AnyFunSuite:
+
+  private def run[A](effect: ZIO[Any, Throwable, A]): A =
+    Unsafe.unsafe { implicit unsafe =>
+      Runtime.default.unsafe.run(effect).getOrThrowFiberFailure()
+    }
+
+  private lazy val toolServer =
+    val s = new McpServer[Any]("OverloadServer", "0.1.0")
+    s.scanAnnotations[OverloadedTools.type]
+    s
+
+  private def schemaOf(server: McpServer[Any], tool: String) =
+    parse(server.toolManager.getToolDefinition(tool).get.inputSchema.toJsonString).toOption.get
+
+  test("(a) @Tool binds to the annotated String overload, not the earlier Int one") {
+    val schema = schemaOf(toolServer, "echo")
+    val a = schema.hcursor.downField("properties").downField("a")
+    assert(a.downField("type").as[String] == Right("string"))
+    assert(a.downField("description").as[String] == Right("Text to echo"))
+    assert(schema.hcursor.downField("required").as[List[String]] == Right(List("a")))
+    assert(toolServer.toolManager.getToolDefinition("echo").get.description == Some("Echo a string"))
+
+    val result = run(toolServer.toolManager.callTool("echo", Map("a" -> "hi"), None))
+    assert(result == "string:hi")
+  }
+
+  test("(b) the un-annotated raw helper's extra parameter is not part of the registered signature") {
+    val schema = schemaOf(toolServer, "safe")
+    assert(schema.hcursor.downField("properties").keys.map(_.toSet) == Some(Set("a")))
+    val result = run(toolServer.toolManager.callTool("safe", Map("a" -> "x"), None))
+    assert(result == "safe:x")
+  }
+
+  test("(c) differing effect shapes: the annotated pure overload runs without a cast failure") {
+    val schema = schemaOf(toolServer, "eff")
+    assert(
+      schema.hcursor.downField("properties").downField("a").downField("type").as[String] ==
+        Right("integer")
+    )
+    val result = run(toolServer.toolManager.callTool("eff", Map("a" -> 21), None))
+    assert(result == 42)
+  }
+
+  test("(d) two annotated overloads with distinct explicit names both register and dispatch") {
+    val ints = schemaOf(toolServer, "sum-ints")
+    val strings = schemaOf(toolServer, "sum-strings")
+    assert(
+      ints.hcursor.downField("properties").downField("a").downField("type").as[String] ==
+        Right("integer")
+    )
+    assert(
+      strings.hcursor.downField("properties").downField("b").downField("type").as[String] ==
+        Right("string")
+    )
+    assert(run(toolServer.toolManager.callTool("sum-ints", Map("a" -> 2, "b" -> 3), None)) == 5)
+    assert(
+      run(toolServer.toolManager.callTool("sum-strings", Map("a" -> "x", "b" -> "y"), None)) ==
+        "xy"
+    )
+    assert(toolServer.toolManager.listDefinitions().map(_.name).toSet ==
+      Set("echo", "safe", "eff", "sum-ints", "sum-strings"))
+  }
+
+  test("description-only @Tool registers under the method name, never under the description") {
+    val server = new McpServer[Any]("DescriptionOnlyServer", "0.1.0")
+    server.scanAnnotations[DescriptionOnlyTools.type]
+
+    val add = server.toolManager.getToolDefinition("add")
+    assert(add.isDefined)
+    assert(add.get.description == Some("Adds two numbers"))
+    assert(server.toolManager.getToolDefinition("Adds two numbers").isEmpty)
+    assert(run(server.toolManager.callTool("add", Map("a" -> 1, "b" -> 2), None)) == 3)
+  }
+
+  test("@Resource static + template bind to the annotated overloads") {
+    val server = new McpServer[Any]("OverloadResourceServer", "0.1.0")
+    server.scanAnnotations[OverloadedResources.type]
+
+    assert(run(server.resourceManager.readResource("static://greeting", None)) == "hello")
+    assert(run(server.resourceManager.readResource("users://abc", None)) == "user:abc")
+
+    val templateArgs = server.resourceManager
+      .listTemplateResources()
+      .find(_.uri == "users://{userId}")
+      .flatMap(_.arguments)
+    assert(templateArgs == Some(List(ResourceArgument("userId", Some("The user id"), true))))
+  }
+
+  test("@Prompt binds to the annotated String overload") {
+    val server = new McpServer[Any]("OverloadPromptServer", "0.1.0")
+    server.scanAnnotations[OverloadedPrompts.type]
+
+    val messages = run(server.promptManager.getPrompt("ask", Map("topic" -> "scala"), None))
+    assert(messages.head.content.asInstanceOf[TextContent].text.contains("scala"))
+    assert(
+      server.promptManager.getPromptDefinition("ask").get.arguments ==
+        Some(List(PromptArgument("topic", Some("Topic"), true)))
+    )
+  }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/OverloadNegativeTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/OverloadNegativeTest.scala
@@ -48,6 +48,19 @@ object ApplyOverloadReq:
   def apply(x: Int, y: Boolean = true, z: String): ApplyOverloadReq =
     new ApplyOverloadReq(x, y)
 
+object NonLiteralNames:
+  val n: String = "runtime-name"
+  val flag: Boolean = true
+
+object NonLiteralToolName:
+  @Tool(name = Some(NonLiteralNames.n)) def t(a: Int): Int = a
+
+object NonLiteralHint:
+  @Tool(readOnlyHint = Some(NonLiteralNames.flag)) def t(a: Int): Int = a
+
+object NonLiteralResourceName:
+  @Resource("res://x", name = Some(NonLiteralNames.n)) def r(): String = ""
+
 /** Compile-time diagnostics for F4 (TJC-2298): duplicate registered keys within one scanned object,
   * non-object scan targets, and `required = false` gates that used to be satisfied by a same-named
   * sibling's (or a companion `apply` overload's) default getters.
@@ -77,8 +90,8 @@ class OverloadNegativeTest extends AnyFunSuite:
     assertSomeMessageContains(
       errs,
       "@Tool name 'dup'",
-      "dup(scala.Int)",
-      "dup(java.lang.String)",
+      "dup(a: Int)",
+      "dup(a: String)",
       "OverloadNegativeTest.scala"
     )
   }
@@ -88,7 +101,7 @@ class OverloadNegativeTest extends AnyFunSuite:
       val s = McpServer.typed[Any]("neg")
       s.scanAnnotations[DupExplicitNames.type]
     """)
-    assertSomeMessageContains(errs, "@Tool name 'same'", "one(scala.Int)", "two(java.lang.String)")
+    assertSomeMessageContains(errs, "@Tool name 'same'", "one(a: Int)", "two(a: String)")
   }
 
   test("two @Prompt overloads registering the same name are rejected") {
@@ -112,7 +125,7 @@ class OverloadNegativeTest extends AnyFunSuite:
       val s = McpServer.typed[Any]("neg")
       s.scanAnnotations[DupTemplates.type]
     """)
-    assertSomeMessageContains(errs, "@Resource uri 'users://{}'", "placeholder names")
+    assertSomeMessageContains(errs, "@Resource template 'users://{}'", "placeholder names")
   }
 
   test("scanning a class (not an object's singleton type) is rejected with a hint") {
@@ -141,6 +154,34 @@ class OverloadNegativeTest extends AnyFunSuite:
     )
   }
 
+  test("a non-literal @Tool name is a compile-time error, not a silent fallback to the method name") {
+    val errs: List[scala.compiletime.testing.Error] = typeCheckErrors("""
+      val s = McpServer.typed[Any]("neg")
+      s.scanAnnotations[NonLiteralToolName.type]
+    """)
+    assertSomeMessageContains(
+      errs,
+      "@Tool(name) must be a literal Option[String]",
+      "NonLiteralNames.n"
+    )
+  }
+
+  test("a non-literal @Tool hint is a compile-time error") {
+    val errs: List[scala.compiletime.testing.Error] = typeCheckErrors("""
+      val s = McpServer.typed[Any]("neg")
+      s.scanAnnotations[NonLiteralHint.type]
+    """)
+    assertSomeMessageContains(errs, "@Tool(readOnlyHint) must be a literal Option[Boolean]")
+  }
+
+  test("a non-literal @Resource name is a compile-time error") {
+    val errs: List[scala.compiletime.testing.Error] = typeCheckErrors("""
+      val s = McpServer.typed[Any]("neg")
+      s.scanAnnotations[NonLiteralResourceName.type]
+    """)
+    assertSomeMessageContains(errs, "@Resource(name) must be a literal Option[String]")
+  }
+
   test("control: the positive fixtures still compile (no false-positive collisions)") {
     val errs: List[scala.compiletime.testing.Error] = typeCheckErrors("""
       val s = McpServer.typed[Any]("ok")
@@ -148,6 +189,9 @@ class OverloadNegativeTest extends AnyFunSuite:
       val _ = s.scanAnnotations[DescriptionOnlyTools.type]
       val _ = s.scanAnnotations[OverloadedResources.type]
       val _ = s.scanAnnotations[OverloadedPrompts.type]
+      val _ = s.scanAnnotations[SpelledNames.type]
+      val _ = s.scanAnnotations[StaticBraceAndTemplate.type]
+      val _ = ToolInputSchema.derived[CaseWithCtorDefault]
     """)
     assert(errs == Nil, s"unexpected errors: ${messages(errs).mkString("\n---\n")}")
   }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/OverloadNegativeTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/OverloadNegativeTest.scala
@@ -1,0 +1,153 @@
+package com.tjclp.fastmcp
+package macros
+
+import scala.compiletime.testing.typeCheckErrors
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import com.tjclp.fastmcp.core.*
+import com.tjclp.fastmcp.macros.RegistrationMacro.scanAnnotations
+import com.tjclp.fastmcp.server.*
+import com.tjclp.fastmcp.server.transport.JvmTransportBackend.given
+
+// ---------------------------------------------------------------------------------------------
+// Negative fixtures (TOP-LEVEL so the typeCheckErrors snippets can name them). Every one of them
+// compiled silently at HEAD (F4 / TJC-2298) and registered with mixed provenance or last-writer-
+// wins semantics; they must now be compile-time errors.
+// ---------------------------------------------------------------------------------------------
+
+object DupToolNames:
+  @Tool def dup(@Param("a") a: Int): Int = a
+  @Tool def dup(@Param("a") a: String): String = a
+
+object DupExplicitNames:
+  @Tool(name = Some("same")) def one(a: Int): Int = a
+  @Tool(name = Some("same")) def two(a: String): String = a
+
+object DupPrompts:
+  @Prompt def p(a: Int): String = ""
+  @Prompt def p(a: String): String = ""
+
+object DupResources:
+  @Resource("static://x") def x1(): String = ""
+  @Resource("static://x") def x2(): String = ""
+
+object DupTemplates:
+  @Resource("users://{id}") def a(id: String): String = id
+  @Resource("users://{userId}") def b(userId: String): String = userId
+
+class NotAnObject:
+  @Tool def t(a: Int): Int = a
+
+object SiblingDefault:
+  def opt(s: String = "d"): String = s
+  @Tool def opt(@Param("x", required = false) x: Int): Int = x
+
+case class ApplyOverloadReq(x: Int, @Param(description = "y", required = false) y: Boolean)
+object ApplyOverloadReq:
+  def apply(x: Int, y: Boolean = true, z: String): ApplyOverloadReq =
+    new ApplyOverloadReq(x, y)
+
+/** Compile-time diagnostics for F4 (TJC-2298): duplicate registered keys within one scanned object,
+  * non-object scan targets, and `required = false` gates that used to be satisfied by a same-named
+  * sibling's (or a companion `apply` overload's) default getters.
+  */
+class OverloadNegativeTest extends AnyFunSuite:
+
+  private def messages(errors: List[scala.compiletime.testing.Error]): List[String] =
+    errors.map(_.message)
+
+  private def assertSomeMessageContains(
+      errors: List[scala.compiletime.testing.Error],
+      fragments: String*
+  ): Unit =
+    val msgs = messages(errors)
+    fragments.foreach { fragment =>
+      assert(
+        msgs.exists(_.contains(fragment)),
+        s"expected an error containing <$fragment>; got: ${msgs.mkString("\n---\n")}"
+      )
+    }
+
+  test("two @Tool overloads registering the same default name are rejected, naming both") {
+    val errs: List[scala.compiletime.testing.Error] = typeCheckErrors("""
+      val s = McpServer.typed[Any]("neg")
+      s.scanAnnotations[DupToolNames.type]
+    """)
+    assertSomeMessageContains(
+      errs,
+      "@Tool name 'dup'",
+      "dup(scala.Int)",
+      "dup(java.lang.String)",
+      "OverloadNegativeTest.scala"
+    )
+  }
+
+  test("two @Tool methods with the same explicit name are rejected") {
+    val errs: List[scala.compiletime.testing.Error] = typeCheckErrors("""
+      val s = McpServer.typed[Any]("neg")
+      s.scanAnnotations[DupExplicitNames.type]
+    """)
+    assertSomeMessageContains(errs, "@Tool name 'same'", "one(scala.Int)", "two(java.lang.String)")
+  }
+
+  test("two @Prompt overloads registering the same name are rejected") {
+    val errs: List[scala.compiletime.testing.Error] = typeCheckErrors("""
+      val s = McpServer.typed[Any]("neg")
+      s.scanAnnotations[DupPrompts.type]
+    """)
+    assertSomeMessageContains(errs, "@Prompt name 'p'")
+  }
+
+  test("two @Resource methods with the same static uri are rejected") {
+    val errs: List[scala.compiletime.testing.Error] = typeCheckErrors("""
+      val s = McpServer.typed[Any]("neg")
+      s.scanAnnotations[DupResources.type]
+    """)
+    assertSomeMessageContains(errs, "@Resource uri 'static://x'")
+  }
+
+  test("two @Resource templates differing only in placeholder names are rejected") {
+    val errs: List[scala.compiletime.testing.Error] = typeCheckErrors("""
+      val s = McpServer.typed[Any]("neg")
+      s.scanAnnotations[DupTemplates.type]
+    """)
+    assertSomeMessageContains(errs, "@Resource uri 'users://{}'", "placeholder names")
+  }
+
+  test("scanning a class (not an object's singleton type) is rejected with a hint") {
+    val errs: List[scala.compiletime.testing.Error] = typeCheckErrors("""
+      val s = McpServer.typed[Any]("neg")
+      s.scanAnnotations[NotAnObject]
+    """)
+    assertSomeMessageContains(errs, "requires the singleton type of an object")
+  }
+
+  test("required=false is not satisfied by a same-named sibling's default getter") {
+    val errs: List[scala.compiletime.testing.Error] = typeCheckErrors("""
+      val s = McpServer.typed[Any]("neg")
+      s.scanAnnotations[SiblingDefault.type]
+    """)
+    assertSomeMessageContains(errs, "marked as required=false", "'x'")
+  }
+
+  test("required=false on a typed-request field is not satisfied by a companion apply overload") {
+    val errs: List[scala.compiletime.testing.Error] = typeCheckErrors("""
+      ToolInputSchema.derived[ApplyOverloadReq]
+    """)
+    assertSomeMessageContains(
+      errs,
+      "Field 'y' in typed request ApplyOverloadReq is marked as required=false"
+    )
+  }
+
+  test("control: the positive fixtures still compile (no false-positive collisions)") {
+    val errs: List[scala.compiletime.testing.Error] = typeCheckErrors("""
+      val s = McpServer.typed[Any]("ok")
+      val _ = s.scanAnnotations[OverloadedTools.type]
+      val _ = s.scanAnnotations[DescriptionOnlyTools.type]
+      val _ = s.scanAnnotations[OverloadedResources.type]
+      val _ = s.scanAnnotations[OverloadedPrompts.type]
+    """)
+    assert(errs == Nil, s"unexpected errors: ${messages(errs).mkString("\n---\n")}")
+  }

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/AnnotationProcessorBase.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/AnnotationProcessorBase.scala
@@ -17,8 +17,15 @@ private[macros] trait AnnotationProcessorBase:
   ): Option[quotes.reflect.Term] =
     MacroUtils.extractAnnotation[A](sym)
 
-  /** Retrieve `(name, description)` from any annotation following the `(name: Option[String],
-    * description: Option[String], ...)` constructor pattern. Falls back to the method's Scaladoc.
+  /** Retrieve `(name, description)` from an annotation whose constructor starts with `(name:
+    * Option[String], description: Option[String], ...)` (`@Tool`, `@Prompt`).
+    *
+    * Typed annotation trees are argument-complete and in constructor order: named arguments stay
+    * `NamedArg`, omitted ones appear as `<Annot>.$lessinit$greater$default$N`. So `name` is either
+    * `NamedArg("name", v)` or the unnamed argument at index 0, and `description` is
+    * `NamedArg("description", v)` or the unnamed argument at index 1; nothing else can ever be
+    * taken as the registered name (a description-only annotation registers under the method name).
+    * Falls back to the method name and its Scaladoc.
     */
   protected def nameAndDescription(using Quotes)(
       annot: quotes.reflect.Term,
@@ -28,20 +35,22 @@ private[macros] trait AnnotationProcessorBase:
 
     val (maybeName, maybeDesc) = annot match
       case Apply(_, args) =>
-        val literals = args.collect {
-          case Literal(StringConstant(s)) => Some(s)
-          case Apply(_, List(Literal(StringConstant(s)))) => Some(s)
-          case NamedArg(_, Literal(StringConstant(s))) => Some(s)
-          case NamedArg(_, Apply(_, List(Literal(StringConstant(s))))) => Some(s)
-          case _ => None
-        }.flatten
-        (literals.headOption, literals.drop(1).headOption)
+        args.zipWithIndex.foldLeft((Option.empty[String], Option.empty[String])) {
+          case ((_, d), (NamedArg("name", v), _)) => (MacroUtils.parseOptionStringLiteral(v), d)
+          case ((n, _), (NamedArg("description", v), _)) =>
+            (n, MacroUtils.parseOptionStringLiteral(v))
+          case (acc, (NamedArg(_, _), _)) => acc
+          case ((_, d), (v, 0)) => (MacroUtils.parseOptionStringLiteral(v), d)
+          case ((n, _), (v, 1)) => (n, MacroUtils.parseOptionStringLiteral(v))
+          case (acc, _) => acc
+        }
       case _ => (None, None)
 
-    val name = maybeName.getOrElse(methodSym.name)
-    (name, maybeDesc.orElse(methodSym.docstring))
+    (maybeName.getOrElse(methodSym.name), maybeDesc.orElse(methodSym.docstring))
 
-  /** Build a stable method reference expression that survives inlining. */
+  /** Build a method reference expression that survives inlining and denotes EXACTLY `method` (the
+    * annotated symbol), never a same-named sibling overload — see [[MacroUtils.getMethodRefExpr]].
+    */
   protected def methodRef(using Quotes)(
       owner: quotes.reflect.Symbol,
       method: quotes.reflect.Symbol

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/AnnotationProcessorBase.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/AnnotationProcessorBase.scala
@@ -25,7 +25,9 @@ private[macros] trait AnnotationProcessorBase:
     * `NamedArg("name", v)` or the unnamed argument at index 0, and `description` is
     * `NamedArg("description", v)` or the unnamed argument at index 1; nothing else can ever be
     * taken as the registered name (a description-only annotation registers under the method name).
-    * Falls back to the method name and its Scaladoc.
+    * A present but non-literal `name` / `description` is a compile-time error (see
+    * [[MacroUtils.parseOptionStringLiteral]]) rather than a silent fallback. Falls back to the
+    * method name and its Scaladoc.
     */
   protected def nameAndDescription(using Quotes)(
       annot: quotes.reflect.Term,
@@ -33,15 +35,18 @@ private[macros] trait AnnotationProcessorBase:
   ): (String, Option[String]) =
     import quotes.reflect.*
 
+    val annotName = "@" + annot.tpe.typeSymbol.name
+    def parseName(v: Term) = MacroUtils.parseOptionStringLiteral(v, s"$annotName(name)")
+    def parseDesc(v: Term) = MacroUtils.parseOptionStringLiteral(v, s"$annotName(description)")
+
     val (maybeName, maybeDesc) = annot match
       case Apply(_, args) =>
         args.zipWithIndex.foldLeft((Option.empty[String], Option.empty[String])) {
-          case ((_, d), (NamedArg("name", v), _)) => (MacroUtils.parseOptionStringLiteral(v), d)
-          case ((n, _), (NamedArg("description", v), _)) =>
-            (n, MacroUtils.parseOptionStringLiteral(v))
+          case ((_, d), (NamedArg("name", v), _)) => (parseName(v), d)
+          case ((n, _), (NamedArg("description", v), _)) => (n, parseDesc(v))
           case (acc, (NamedArg(_, _), _)) => acc
-          case ((_, d), (v, 0)) => (MacroUtils.parseOptionStringLiteral(v), d)
-          case ((n, _), (v, 1)) => (n, MacroUtils.parseOptionStringLiteral(v))
+          case ((_, d), (v, 0)) => (parseName(v), d)
+          case ((n, _), (v, 1)) => (n, parseDesc(v))
           case (acc, _) => acc
         }
       case _ => (None, None)

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/MacroUtils.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/MacroUtils.scala
@@ -121,8 +121,10 @@ private[macros] object MacroUtils:
     term match {
       case Apply(Select(New(_), _), argTerms) =>
         argTerms.foreach {
-          case NamedArg("name", valueTerm) => toolName = parseOptionStringLiteral(valueTerm)
-          case NamedArg("description", valueTerm) => toolDesc = parseOptionStringLiteral(valueTerm)
+          case NamedArg("name", valueTerm) =>
+            toolName = parseOptionStringLiteral(valueTerm, "@Tool(name)")
+          case NamedArg("description", valueTerm) =>
+            toolDesc = parseOptionStringLiteral(valueTerm, "@Tool(description)")
           case NamedArg("tags", valueTerm) => toolTags = parseListString(valueTerm)
           case _ => () // Ignore other args
         }
@@ -142,9 +144,10 @@ private[macros] object MacroUtils:
     term match {
       case Apply(Select(New(_), _), argTerms) =>
         argTerms.foreach {
-          case NamedArg("name", valueTerm) => promptName = parseOptionStringLiteral(valueTerm)
+          case NamedArg("name", valueTerm) =>
+            promptName = parseOptionStringLiteral(valueTerm, "@Prompt(name)")
           case NamedArg("description", valueTerm) =>
-            promptDesc = parseOptionStringLiteral(valueTerm)
+            promptDesc = parseOptionStringLiteral(valueTerm, "@Prompt(description)")
           case _ => ()
         }
       case _ => ()
@@ -246,7 +249,7 @@ private[macros] object MacroUtils:
                 }
               // Named schema
               case NamedArg("schema", valueTerm) =>
-                paramSchema = parseOptionStringLiteral(valueTerm)
+                paramSchema = parseOptionStringLiteral(valueTerm, "@Param(schema)")
                 schemaSetByName = true
               // Positional args: description, examples, required, schema
               case term =>
@@ -266,7 +269,7 @@ private[macros] object MacroUtils:
                       case _ => ()
                     }
                   case 3 if !schemaSetByName =>
-                    paramSchema = parseOptionStringLiteral(term)
+                    paramSchema = parseOptionStringLiteral(term, "@Param(schema)")
                   case _ => ()
                 }
                 positionalIndex += 1
@@ -396,16 +399,26 @@ private[macros] object MacroUtils:
     var resourceDesc: Option[String] = None
     var mimeType: Option[String] = None
 
+    // Typed annotation trees are argument-complete and in constructor order (`uri`, `name`,
+    // `description`, `mimeType`); named arguments stay `NamedArg`, omitted ones are default getters.
     term match {
       case Apply(Select(New(_), _), argTerms) =>
-        argTerms.foreach {
-          // Handle positional URI argument first
-          case Literal(StringConstant(s)) if uri.isEmpty => uri = s
-          case NamedArg("uri", Literal(StringConstant(s))) => uri = s
-          case NamedArg("name", valueTerm) => resourceName = parseOptionStringLiteral(valueTerm)
-          case NamedArg("description", valueTerm) =>
-            resourceDesc = parseOptionStringLiteral(valueTerm)
-          case NamedArg("mimeType", valueTerm) => mimeType = parseOptionStringLiteral(valueTerm)
+        argTerms.zipWithIndex.foreach {
+          case (NamedArg("uri", Literal(StringConstant(s))), _) => uri = s
+          case (NamedArg("name", valueTerm), _) =>
+            resourceName = parseOptionStringLiteral(valueTerm, "@Resource(name)")
+          case (NamedArg("description", valueTerm), _) =>
+            resourceDesc = parseOptionStringLiteral(valueTerm, "@Resource(description)")
+          case (NamedArg("mimeType", valueTerm), _) =>
+            mimeType = parseOptionStringLiteral(valueTerm, "@Resource(mimeType)")
+          case (NamedArg(_, _), _) => ()
+          case (Literal(StringConstant(s)), 0) => uri = s
+          case (valueTerm, 1) =>
+            resourceName = parseOptionStringLiteral(valueTerm, "@Resource(name)")
+          case (valueTerm, 2) =>
+            resourceDesc = parseOptionStringLiteral(valueTerm, "@Resource(description)")
+          case (valueTerm, 3) =>
+            mimeType = parseOptionStringLiteral(valueTerm, "@Resource(mimeType)")
           case _ => ()
         }
       case _ => ()
@@ -413,50 +426,93 @@ private[macros] object MacroUtils:
     if uri.isEmpty then report.errorAndAbort("@Resource annotation must have a 'uri' parameter.")
     (uri, resourceName, resourceDesc, mimeType)
 
-  // Helper to parse Option[String] literals from annotation arguments
-  private[macros] def parseOptionStringLiteral(using quotes: Quotes)(
+  /** Name of the annotation constructor's default getters (`<init>$default$N`), which appear
+    * positionally in a typed annotation tree wherever an argument was omitted.
+    */
+  private val AnnotationDefaultGetterPrefix = "$lessinit$greater$default$"
+
+  /** Classify an `Option[?]`-typed annotation argument. `Some(None)` is the `None` literal or an
+    * omitted argument (every `Option` parameter of `@Tool` / `@Prompt` / `@Resource` / `@Param`
+    * defaults to `None`); `Some(Some(inner))` is `Some(inner)` / `Option(inner)` / `new
+    * Some(inner)` in any qualified or type-applied spelling; `None` is an unrecognised shape.
+    */
+  private def optionArgShape(using quotes: Quotes)(
       argTerm: quotes.reflect.Term
+  ): Option[Option[quotes.reflect.Term]] =
+    import quotes.reflect.*
+    val optionModule = Symbol.requiredModule("scala.Option")
+    val someClass = Symbol.requiredClass("scala.Some")
+
+    def isOptionFactory(fn: Term): Boolean =
+      val callee = fn match
+        case TypeApply(f, _) => f
+        case f => f
+      callee match
+        case Select(qual, "apply") =>
+          val q = qual.tpe.termSymbol
+          q == defn.SomeModule || q == optionModule
+        case Select(New(tpt), "<init>") => tpt.tpe.typeSymbol == someClass
+        case _ => false
+
+    stripTerm(argTerm) match
+      case Apply(fn, List(inner)) if isOptionFactory(fn) => Some(Some(inner))
+      case t if t.symbol == defn.NoneModule || t.tpe.termSymbol == defn.NoneModule => Some(None)
+      case t if t.symbol.exists && t.symbol.name.startsWith(AnnotationDefaultGetterPrefix) =>
+        Some(None)
+      case _ => None
+
+  /** A compile-time constant carried by `term`: a literal, or a `final val` whose type is the
+    * constant itself (`ConstantType`). Anything else is not statically known.
+    */
+  private def constantOf[C](using quotes: Quotes)(term: quotes.reflect.Term)(
+      pf: PartialFunction[quotes.reflect.Constant, C]
+  ): Option[C] =
+    import quotes.reflect.*
+    stripTerm(term) match
+      case Literal(c) => pf.lift(c)
+      case t =>
+        t.tpe.widenTermRefByName.dealias match
+          case ConstantType(c) => pf.lift(c)
+          case _ => None
+
+  /** Parse a literal `Option[C]` annotation argument or ABORT compilation. Annotation arguments are
+    * read at expansion time, so a non-literal payload (`Some(someVal)`) cannot be honoured; failing
+    * loudly keeps the registered name / hint provenance explicit instead of silently falling back
+    * to a default (F4 / TJC-2298). `what` names the argument in the diagnostic, e.g. `@Tool(name)`.
+    */
+  private def parseOptionLiteral[C](using quotes: Quotes)(
+      argTerm: quotes.reflect.Term,
+      what: String,
+      payloadType: String
+  )(pf: PartialFunction[quotes.reflect.Constant, C]): Option[C] =
+    import quotes.reflect.*
+    def fail(t: Term): Nothing =
+      report.errorAndAbort(
+        s"$what must be a literal Option[$payloadType] — Some(<literal>), Option(<literal>) or None " +
+          s"— but was `${t.show}`. Annotation arguments are read at compile time, so only literals " +
+          "(or `final val` constants) can be used here.",
+        argTerm.pos
+      )
+    optionArgShape(argTerm) match
+      case Some(None) => None
+      case Some(Some(inner)) => Some(constantOf(inner)(pf).getOrElse(fail(inner)))
+      case None => fail(argTerm)
+
+  /** Literal `Option[String]` annotation argument (see [[parseOptionLiteral]]). */
+  private[macros] def parseOptionStringLiteral(using quotes: Quotes)(
+      argTerm: quotes.reflect.Term,
+      what: String
   ): Option[String] =
     import quotes.reflect.*
+    parseOptionLiteral(argTerm, what, "String") { case StringConstant(s) => s }
 
-    def parseLiteral(term: Term): Option[String] = stripTerm(term) match {
-      case Literal(StringConstant(s)) => Some(s)
-      case _ => None
-    }
-
-    stripTerm(argTerm) match {
-      // Matches Some("literal") created via Some.apply[String]("literal")
-      case Apply(TypeApply(Select(Ident("Some"), "apply"), _), List(arg)) =>
-        parseLiteral(arg)
-      // Matches Some("literal") created via Some("literal")
-      case Apply(Select(Ident("Some"), "apply"), List(arg)) =>
-        parseLiteral(arg)
-      // Matches None
-      case Select(Ident("None"), _) | Ident("None") => None
-      case _ =>
-        // report.warning(s"Could not parse Option[String] from term: ${argTerm.show}") // Optional warning
-        None
-    }
-
-  // Helper to parse Option[Boolean] literals from annotation arguments
+  /** Literal `Option[Boolean]` annotation argument (see [[parseOptionLiteral]]). */
   private def parseOptionBooleanLiteral(using quotes: Quotes)(
-      argTerm: quotes.reflect.Term
+      argTerm: quotes.reflect.Term,
+      what: String
   ): Option[Boolean] =
     import quotes.reflect.*
-
-    def parseLiteral(term: Term): Option[Boolean] = stripTerm(term) match {
-      case Literal(BooleanConstant(b)) => Some(b)
-      case _ => None
-    }
-
-    stripTerm(argTerm) match {
-      case Apply(TypeApply(Select(Ident("Some"), "apply"), _), List(arg)) =>
-        parseLiteral(arg)
-      case Apply(Select(Ident("Some"), "apply"), List(arg)) =>
-        parseLiteral(arg)
-      case Select(Ident("None"), _) | Ident("None") => None
-      case _ => None
-    }
+    parseOptionLiteral(argTerm, what, "Boolean") { case BooleanConstant(b) => b }
 
   /** Extract MCP ToolAnnotation hints from a @Tool annotation term.
     *
@@ -488,19 +544,19 @@ private[macros] object MacroUtils:
       case Apply(Select(New(_), _), argTerms) =>
         argTerms.foreach {
           case NamedArg("title", valueTerm) =>
-            title = parseOptionStringLiteral(valueTerm)
+            title = parseOptionStringLiteral(valueTerm, "@Tool(title)")
           case NamedArg("readOnlyHint", valueTerm) =>
-            readOnlyHint = parseOptionBooleanLiteral(valueTerm)
+            readOnlyHint = parseOptionBooleanLiteral(valueTerm, "@Tool(readOnlyHint)")
           case NamedArg("destructiveHint", valueTerm) =>
-            destructiveHint = parseOptionBooleanLiteral(valueTerm)
+            destructiveHint = parseOptionBooleanLiteral(valueTerm, "@Tool(destructiveHint)")
           case NamedArg("idempotentHint", valueTerm) =>
-            idempotentHint = parseOptionBooleanLiteral(valueTerm)
+            idempotentHint = parseOptionBooleanLiteral(valueTerm, "@Tool(idempotentHint)")
           case NamedArg("openWorldHint", valueTerm) =>
-            openWorldHint = parseOptionBooleanLiteral(valueTerm)
+            openWorldHint = parseOptionBooleanLiteral(valueTerm, "@Tool(openWorldHint)")
           case NamedArg("returnDirect", valueTerm) =>
-            returnDirect = parseOptionBooleanLiteral(valueTerm)
+            returnDirect = parseOptionBooleanLiteral(valueTerm, "@Tool(returnDirect)")
           case NamedArg("taskSupport", valueTerm) =>
-            taskSupport = parseOptionStringLiteral(valueTerm)
+            taskSupport = parseOptionStringLiteral(valueTerm, "@Tool(taskSupport)")
           case _ => ()
         }
       case _ => ()

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/MacroUtils.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/MacroUtils.scala
@@ -47,18 +47,31 @@ private[macros] object MacroUtils:
     val annotTpe = TypeRepr.of[A]
     sym.annotations.filter(_.tpe <:< annotTpe)
 
-  // Gets a reference to the method within its owner object
+  /** Wording shared by the two "not an object" diagnostics so tests can assert one substring. */
+  private[macros] val NotAnObjectHint: String =
+    "requires the singleton type of an object (e.g. scanAnnotations[MyServer.type])"
+
+  /** Emit `owner.<method>` eta-expanded to a `FunctionN`, denoting EXACTLY `methodSym`.
+    *
+    * `Select(qualifier, symbol)` builds a symbol-designated `TermRef` whose denotation is the
+    * symbol's own (not a by-name member lookup), so overloads declared on the same object can never
+    * be confused: schema derivation, argument decoding and invocation all see the annotated
+    * declaration. The eta-expansion yields `Block(DefDef($anonfun(<original param names>)),
+    * Closure(Ident($anonfun)))`, the shape read by `MapToFunctionMacro.tryGetRealParamNames` and
+    * `FunctionAnalyzer.maybeRealParamNames`.
+    */
   def getMethodRefExpr(using
       quotes: Quotes
   )(ownerSym: quotes.reflect.Symbol, methodSym: quotes.reflect.Symbol): Expr[Any] =
     import quotes.reflect.*
-    val companionSym = ownerSym.companionModule
-    val methodSymOpt = companionSym.declaredMethod(methodSym.name).headOption.getOrElse {
+    // Defensive backstop only: RegistrationMacro reports this first with the full T-aware message.
+    if !ownerSym.flags.is(Flags.Module) then
       report.errorAndAbort(
-        s"Could not find method symbol for '${methodSym.name}' in ${companionSym.fullName}"
+        s"Cannot bind annotated method '${methodSym.name}' on ${ownerSym.fullName}: annotation " +
+          s"scanning $NotAnObjectHint."
       )
-    }
-    Select(Ref(companionSym), methodSymOpt).etaExpand(Symbol.spliceOwner).asExprOf[Any]
+    val moduleSym = ownerSym.companionModule // module class -> its module value (the Ref target)
+    Select(Ref(moduleSym), methodSym).etaExpand(Symbol.spliceOwner).asExprOf[Any]
 
   private def stripTerm(using quotes: Quotes)(term: quotes.reflect.Term): quotes.reflect.Term =
     import quotes.reflect.*
@@ -275,15 +288,6 @@ private[macros] object MacroUtils:
 
     val tpe = rawTpe.dealias.simplified
 
-    def hasDefaultValue(owner: Symbol, fieldIndex: Int): Boolean =
-      if owner == Symbol.noSymbol then false
-      else
-        val candidateNames = List(
-          s"$$lessinit$$greater$$default$$${fieldIndex + 1}",
-          s"apply$$default$$${fieldIndex + 1}"
-        )
-        candidateNames.exists(name => owner.methodMember(name).nonEmpty)
-
     def fieldAnnotation(fieldSym: Symbol, ctorParams: List[Symbol]): Option[Term] =
       extractAnnotation[com.tjclp.fastmcp.core.Param](fieldSym).orElse {
         ctorParams
@@ -313,16 +317,19 @@ private[macros] object MacroUtils:
         if !isProduct then None
         else
           val ctorParams = tpeSym.primaryConstructor.paramSymss.flatten
-          val companion = tpeSym.companionModule
 
-          val entries = tpeSym.caseFields.zipWithIndex.flatMap { case (fieldSym, idx) =>
+          val entries = tpeSym.caseFields.flatMap { fieldSym =>
             val fieldTpe = tpe.memberType(fieldSym)
             val nested = schemaMetadataForTypeRepr(fieldTpe)
             val parsedMeta = fieldAnnotation(fieldSym, ctorParams).map { annot =>
               val (desc, examples, required, schema) = parseToolParam(Some(annot))
               if !required then
                 val isOption = fieldTpe <:< TypeRepr.of[Option[?]]
-                val hasDefault = hasDefaultValue(companion, idx)
+                // `HasDefault` lives on the primary-constructor parameter itself (pickled), so a
+                // hand-written companion `apply` overload with defaults can no longer satisfy the
+                // gate on behalf of a field that has none.
+                val hasDefault =
+                  ctorParams.find(_.name == fieldSym.name).exists(_.flags.is(Flags.HasDefault))
                 if !isOption && !hasDefault then
                   report.errorAndAbort(
                     s"Field '${fieldSym.name}' in typed request ${tpeSym.name} is marked as required=false " +
@@ -407,7 +414,7 @@ private[macros] object MacroUtils:
     (uri, resourceName, resourceDesc, mimeType)
 
   // Helper to parse Option[String] literals from annotation arguments
-  private def parseOptionStringLiteral(using quotes: Quotes)(
+  private[macros] def parseOptionStringLiteral(using quotes: Quotes)(
       argTerm: quotes.reflect.Term
   ): Option[String] =
     import quotes.reflect.*

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/PromptProcessor.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/PromptProcessor.scala
@@ -12,6 +12,14 @@ import com.tjclp.fastmcp.server.manager.PromptHandler
 /** Cross-platform `@Prompt` annotation processor. Emits registration against [[McpServerCore]]. */
 private[macros] object PromptProcessor extends AnnotationProcessorBase:
 
+  /** The name this method registers under — identical to what [[processPromptAnnotation]] uses. */
+  def registeredName(using Quotes)(methodSym: quotes.reflect.Symbol): String =
+    import quotes.reflect.*
+    val annot = findAnnotation[Prompt](methodSym).getOrElse(
+      report.errorAndAbort(s"No @Prompt annotation found on method '${methodSym.name}'")
+    )
+    nameAndDescription(annot, methodSym)._1
+
   def processPromptAnnotation[R: Type](using Quotes)(
       server: Expr[McpServerCore[R]],
       ownerSym: quotes.reflect.Symbol,

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/RegistrationMacro.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/RegistrationMacro.scala
@@ -71,13 +71,31 @@ object RegistrationMacro:
           case a if a.tpe <:< TypeRepr.of[Prompt] =>
             ("@Prompt name", PromptProcessor.registeredName(method), method)
           case a if a.tpe <:< TypeRepr.of[Resource] =>
-            ("@Resource uri", ResourceProcessor.registeredUriKey(method), method)
+            val (kind, key) = ResourceProcessor.registeredUriKey(method)
+            (kind, key, method)
         }
       }
 
+      // The position is only consulted for symbols compiled in this run: a scanned object unpickled
+      // from a dependency has no recorded span, and asking for it would emit a spurious compiler
+      // warning ("Missing symbol position"); such methods are anchored at the call site instead.
+      def position(m: Symbol): Option[Position] =
+        if m.isDefinedInCurrentRun then m.pos else None
+
+      def where(m: Symbol): String =
+        position(m).map(p => s" @ ${p.sourceFile.name}:${p.startLine + 1}").getOrElse("")
+
+      // `name(p: T, ...) @ File.scala:line`. Value parameters are rendered from the method type so
+      // type parameters and erased class names never leak into the message.
       def describe(m: Symbol): String =
-        val where = m.pos.map(p => s" @ ${p.sourceFile.name}:${p.startLine + 1}").getOrElse("")
-        m.name + m.signature.paramSigs.mkString("(", ", ", ")") + where
+        def valueParams(t: TypeRepr): List[String] = t match
+          case mt: MethodType =>
+            mt.paramNames.zip(mt.paramTypes).map { case (n, pt) =>
+              s"$n: ${pt.show(using Printer.TypeReprShortCode)}"
+            } ++ valueParams(mt.resType)
+          case pt: PolyType => valueParams(pt.resType)
+          case _ => Nil
+        m.name + valueParams(tpe.memberType(m)).mkString("(", ", ", ")") + where(m)
 
       val collisions: List[((String, String), List[Symbol])] = keyed
         .groupBy { case (kind, key, _) => (kind, key) }
@@ -88,8 +106,9 @@ object RegistrationMacro:
       val objectName = sym.companionModule.fullName
       collisions.foreach { case ((kind, key), methods) =>
         val remedy =
-          if kind.startsWith("@Resource") then
+          if kind == ResourceProcessor.TemplateKind then
             "a distinct uri (placeholder names alone do not distinguish templates)"
+          else if kind == ResourceProcessor.StaticKind then "a distinct uri"
           else "an explicit name = Some(\"...\")"
         val msg =
           s"$kind '$key' is registered by ${methods.size} annotated methods in $objectName: " +
@@ -97,7 +116,7 @@ object RegistrationMacro:
             s"unique $kind — give one of them $remedy or remove its annotation."
         // One error per colliding declaration so IDEs navigate to each; the summary below lands
         // at the scanAnnotations call site (the scanned object usually lives in another file).
-        methods.foreach(m => report.error(msg, m.pos.getOrElse(Position.ofMacroExpansion)))
+        methods.foreach(m => report.error(msg, position(m).getOrElse(Position.ofMacroExpansion)))
       }
       if collisions.nonEmpty then
         report.errorAndAbort(

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/RegistrationMacro.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/RegistrationMacro.scala
@@ -56,6 +56,59 @@ object RegistrationMacro:
         report.warning(s"No @Tool, @Prompt, or @Resource annotations found in ${Type.show[T]}")
       server
     else
+      if !sym.flags.is(Flags.Module) then
+        report.errorAndAbort(
+          s"scanAnnotations[${Type.show[T]}] ${MacroUtils.NotAnObjectHint}; ${sym.fullName} is a " +
+            "class. Annotated methods can only be registered from an object."
+        )
+
+      // (kind label, registered key, method). Mirrors the collectFirst order used below so a method
+      // carrying several annotations is keyed by the one that actually gets registered.
+      val keyed: List[(String, String, Symbol)] = annotatedMethods.flatMap { method =>
+        method.annotations.collectFirst {
+          case a if a.tpe <:< TypeRepr.of[Tool] =>
+            ("@Tool name", ToolProcessor.registeredName(method), method)
+          case a if a.tpe <:< TypeRepr.of[Prompt] =>
+            ("@Prompt name", PromptProcessor.registeredName(method), method)
+          case a if a.tpe <:< TypeRepr.of[Resource] =>
+            ("@Resource uri", ResourceProcessor.registeredUriKey(method), method)
+        }
+      }
+
+      def describe(m: Symbol): String =
+        val where = m.pos.map(p => s" @ ${p.sourceFile.name}:${p.startLine + 1}").getOrElse("")
+        m.name + m.signature.paramSigs.mkString("(", ", ", ")") + where
+
+      val collisions: List[((String, String), List[Symbol])] = keyed
+        .groupBy { case (kind, key, _) => (kind, key) }
+        .collect { case (k, ms) if ms.sizeIs > 1 => (k, ms.map(_._3)) }
+        .toList
+        .sortBy { case ((kind, key), _) => (kind, key) }
+
+      val objectName = sym.companionModule.fullName
+      collisions.foreach { case ((kind, key), methods) =>
+        val remedy =
+          if kind.startsWith("@Resource") then
+            "a distinct uri (placeholder names alone do not distinguish templates)"
+          else "an explicit name = Some(\"...\")"
+        val msg =
+          s"$kind '$key' is registered by ${methods.size} annotated methods in $objectName: " +
+            s"${methods.map(describe).mkString(", ")}. Each annotated method must register a " +
+            s"unique $kind — give one of them $remedy or remove its annotation."
+        // One error per colliding declaration so IDEs navigate to each; the summary below lands
+        // at the scanAnnotations call site (the scanned object usually lives in another file).
+        methods.foreach(m => report.error(msg, m.pos.getOrElse(Position.ofMacroExpansion)))
+      }
+      if collisions.nonEmpty then
+        report.errorAndAbort(
+          s"scanAnnotations[${Type.show[T]}]: ${collisions.size} duplicate registration(s) in " +
+            s"$objectName — " + collisions
+              .map { case ((kind, key), ms) =>
+                s"$kind '$key' <- ${ms.map(describe).mkString(" | ")}"
+              }
+              .mkString("; ")
+        )
+
       val registrationExprs: List[Expr[McpServerCore[R]]] = annotatedMethods.flatMap { method =>
         method.annotations.collectFirst {
           case toolAnnot if toolAnnot.tpe <:< TypeRepr.of[Tool] =>

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ResourceProcessor.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ResourceProcessor.scala
@@ -17,17 +17,28 @@ private[macros] object ResourceProcessor extends AnnotationProcessorBase:
 
   private[macros] val placeholderRegex = raw"\{([^{}]+)}".r
 
-  /** The URI (static) or placeholder-name-agnostic URI pattern (template) this method registers.
+  /** Kind label used in duplicate-registration diagnostics for static resources. */
+  private[macros] val StaticKind = "@Resource uri"
+
+  /** Kind label used in duplicate-registration diagnostics for resource templates. */
+  private[macros] val TemplateKind = "@Resource template"
+
+  /** `(kind, key)` this method registers: for a static resource the verbatim URI under
+    * [[StaticKind]]; for a template the placeholder-name-agnostic pattern under [[TemplateKind]].
     * `users://{id}` and `users://{userId}` produce the same key because `ResourceTemplatePattern`
     * builds the same match regex for both, so they would resolve nondeterministically at read time.
+    * Static and template resources are keyed apart, so a static URI that happens to contain a
+    * literal `{}` never collides with a single-placeholder template on the same stem.
     */
-  def registeredUriKey(using Quotes)(methodSym: quotes.reflect.Symbol): String =
+  def registeredUriKey(using Quotes)(methodSym: quotes.reflect.Symbol): (String, String) =
     import quotes.reflect.*
     val annot = findAnnotation[Resource](methodSym).getOrElse(
       report.errorAndAbort(s"No @Resource annotation found on method '${methodSym.name}'")
     )
     val (uri, _, _, _) = MacroUtils.parseResourceParams(annot)
-    placeholderRegex.replaceAllIn(uri, "{}")
+    if placeholderRegex.findFirstIn(uri).isDefined then
+      (TemplateKind, placeholderRegex.replaceAllIn(uri, "{}"))
+    else (StaticKind, uri)
 
   def processResourceAnnotation[R: Type](using Quotes)(
       server: Expr[McpServerCore[R]],

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ResourceProcessor.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ResourceProcessor.scala
@@ -15,6 +15,20 @@ import com.tjclp.fastmcp.server.manager.ResourceTemplateHandler
   */
 private[macros] object ResourceProcessor extends AnnotationProcessorBase:
 
+  private[macros] val placeholderRegex = raw"\{([^{}]+)}".r
+
+  /** The URI (static) or placeholder-name-agnostic URI pattern (template) this method registers.
+    * `users://{id}` and `users://{userId}` produce the same key because `ResourceTemplatePattern`
+    * builds the same match regex for both, so they would resolve nondeterministically at read time.
+    */
+  def registeredUriKey(using Quotes)(methodSym: quotes.reflect.Symbol): String =
+    import quotes.reflect.*
+    val annot = findAnnotation[Resource](methodSym).getOrElse(
+      report.errorAndAbort(s"No @Resource annotation found on method '${methodSym.name}'")
+    )
+    val (uri, _, _, _) = MacroUtils.parseResourceParams(annot)
+    placeholderRegex.replaceAllIn(uri, "{}")
+
   def processResourceAnnotation[R: Type](using Quotes)(
       server: Expr[McpServerCore[R]],
       ownerSym: quotes.reflect.Symbol,
@@ -32,7 +46,6 @@ private[macros] object ResourceProcessor extends AnnotationProcessorBase:
     val finalName = nameOpt.orElse(Some(methodName))
     val finalDesc = descOpt.orElse(methodSym.docstring)
 
-    val placeholderRegex = raw"\{([^{}]+)}".r
     val placeholders = placeholderRegex.findAllMatchIn(uri).map(_.group(1)).toList
     val isTemplate = placeholders.nonEmpty
 

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ToolProcessor.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ToolProcessor.scala
@@ -16,6 +16,16 @@ import com.tjclp.fastmcp.server.manager.*
   */
 private[macros] object ToolProcessor extends AnnotationProcessorBase:
 
+  /** The name this method registers under — identical to what [[processToolAnnotation]] uses, so
+    * the compile-time collision check in [[RegistrationMacro]] can never diverge from it.
+    */
+  def registeredName(using Quotes)(methodSym: quotes.reflect.Symbol): String =
+    import quotes.reflect.*
+    val annot = findAnnotation[Tool](methodSym).getOrElse(
+      report.errorAndAbort(s"No @Tool annotation found on method '${methodSym.name}'")
+    )
+    nameAndDescription(annot, methodSym)._1
+
   def processToolAnnotation[R: Type](using Quotes)(
       server: Expr[McpServerCore[R]],
       ownerSym: quotes.reflect.Symbol,
@@ -96,16 +106,11 @@ private[macros] object ToolProcessor extends AnnotationProcessorBase:
 
     val params = methodSym.paramSymss.headOption.getOrElse(Nil)
 
-    val defaultMethodOwner =
-      if ownerSym.flags.is(Flags.Module) then ownerSym
-      else ownerSym.companionModule
-
-    val paramsWithDefaults: Set[String] = params.zipWithIndex.collect {
-      case (pSym, idx)
-          if defaultMethodOwner != Symbol.noSymbol &&
-            defaultMethodOwner.declaredMethod(s"${methodSym.name}$$default$$${idx + 1}").nonEmpty =>
-        pSym.name
-    }.toSet
+    // `HasDefault` is set on the annotated method's OWN parameter symbols (pickled, so it survives
+    // separate compilation), so an overloaded sibling's `f$default$N` getters — which are name +
+    // index based — can no longer be attributed to this method.
+    val paramsWithDefaults: Set[String] =
+      params.filter(_.flags.is(Flags.HasDefault)).map(_.name).toSet
 
     val paramMetadata: List[(String, ParamMetadata)] =
       params.flatMap { pSym =>


### PR DESCRIPTION
## Summary

`scanAnnotations` received the exact annotated method `Symbol` but `MacroUtils.getMethodRefExpr` threw that identity away and re-resolved the target by name (`companionModule.declaredMethod(name).headOption`). In any scanned object that declares another method with the same name *before* the annotated one, the emitted reference denoted that other overload: the advertised `inputSchema`, the argument decoder and the invoked body all came from a method the developer never annotated, while the tool name, description, hints and `@Param` metadata came from the annotated one. A client (any HTTP peer, or the stdio host under prompt injection) could therefore call, under a trusted validated name, e.g. a raw `f(a, unsafe)` helper sitting behind the annotated `f(a)` wrapper (F4, CWE-706).

This PR binds every `@Tool` / `@Resource` / `@Prompt` registration to the exact annotated symbol, removes the remaining name-based lookups in the macros (default-argument detection, annotation-argument parsing), and turns the silent failure modes into compile-time errors: duplicate registered names / URI patterns within a scanned object, non-object scan targets, and non-literal annotation `Option` arguments.

Part 2/6 of the TJC-2294 security stack; base: `tjc-2299-ci-supply-chain`. Linear: TJC-2298.

## Findings addressed

| Finding | Severity | CWE | Title | Status |
|---|---|---|---|---|
| F4 | MEDIUM | CWE-706 | Annotation macros bind tool/resource/prompt handlers to the wrong same-named overload | Fixed (both fix criteria met in this PR; independently verified) |

## What changed

All changes are compile-time code under `fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/` (shared by JVM, Scala.js and Scala Native). No runtime type, setting, wire shape or public API changed; the emitted closure shape consumed by `MapToFunctionMacro` / `FunctionAnalyzer` is unchanged.

**Exact-symbol binding**
- `MacroUtils.scala` — `getMethodRefExpr` now emits `Select(Ref(moduleSym), methodSym).etaExpand(...)` on the incoming annotated symbol; the `declaredMethod(name).headOption` lookup is gone. A non-`object` owner aborts with the shared `NotAnObjectHint` (defensive backstop; `RegistrationMacro` reports it first).
- `AnnotationProcessorBase.scala` — `methodRef` documents and delegates to the exact-binding helper; `nameAndDescription` is now `NamedArg`-aware / positional-by-index (`name` = `NamedArg("name")` or arg 0, `description` = `NamedArg("description")` or arg 1), so a description-only `@Tool(description = Some(...))` registers under the method name instead of under the description text.

**Name-based default detection removed**
- `ToolProcessor.scala` — `paramsWithDefaults` uses `Flags.HasDefault` on the annotated method's own parameter symbols instead of looking up `name$default$N` getters on the owner (which an overloaded sibling could satisfy).
- `MacroUtils.scala` (`schemaMetadataForTypeRepr`) — the `@Param(required = false)` gate on typed-request case-class fields uses `HasDefault` on the primary-constructor parameter instead of probing the companion for `<init>$default$N` / `apply$default$N` (a hand-written companion `apply` overload with defaults no longer satisfies it).

**Strict literal parser for annotation `Option` arguments**
- `MacroUtils.scala` — new `optionArgShape` / `constantOf` / `parseOptionLiteral`; `parseOptionStringLiteral(term, what)` and `parseOptionBooleanLiteral(term, what)` now take a diagnostic label. Every `Some` / `Option` / `new Some` spelling (qualified or type-applied), `None`, omitted arguments (annotation default getters) and `final val` constants are accepted; anything else is `report.errorAndAbort` at the argument's position: `` @Tool(name) must be a literal Option[String] — Some(<literal>), Option(<literal>) or None — but was `...` ``. Applied to `name`, `description`, `title`, `taskSupport`, `mimeType`, `@Param(schema)` and all boolean hints.
- `MacroUtils.parseResourceParams` — positional `@Resource(uri, name, description, mimeType)` arguments are read by constructor index; named arguments stay named.

**Compile-time duplicate-registration check**
- `RegistrationMacro.scala` (`scanAnnotationsImpl`, used by both `scanAnnotations` and `scanAnnotationsQuiet` / `McpServerApp`) — rejects a non-object `T` (`scanAnnotations[T] requires the singleton type of an object (e.g. scanAnnotations[MyServer.type])`); keys every annotated method by `(kind, key)` via `ToolProcessor.registeredName`, `PromptProcessor.registeredName`, `ResourceProcessor.registeredUriKey`; groups collisions and emits one `report.error` per colliding declaration (`name(p: T, ...) @ File.scala:line`, position only for symbols defined in the current run so TASTy-loaded objects anchor at the call site without a spurious compiler warning) plus a final `report.errorAndAbort` at the `scanAnnotations` call site.
- `ToolProcessor.registeredName` / `PromptProcessor.registeredName` — the same `nameAndDescription` path the processors register with, so the check cannot diverge from registration.
- `ResourceProcessor.scala` — `StaticKind = "@Resource uri"`, `TemplateKind = "@Resource template"`, `registeredUriKey`: static URIs are keyed verbatim; templates are keyed with every `{placeholder}` normalised to `{}` (`users://{id}` and `users://{userId}` build the same match regex and would resolve nondeterministically at read time). Static and template kinds never compare with each other, so a static `x://{}` does not collide with `x://{id}`.

**Tests** (new)
- `fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/OverloadBindingTest.scala`
- `fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/OverloadNegativeTest.scala`
- `fast-mcp-scala/js/test/src/com/tjclp/fastmcp/macros/OverloadBindingJsTest.scala`

## Behaviour changes (pre-1.0)

- **Overloads bind to the annotated declaration.** A scanned object may overload freely; only the annotated overload is registered, and its schema, decoder and handler come from that exact declaration. Two annotated overloads must register distinct `name`s. Previously an earlier same-named sibling was silently registered under the annotated method's name.
- **Compile-time error on duplicate registrations within one scanned object**: same tool name, same prompt name, same static resource URI, or resource templates differing only in placeholder names. The error names every colliding method as `name(param: Type, ...)` with `file:line` and is also reported at the `scanAnnotations` call site. Previously last-writer-wins with a stderr warning (tools/resources) or silent overwrite / nondeterministic template selection.
- **Compile-time error when `scanAnnotations[T]` is not an object's singleton type** (`scanAnnotations[MyServer.type]`).
- **Annotation `Option` arguments must be literals.** `@Tool(name = Some(someVal))` (or any non-literal `description` / `title` / `taskSupport` / `mimeType` / `schema` / hint) is now a compile-time error; at `main` it compiled and silently fell back to the method name / `None`. `final val` string and boolean constants are accepted.
- **Every literal spelling of an `Option` argument is honoured**: `scala.Some("x")`, `Option("x")`, `Some.apply("x")`, `new Some("x")`, `Some[String]("x")`, `final val` constants and positional `@Tool(Some(name), Some(desc))` / `@Resource(uri, Some(name), Option(desc))` now register under the given value. At `main` these were silently ignored (tool registered under the method name; hints dropped).
- **Description-only annotations register under the method name.** `@Tool(description = Some("..."))` without `name` registers as the method name with that description; previously the description text became the registered name.
- **`@Param(required = false)` default detection is exact.** A same-named sibling method's `f$default$N` getter or a companion `apply` overload with defaults no longer satisfies the gate; a genuine primary-constructor default still does.
- Diagnostic wording changes for people asserting on messages: template collisions read `@Resource template 'users://{}'` (static ones keep `@Resource uri '...'`); colliding methods render as `dup(a: Int)` rather than `dup(scala.Int)`.
- Internal (`private[macros]`) signature changes only: `parseOptionStringLiteral(term, what)`, `ResourceProcessor.registeredUriKey` returns `(kind, key)`, new `StaticKind` / `TemplateKind`. No public API impact.

## Fix criteria -> evidence

**F4 #1 — the emitted reference must denote exactly the annotated Symbol so handler, schema and metadata all come from the annotated method (verify with un-annotated `f(a: Int)` declared before `@Tool f(a: String)`: `tools/call` executes the String overload and the schema describes it).** Status: met.
- Code: `fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/MacroUtils.scala:63-74` (`getMethodRefExpr`, `Select(Ref(moduleSym), methodSym)`); `AnnotationProcessorBase.scala:59-63` (`methodRef`); consumers `ToolProcessor.scala:90`, `ResourceProcessor.scala:102`, `PromptProcessor.scala:50`. Related name-based lookups removed: `ToolProcessor.scala:112-113` (`HasDefault` on own params), `MacroUtils.scala:335` (ctor-param `HasDefault`). Literal-only argument provenance: `MacroUtils.scala:439-514` (`optionArgShape`, `constantOf`, `parseOptionLiteral`, `parseOptionStringLiteral`, `parseOptionBooleanLiteral`); `AnnotationProcessorBase.scala:32-55` (`nameAndDescription`).
- Tests: `OverloadBindingTest` (a) line 126 — Int overload declared first, `@Tool` on the String one: schema `properties.a.type == "string"`, description `"Text to echo"`, `required == [a]`, `callTool("echo", a = "hi") == "string:hi"`; (b) line 138 — un-annotated `raw(a, unsafe)` before `@Tool(name = "safe") raw(a)`: `properties.keys == {a}`, dispatch `"safe:x"`; (c) line 145 — differing effect shapes (ZIO sibling, pure annotated) no longer cast-fails, returns 42; (d) line 155 — two annotated overloads with distinct explicit names both register; line 175 description-only registers under the method name; line 186 `@Resource` static + template bind to the annotated overloads; line 200 every literal `Option` spelling honoured; line 222 genuine ctor default satisfies `required = false`; line 235 `@Prompt` binds to the annotated String overload. `OverloadBindingJsTest` lines 31 and 45 mirror (a) and (b) on a class-nested object under Bun.
- Independent verification (verifier, scala-cli `-Xcheck-macros` probes against this branch's compiled classes): the finding's exact repro `f` -> `right-string:hi` with schema `{a: string}`, and `f(a = 7)` now fails decoding (`expected string`) instead of routing to `f(a: Int)`; ctx-taking, ZIO, inherited, generic (`PolyType`), nested-object and default-arg sibling variants all bind to the annotated overload; a separately compiled (TASTy) fixture binds correctly and its `safe` schema carries no `unsafe`.

**F4 #2 — scanning an object whose annotated method name is overloaded (or whose annotated methods collapse to the same registered name) is either fully supported per-signature or rejected with a compile-time error naming the method; no silent registration with mixed provenance.** Status: met.
- Code: `fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/RegistrationMacro.scala:59-63` (non-object target), `:67-77` (`keyed`), `:82-98` (`position` / `describe`), `:100-119` (collision grouping, one `report.error` per declaration), `:122-128` (`errorAndAbort` at the call site); `ToolProcessor.scala:22-27`, `PromptProcessor.scala:16-21`, `ResourceProcessor.scala:21-41` (`registeredName` / `registeredUriKey`). Both `scanAnnotations` and `scanAnnotationsQuiet` (`RegistrationMacro.scala:26-36`) go through `scanAnnotationsImpl`; the processors are `private[macros]`, so no path bypasses the check.
- Per-signature support: `OverloadBindingTest` (d) line 155 (`sum-ints` / `sum-strings` both register and dispatch).
- Rejection: `OverloadNegativeTest` via `scala.compiletime.testing.typeCheckErrors` — line 85 duplicate default `@Tool` names (`@Tool name 'dup'`, `dup(a: Int)`, `dup(a: String)`, file suffix); line 99 duplicate explicit names; line 107 duplicate `@Prompt`; line 115 duplicate static `@Resource` uri; line 123 templates differing only in placeholder names (`@Resource template 'users://{}'`, `placeholder names`); line 131 class scan target; line 139 / 147 sibling-default and companion-`apply` `required = false` cases; lines 157 / 169 / 177 non-literal `@Tool(name)`, `@Tool(readOnlyHint)`, `@Resource(name)`; line 185 control: all positive fixtures compile with `typeCheckErrors == Nil`.
- Independent verification: mixed default-name `@Tool def x(a: Int)` + `@Tool(name = Some("x")) def y(a: String)` with an un-annotated `x(Long, Long)` between them -> exactly one error naming `x(a: Int) @ Neg.scala:8, y(a: String) @ Neg.scala:10`; case-variant names `Foo` / `foo` do not collide (consistent with the case-sensitive `ToolManager` map); `@Tool` and `@Prompt` sharing a name on different methods correctly do not collide (distinct registries). Verifier verdict: **fixed**, no bypasses.

## Tests

- `OverloadBindingTest` (JVM, 10 tests) — positive binding fixtures with the un-annotated overload always declared first (the exact shape `declaredMethod(name).headOption` mis-bound): tool/resource/prompt overloads, differing effect shapes, distinct-name overloads, description-only annotations, every literal `Option` spelling, ctor-default `required = false`, static `x://{}` vs template `x://{id}` on one object.
- `OverloadNegativeTest` (JVM, 12 tests) — `typeCheckErrors` assertions on message substrings for every new compile-time rejection plus a positive control. Fixtures are top-level so the snippets can name them.
- `OverloadBindingJsTest` (Scala.js/Bun, 2 tests) — the (a)/(b) fixtures on a class-nested object, run under Bun in the js suite.
- Not committed, recorded here for the record: a stash-based regression proof (15 of 16 first-round tests fail on the pre-fix macros; only the control passes) and a scala-cli TASTy probe (separately compiled `LibDup` -> one call-site error `z(a: Int), z(a: String)` with no `Missing symbol position` warning; `LibOk` with `scala.Some("libqual")` / `Option("libopt")` registers both).

## Verification

Run on this branch in isolation, as reported by the implementation report (no CI results claimed):

- `rm -rf out/fast-mcp-scala && ./mill fast-mcp-scala.compile` — 168/168 SUCCESS (jvm + js + scalaNative). Only pre-existing WartRemover `Var` / `AsInstanceOf` warnings in untouched macro code.
- `./mill fast-mcp-scala.jvm.test.testOnly com.tjclp.fastmcp.macros.OverloadBindingTest com.tjclp.fastmcp.macros.OverloadNegativeTest` — 10/10 and 12/12.
- `./mill fast-mcp-scala.reformat` then `./mill fast-mcp-scala.checkFormat` (separate invocations) — 16/16 SUCCESS, "Everything is formatted already", re-confirmed after commit.
- `./mill fast-mcp-scala.test` (after the clean rebuild) — 532/532 SUCCESS; every suite `failed 0`; js under Bun: 8 suites, 44/44 incl. `OverloadBindingJsTest`; scalaNative 8/8.
- `scripts/conformance.sh jvm` — 73 passed, 0 failed; `conformance/baseline-jvm.yml` still empty.
- `scripts/conformance.sh js` — 73 passed, 0 failed; `conformance/baseline-js.yml` still empty.
- `git diff --name-only`: exactly the six `shared/.../macros/` files plus the three new test files; `McpServer.scala`, `MapToFunctionMacro.scala`, `core/Annotations.scala` and docs untouched.

Note for reviewers running locally: after any edit (or `reformat`) touching `macros/`, clean-rebuild (`rm -rf out/fast-mcp-scala && ./mill fast-mcp-scala.compile`) before `fast-mcp-scala.test`; the incremental build otherwise hits the documented `NoClassDefFoundError: MacroUtils$` / `-Xcheck-macros` false positive during `AnnotatedServer` / `TaskManagerServer` expansion (observed once during this work, resolved by the clean rebuild).

## Residual risk / follow-ups

- **Duplicate detection is per scanned object.** Two different objects scanned onto one server, or an `McpServerApp` mixing an annotated tool/prompt with a same-named typed contract, still take the runtime overwrite path: `ToolManager` / `ResourceManager` warn on stderr and overwrite; `PromptManager.addContextualPrompt` overwrites silently. This is last-writer-wins with *consistent* provenance (not the mixed-provenance defect of F4). The verifier flagged it as minor and suggested a server-level `strictRegistration` / fail-closed default as a follow-up; the `PromptManager` stderr warning and the placeholder-normalised `ResourceManager.addTemplateResource` duplicate check are handed to the core arc (#90) / integration (#92) via merge notes, not required for F4.
- **Cross-object template resolution** remains first-match over `ConcurrentHashMap.values()` in `ResourceManager`; `users://{id}` vs `users://{userId}` registered from two different objects is still nondeterministic at read time (compile-time rejection covers the single-object case).
- **Default arguments are still not applied at runtime** by `MapToFunctionMacro` (a missing non-`Option` key fails decoding); the `HasDefault` change only attributes defaults to the correct declaration for the compile-time `required = false` gate. Out of F4 scope.
- **Private/protected annotated methods**: `Select(Ref(obj), privateMethod)` from the splice site could trip access checks; identical exposure at `main`, no regression, not addressed here.
- Collision diagnostics for scan targets loaded from a pre-compiled dependency (TASTy) intentionally omit the ` @ file:line` suffix and anchor at the `scanAnnotations` call site.
- `@Param` positional-argument bookkeeping (`parseToolParam`) still counts default getters as positional slots when named and positional arguments are mixed (pre-existing; harmless now that default getters parse as `None`).
- **Docs are deferred to the integration PR** (#92): CHANGELOG (Fixed + Changed), README ("Tools and `@Param` metadata"), `docs/architecture.md` discovery stage, `core/Annotations.scala` scaladoc for the literal-only rule and template identity, optional SECURITY.md note. This PR edits no docs.

## Stack & merge order

1. #87 `tjc-2299-ci-supply-chain` -> `main` (TJC-2299, CI supply chain: F6, F7)
2. **#88 `tjc-2298-macro-overload-binding` -> `tjc-2299-ci-supply-chain` (TJC-2298, macros: F4) — this PR**
3. #89 `tjc-2297-tasks-hardening` -> `tjc-2298-macro-overload-binding` (TJC-2297, tasks: F8, F9, F11)
4. #90 `tjc-2295-core-input-limits` -> `tjc-2297-tasks-hardening` (TJC-2295, core input limits: F1, F2, F3)
5. #91 `tjc-2296-http-transport-hardening` -> `tjc-2295-core-input-limits` (TJC-2296, HTTP transports: F1, F5, F10, F12)
6. #92 `tjc-2294-security-hardening` -> `tjc-2296-http-transport-hardening` (TJC-2294, cross-arc integration + docs)

Review and merge bottom-up. Merge each PR with a **merge commit**, not squash: squashing the bottom of a stack orphans the PRs above it (see TJC-2114). After each merge, retarget the next PR to `main` (GitHub does this automatically when the merged base branch is deleted). The stack tip is byte-identical to a fully verified integrated tree: 532/532 Mill test tasks incl. JVM, Bun and Scala Native suites; official MCP conformance 73/73 checks on both JVM and Bun with empty baselines; scalafmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
