### PR TITLE
Bound the task store, single TTL sweeper, per-client bearer buckets, atomic create (TJC-2297)

### DIFF
--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/TaskTransportGuardTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/TaskTransportGuardTest.scala
@@ -5,8 +5,8 @@ import org.scalatest.matchers.should.Matchers
 import zio.*
 import zio.json.ast.Json
 
-import com.tjclp.fastmcp.{given, *}
-import com.tjclp.fastmcp.core.{Tasks, TaskSupport}
+import com.tjclp.fastmcp.{*, given}
+import com.tjclp.fastmcp.core.{TaskSupport, Tasks}
 import com.tjclp.fastmcp.core.wire.Implementation
 import com.tjclp.fastmcp.jsonrpc.{JsonRpcMessage, RequestId}
 import com.tjclp.fastmcp.server.manager.TaskManager
@@ -50,7 +50,9 @@ class TaskTransportGuardTest extends AnyFunSuite with Matchers:
     val server = McpServer.typed[Any]("GuardServer", "0.1.0", McpServerSettings(tasks = settings))
     runUnsafe(
       server.tool(
-        McpTool[NoArgs, String](name = "blocky")(_ => gate.await.onInterrupt(onInterrupt).as("blocky"))
+        McpTool[NoArgs, String](name = "blocky")(_ =>
+          gate.await.onInterrupt(onInterrupt).as("blocky")
+        )
           .withTaskSupport(TaskSupport.Optional)
       )
     )
@@ -151,7 +153,8 @@ class TaskTransportGuardTest extends AnyFunSuite with Matchers:
           else ZIO.sleep(5.millis) *> awaitPendingInterrupt(n - 1)
         )
     val hook: String => UIO[Unit] =
-      stage => if stage == "registered" then latch.succeed(()) *> awaitPendingInterrupt(1000) else ZIO.unit
+      stage =>
+        if stage == "registered" then latch.succeed(()) *> awaitPendingInterrupt(1000) else ZIO.unit
     val (router, tm) = build(TaskSettings(enabled = true), gate, hook)
     try
       val session = initialized(router, "cancel-race")
@@ -193,7 +196,11 @@ class TaskTransportGuardTest extends AnyFunSuite with Matchers:
       stats.total shouldBe 0
       stats.running shouldBe 0
       stats.perOwner shouldBe empty
-      frame(router, session, """{"jsonrpc":"2.0","id":78,"method":"tasks/list","params":{}}""") should include(
+      frame(
+        router,
+        session,
+        """{"jsonrpc":"2.0","id":78,"method":"tasks/list","params":{}}"""
+      ) should include(
         """"tasks":[]"""
       )
       runUnsafe(session.inflightIds) shouldBe empty
@@ -238,6 +245,74 @@ class TaskTransportGuardTest extends AnyFunSuite with Matchers:
       runUnsafe(interrupted.get) shouldBe 1
       // A session that never created a task terminates cleanly too.
       runUnsafe(runUnsafe(Session.make("idle")).terminate)
+    finally
+      runUnsafe(gate.succeed(()))
+      runUnsafe(tm.shutdown)
+  }
+
+  test("a finalizer registered after terminate runs immediately instead of being parked") {
+    val session = runUnsafe(Session.make("late"))
+    val ran = runUnsafe(Ref.make(List.empty[String]))
+    runUnsafe(session.addFinalizer("a")(ran.update("a" :: _)))
+    runUnsafe(session.isTerminated) shouldBe false
+    runUnsafe(session.terminate)
+    runUnsafe(session.isTerminated) shouldBe true
+    runUnsafe(ran.get) shouldBe List("a")
+    // Late registration: runs now, is not stored, and a second terminate does not re-run anything.
+    runUnsafe(session.addFinalizer("b")(ran.update("b" :: _)))
+    runUnsafe(ran.get) shouldBe List("b", "a")
+    runUnsafe(session.terminate)
+    runUnsafe(ran.get) shouldBe List("b", "a")
+  }
+
+  test("session.terminate racing a task-augmented legacy call leaves no task behind") {
+    val gate = runUnsafe(Promise.make[Nothing, Unit])
+    val latch = runUnsafe(Promise.make[Nothing, Unit])
+    val proceed = runUnsafe(Promise.make[Nothing, Unit])
+    // Park the create AFTER admission (entry registered, gate closed) until the test has
+    // terminated the session — the worst-case interleaving for a DELETE racing a POST.
+    val hook: String => UIO[Unit] =
+      stage => if stage == "registered" then latch.succeed(()) *> proceed.await else ZIO.unit
+    val (router, tm) = build(TaskSettings(enabled = true), gate, hook)
+    try
+      val session = initialized(router, "delete-race")
+      val id = RequestId.NumId(79)
+      val call = JsonRpcMessage.Request(
+        id,
+        "tools/call",
+        Some(
+          Json.Obj(
+            "name" -> Json.Str("blocky"),
+            "arguments" -> Json.Obj(),
+            "task" -> Json.Obj("ttl" -> Json.Num(60000))
+          )
+        )
+      )
+      val (response, stats) = runUnsafe(
+        for
+          fiber <- router.dispatch(session, call).fork
+          _ <- latch.await
+          _ <- (ZIO.sleep(5.millis) *> session.inflightIds.map(_.contains(id)))
+            .repeatUntil(identity)
+            .timeoutFail(new RuntimeException("request never tracked"))(10.seconds)
+          registered <- tm.stats
+          _ <- ZIO.succeed(registered.total shouldBe 1)
+          // terminate: latches, interrupts the in-flight pipeline fiber, runs the release hook
+          // that was registered BEFORE the create.
+          _ <- session.terminate
+          _ <- proceed.succeed(())
+          response <- fiber.join
+          stats <- tm.stats
+        yield (response, stats)
+      )
+      // Either the pending interrupt rolled the create back, or the post-create re-registration
+      // ran the release on the terminated session — in both cases nothing survives.
+      response shouldBe None
+      stats.total shouldBe 0
+      stats.running shouldBe 0
+      stats.perOwner shouldBe empty
+      runUnsafe(session.inflightIds) shouldBe empty
+      runUnsafe(session.isTerminated) shouldBe true
     finally
       runUnsafe(gate.succeed(()))
       runUnsafe(tm.shutdown)

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/TaskTransportGuardTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/TaskTransportGuardTest.scala
@@ -3,15 +3,77 @@ package com.tjclp.fastmcp.server
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import zio.*
+import zio.json.ast.Json
 
 import com.tjclp.fastmcp.{given, *}
-import com.tjclp.fastmcp.core.Tasks
+import com.tjclp.fastmcp.core.{Tasks, TaskSupport}
+import com.tjclp.fastmcp.core.wire.Implementation
+import com.tjclp.fastmcp.jsonrpc.{JsonRpcMessage, RequestId}
+import com.tjclp.fastmcp.server.manager.TaskManager
+import com.tjclp.fastmcp.server.router.{McpRouter, RouterBuilder, Session}
+import com.tjclp.fastmcp.server.transport.MessageLoop
 
-/** Modern Tasks are bearer handles explicitly designed to outlive protocol-level sessions. */
+/** Modern Tasks are bearer handles explicitly designed to outlive protocol-level sessions. The
+  * router-level cases below drive `McpRouter` directly with a hand-built `TaskManager`, so they
+  * exercise the accounting (per-client buckets, per-pool ceilings), session release, and the
+  * cancellation race without a transport in the way.
+  */
 class TaskTransportGuardTest extends AnyFunSuite with Matchers:
 
   private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
     Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(effect).getOrThrowFiberFailure())
+
+  private case class NoArgs()
+
+  private val initFrame =
+    """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"1.0"}}}"""
+
+  private val taskMeta =
+    s""""_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{"extensions":{"${Tasks.ExtensionId}":{}}}}"""
+
+  private def modernCall(id: Int, tool: String): String =
+    s"""{"jsonrpc":"2.0","id":$id,"method":"tools/call","params":{"name":"$tool","arguments":{},$taskMeta}}"""
+
+  private def legacyCall(id: Int, tool: String): String =
+    s"""{"jsonrpc":"2.0","id":$id,"method":"tools/call","params":{"name":"$tool","arguments":{},"task":{"ttl":60000}}}"""
+
+  private def frame(router: McpRouter[Any], session: Session, value: String): String =
+    runUnsafe(MessageLoop.handleFrame(router, session, value)).getOrElse(fail("no response"))
+
+  /** A server with a gated `blocky` tool plus a router over a TaskManager we keep a handle on. */
+  private def build(
+      settings: TaskSettings,
+      gate: Promise[Nothing, Unit],
+      checkpoint: String => UIO[Unit] = _ => ZIO.unit,
+      onInterrupt: UIO[Unit] = ZIO.unit
+  ): (McpRouter[Any], TaskManager[Any]) =
+    val server = McpServer.typed[Any]("GuardServer", "0.1.0", McpServerSettings(tasks = settings))
+    runUnsafe(
+      server.tool(
+        McpTool[NoArgs, String](name = "blocky")(_ => gate.await.onInterrupt(onInterrupt).as("blocky"))
+          .withTaskSupport(TaskSupport.Optional)
+      )
+    )
+    val tm = TaskManager.makeUnsafe[Any](
+      settings,
+      ZIO.succeed(java.util.UUID.randomUUID().toString),
+      checkpoint
+    )
+    val router = RouterBuilder.build[Any](
+      serverInfo = Implementation(name = "GuardServer", version = "0.1.0"),
+      instructions = None,
+      toolManager = server.toolManager,
+      promptManager = server.promptManager,
+      resourceManager = server.resourceManager,
+      settings = server.settings,
+      taskManager = Some(tm)
+    )
+    (router, tm)
+
+  private def initialized(router: McpRouter[Any], id: String): Session =
+    val session = runUnsafe(Session.make(id))
+    frame(router, session, initFrame) should include(""""tasks"""")
+    session
 
   test("tasks + stateless HTTP builds and advertises the official extension") {
     val server = McpServer(
@@ -27,4 +89,156 @@ class TaskTransportGuardTest extends AnyFunSuite with Matchers:
     val server =
       McpServer("GuardServer2", "0.1.0", McpServerSettings(tasks = TaskSettings(enabled = true)))
     noException should be thrownBy runUnsafe(server.buildRouter)
+  }
+
+  test("modern clients with distinct Session.clientKey get independent task buckets") {
+    val gate = runUnsafe(Promise.make[Nothing, Unit])
+    val (router, tm) = build(TaskSettings(enabled = true, maxConcurrentPerSession = 2), gate)
+    try
+      val a = runUnsafe(Session.make("ra", clientKey = Some("A")))
+      val b = runUnsafe(Session.make("rb", clientKey = Some("B")))
+      frame(router, a, modernCall(1, "blocky")) should include(""""resultType":"task"""")
+      frame(router, a, modernCall(2, "blocky")) should include(""""resultType":"task"""")
+      // A is at its cap; B is untouched.
+      frame(router, b, modernCall(3, "blocky")) should include(""""resultType":"task"""")
+      val third = frame(router, a, modernCall(4, "blocky"))
+      third should include(""""code":-32602""")
+      third should include("Task concurrency limit exceeded")
+      third should not include "client:A"
+      val stats = runUnsafe(tm.stats)
+      stats.perOwner(Some("client:A")).running shouldBe 2
+      stats.perOwner(Some("client:B")).running shouldBe 1
+      // Keyless modern requests fall into the anonymous bucket, not into A's.
+      val anon = runUnsafe(Session.make("anon"))
+      frame(router, anon, modernCall(5, "blocky")) should include(""""resultType":"task"""")
+      runUnsafe(tm.stats).perOwner(None).running shouldBe 1
+    finally
+      runUnsafe(gate.succeed(()))
+      runUnsafe(tm.shutdown)
+  }
+
+  test("legacy-session pool at its ceiling does not block bearer tasks") {
+    val gate = runUnsafe(Promise.make[Nothing, Unit])
+    val (router, tm) =
+      build(TaskSettings(enabled = true, maxConcurrentPerSession = 1, maxConcurrentTotal = 2), gate)
+    try
+      val s1 = initialized(router, "s1")
+      val s2 = initialized(router, "s2")
+      val s3 = initialized(router, "s3")
+      frame(router, s1, legacyCall(10, "blocky")) should include(""""status":"working"""")
+      frame(router, s2, legacyCall(11, "blocky")) should include(""""status":"working"""")
+      val full = frame(router, s3, legacyCall(12, "blocky"))
+      full should include(""""code":-32003""")
+      full should include("Task capacity exceeded (running, limit 2)")
+      // The bearer pool is counted apart from the (freely mintable) legacy sessions.
+      val modern = runUnsafe(Session.make("rm", clientKey = Some("M")))
+      frame(router, modern, modernCall(13, "blocky")) should include(""""resultType":"task"""")
+    finally
+      runUnsafe(gate.succeed(()))
+      runUnsafe(tm.shutdown)
+  }
+
+  test("notifications/cancelled racing a task-augmented legacy call leaves no task behind") {
+    val gate = runUnsafe(Promise.make[Nothing, Unit])
+    val latch = runUnsafe(Promise.make[Nothing, Unit])
+    // Hold the create after admission until the creating fiber has a pending interrupt (bounded
+    // by ~5 s so a broken cancel path fails the test instead of hanging it).
+    def awaitPendingInterrupt(n: Int): UIO[Unit] =
+      if n <= 0 then ZIO.unit
+      else
+        ZIO.descriptorWith(d =>
+          if d.interrupters.nonEmpty then ZIO.unit
+          else ZIO.sleep(5.millis) *> awaitPendingInterrupt(n - 1)
+        )
+    val hook: String => UIO[Unit] =
+      stage => if stage == "registered" then latch.succeed(()) *> awaitPendingInterrupt(1000) else ZIO.unit
+    val (router, tm) = build(TaskSettings(enabled = true), gate, hook)
+    try
+      val session = initialized(router, "cancel-race")
+      val id = RequestId.NumId(77)
+      val call = JsonRpcMessage.Request(
+        id,
+        "tools/call",
+        Some(
+          Json.Obj(
+            "name" -> Json.Str("blocky"),
+            "arguments" -> Json.Obj(),
+            "task" -> Json.Obj("ttl" -> Json.Num(60000))
+          )
+        )
+      )
+      val cancelled = JsonRpcMessage.Notification(
+        "notifications/cancelled",
+        Some(Json.Obj("requestId" -> Json.Num(77)))
+      )
+      val (response, stats) = runUnsafe(
+        for
+          fiber <- router.dispatch(session, call).fork
+          _ <- latch.await
+          // The dispatcher forks the pipeline BEFORE tracking it: wait until the id is tracked so
+          // the cancellation cannot outrun `trackInflight`.
+          _ <- (ZIO.sleep(5.millis) *> session.inflightIds.map(_.contains(id)))
+            .repeatUntil(identity)
+            .timeoutFail(new RuntimeException("request never tracked"))(10.seconds)
+          // cancelInflight awaits the pipeline fiber, which is parked in the hook until it sees
+          // the interrupt — so the cancel must run concurrently with the create.
+          cancel <- router.dispatch(session, cancelled).fork
+          response <- fiber.join
+          _ <- cancel.join
+          stats <- tm.stats
+        yield (response, stats)
+      )
+      // A cancelled request emits no response and leaves no task: the registration rolled back.
+      response shouldBe None
+      stats.total shouldBe 0
+      stats.running shouldBe 0
+      stats.perOwner shouldBe empty
+      frame(router, session, """{"jsonrpc":"2.0","id":78,"method":"tasks/list","params":{}}""") should include(
+        """"tasks":[]"""
+      )
+      runUnsafe(session.inflightIds) shouldBe empty
+    finally
+      runUnsafe(gate.succeed(()))
+      runUnsafe(tm.shutdown)
+  }
+
+  test("session.terminate releases the session's legacy tasks") {
+    val gate = runUnsafe(Promise.make[Nothing, Unit])
+    val interrupted = runUnsafe(Ref.make(0))
+    val (router, tm) =
+      build(TaskSettings(enabled = true), gate, onInterrupt = interrupted.update(_ + 1))
+    try
+      val session = initialized(router, "terminating")
+      val created = frame(router, session, legacyCall(20, "blocky"))
+      created should include(""""status":"working"""")
+      val taskId = "\"taskId\":\"([^\"]+)\"".r
+        .findFirstMatchIn(created)
+        .map(_.group(1))
+        .getOrElse(fail(s"missing task id in $created"))
+      runUnsafe(tm.stats).running shouldBe 1
+      val other = initialized(router, "bystander")
+      frame(router, other, legacyCall(21, "blocky")) should include(""""status":"working"""")
+
+      runUnsafe(session.terminate)
+
+      val stats = runUnsafe(tm.stats)
+      stats.running shouldBe 1 // the bystander's task is untouched
+      stats.total shouldBe 1
+      stats.perOwner.contains(Some("session:terminating")) shouldBe false
+      // The released task no longer exists for anyone, and exactly its fiber was interrupted.
+      runUnsafe(tm.get(taskId, Some("terminating"))) shouldBe None
+      runUnsafe(
+        (ZIO.sleep(10.millis) *> interrupted.get)
+          .repeatUntil(_ >= 1)
+          .timeoutFail(new RuntimeException("released task was not interrupted"))(10.seconds)
+      ) shouldBe 1
+      // Finalizers ran exactly once: terminating again is a harmless no-op.
+      runUnsafe(session.terminate)
+      runUnsafe(tm.stats).total shouldBe 1
+      runUnsafe(interrupted.get) shouldBe 1
+      // A session that never created a task terminates cleanly too.
+      runUnsafe(runUnsafe(Session.make("idle")).terminate)
+    finally
+      runUnsafe(gate.succeed(()))
+      runUnsafe(tm.shutdown)
   }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/manager/TaskManagerSpec.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/manager/TaskManagerSpec.scala
@@ -19,7 +19,13 @@ class TaskManagerSpec extends AnyFlatSpec with Matchers {
 
   private def newManager(
       maxConcurrent: Int = 64,
-      defaultTtl: Long = 3_600_000L
+      defaultTtl: Long = 3_600_000L,
+      maxConcurrentTotal: Int = 1024,
+      maxStoredPerOwner: Int = 256,
+      maxStoredTotal: Int = 4096,
+      minResultRetentionMs: Long = 30_000L,
+      sweepIntervalMs: Long = 1_000L,
+      checkpoint: String => UIO[Unit] = _ => ZIO.unit
   ): TaskManager[Any] =
     TaskManager.makeUnsafe[Any](
       TaskSettings(
@@ -27,9 +33,51 @@ class TaskManagerSpec extends AnyFlatSpec with Matchers {
         defaultTtlMs = defaultTtl,
         maxTtlMs = 86_400_000L,
         pollIntervalMs = 5_000L,
-        maxConcurrentPerSession = maxConcurrent
+        maxConcurrentPerSession = maxConcurrent,
+        maxConcurrentTotal = maxConcurrentTotal,
+        maxStoredPerOwner = maxStoredPerOwner,
+        maxStoredTotal = maxStoredTotal,
+        minResultRetentionMs = minResultRetentionMs,
+        sweepIntervalMs = sweepIntervalMs
       ),
-      newId = ZIO.succeed(java.util.UUID.randomUUID().toString)
+      newId = ZIO.succeed(java.util.UUID.randomUUID().toString),
+      checkpoint = checkpoint
+    )
+
+  private def exitOf[A](z: ZIO[Any, Throwable, A]): Exit[Throwable, A] =
+    Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(z))
+
+  private def failureOf(exit: Exit[Throwable, ?]): Throwable =
+    exit match
+      case Exit.Failure(c) => c.failureOption.getOrElse(fail(s"no typed failure in $c"))
+      case Exit.Success(_) => fail("expected a failure but the effect succeeded")
+
+  /** A task that runs to completion and returns `value`; the create is fenced by awaiting the
+    * result so the entry is terminal when the helper returns.
+    */
+  private def completed(tm: TaskManager[Any], scope: TaskScope, value: String = "ok"): String =
+    val created = runUnsafe(tm.create(scope, None, ZIO.succeed(value), _ => ZIO.unit))
+    val _ = runUnsafe(tm.result(created.task.taskId, scope.sessionId))
+    created.task.taskId
+
+  private def rootFibers: Int = runUnsafe(Fiber.roots.map(_.size))
+
+  /** Never assert `Fiber.roots` after a fixed sleep: poll until the delta settles. */
+  private def awaitRootsSettle(before: Int, tolerance: Int = 5): Unit =
+    runUnsafe(
+      (ZIO.sleep(25.millis) *> Fiber.roots.map(_.size))
+        .repeatUntil(_ - before <= tolerance)
+        .timeoutFail(new RuntimeException("root fibers did not settle"))(10.seconds)
+        .unit
+    )
+
+  private def awaitStats(tm: TaskManager[Any])(p: TaskStoreStats => Boolean): TaskStoreStats =
+    runUnsafe(
+      (ZIO.sleep(20.millis) *> tm.stats)
+        .repeatUntil(p)
+        .timeoutFail(new RuntimeException("task store never reached the expected state"))(
+          10.seconds
+        )
     )
 
   "create" should "return a CreateTaskResult in Working status" in {
@@ -270,5 +318,392 @@ class TaskManagerSpec extends AnyFlatSpec with Matchers {
           10.seconds
         )
     )
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // F8: bounded store, single sweeper
+  // ---------------------------------------------------------------------------------------------
+
+  "stored-entry cap" should "evict the owner's oldest terminal entry" in {
+    val tm = newManager(maxConcurrent = 4, maxStoredPerOwner = 4, minResultRetentionMs = 0L)
+    try
+      val scope = TaskScope.session("loop")
+      val ids = (1 to 6).map(i => completed(tm, scope, s"v$i"))
+      val stats = runUnsafe(tm.stats)
+      stats.total shouldBe 4
+      stats.running shouldBe 0
+      ids.take(2).foreach(id => runUnsafe(tm.get(id, Some("loop"))) shouldBe None)
+      ids.drop(2).foreach(id => runUnsafe(tm.get(id, Some("loop"))).isDefined shouldBe true)
+    finally runUnsafe(tm.shutdown)
+  }
+
+  it should "bound the store across owners at the pool cap and charge the largest owner" in {
+    // Stored caps normalise to >= the running caps, so the running ceilings are lowered too.
+    val tm = newManager(maxConcurrent = 8, maxConcurrentTotal = 8, maxStoredPerOwner = 8, maxStoredTotal = 8, minResultRetentionMs = 0L)
+    try
+      val a = TaskScope.session("A")
+      val b = TaskScope.session("B")
+      val c = TaskScope.session("C")
+      val aIds = (1 to 6).map(_ => completed(tm, a))
+      val bIds = (1 to 2).map(_ => completed(tm, b))
+      runUnsafe(tm.stats).total shouldBe 8
+      val cId = completed(tm, c)
+      val stats = runUnsafe(tm.stats)
+      stats.total shouldBe 8
+      stats.perOwner(a.ownerKey).total shouldBe 5
+      stats.perOwner(b.ownerKey).total shouldBe 2
+      stats.perOwner(c.ownerKey).total shouldBe 1
+      // A's OLDEST completed task paid for C's admission; B is intact.
+      runUnsafe(tm.get(aIds.head, Some("A"))) shouldBe None
+      aIds.tail.foreach(id => runUnsafe(tm.get(id, Some("A"))).isDefined shouldBe true)
+      bIds.foreach(id => runUnsafe(tm.get(id, Some("B"))).isDefined shouldBe true)
+      runUnsafe(tm.get(cId, Some("C"))).isDefined shouldBe true
+    finally runUnsafe(tm.shutdown)
+  }
+
+  it should "reject when nothing is evictable" in {
+    val tm = newManager(maxConcurrent = 2, maxConcurrentTotal = 2, maxStoredTotal = 2, minResultRetentionMs = 60_000L)
+    val gate = runUnsafe(Promise.make[Nothing, Unit])
+    try
+      val never: ZIO[Any, Throwable, Any] = gate.await
+      runUnsafe(tm.create(TaskScope.session("s1"), None, never, _ => ZIO.unit))
+      runUnsafe(tm.create(TaskScope.session("s2"), None, never, _ => ZIO.unit))
+      // Two running entries: the running ceiling is reported first (stored is normalised >= it).
+      val err = failureOf(exitOf(tm.create(TaskScope.session("s3"), None, never, _ => ZIO.unit)))
+      err match
+        case e: TaskCapacityExceeded =>
+          e.kind shouldBe "running"
+          e.limit shouldBe 2
+          e.getMessage shouldBe "Task capacity exceeded (running, limit 2)"
+          e.toMcpError.code shouldBe ErrorCodes.CapacityExceeded
+          e.toMcpError.code shouldBe -32003
+        case other => fail(s"expected TaskCapacityExceeded but got $other")
+      runUnsafe(tm.stats).total shouldBe 2
+    finally
+      runUnsafe(gate.succeed(()))
+      runUnsafe(tm.shutdown)
+
+    // Stored cap with a completed-but-young entry: rejected as "stored", store unchanged.
+    val tm2 = newManager(maxConcurrent = 3, maxConcurrentTotal = 3, maxStoredPerOwner = 3, maxStoredTotal = 3, minResultRetentionMs = 60_000L)
+    val gate2 = runUnsafe(Promise.make[Nothing, Unit])
+    try
+      val never: ZIO[Any, Throwable, Any] = gate2.await
+      val done = completed(tm2, TaskScope.session("s1"))
+      runUnsafe(tm2.create(TaskScope.session("s2"), None, never, _ => ZIO.unit))
+      runUnsafe(tm2.create(TaskScope.session("s3"), None, never, _ => ZIO.unit))
+      val before = runUnsafe(tm2.stats)
+      val err = failureOf(exitOf(tm2.create(TaskScope.session("s4"), None, never, _ => ZIO.unit)))
+      err match
+        case e: TaskCapacityExceeded =>
+          e.kind shouldBe "stored"
+          e.limit shouldBe 3
+        case other => fail(s"expected TaskCapacityExceeded but got $other")
+      runUnsafe(tm2.stats) shouldBe before
+      runUnsafe(tm2.result(done, Some("s1"))) shouldBe "ok"
+    finally
+      runUnsafe(gate2.succeed(()))
+      runUnsafe(tm2.shutdown)
+  }
+
+  it should "map TaskCapacityExceeded to -32003 through McpError.fromThrowable" in {
+    val mapped = com.tjclp.fastmcp.jsonrpc.McpError.fromThrowable(TaskCapacityExceeded("stored", 7))
+    mapped.code shouldBe -32003
+    mapped.message shouldBe "Task capacity exceeded (stored, limit 7)"
+  }
+
+  "retention grace" should "protect a completed-but-unfetched result from a flooding co-owner" in {
+    val tm = newManager(maxConcurrent = 4, maxStoredPerOwner = 4, minResultRetentionMs = 60_000L)
+    try
+      val anon = TaskScope.bearer(None)
+      val victim = runUnsafe(tm.create(anon, None, ZIO.succeed("precious"), _ => ZIO.unit))
+      // Let the victim complete, but do NOT collect its result.
+      val _ = awaitStats(tm)(_.running == 0)
+      (1 to 3).foreach(_ => completed(tm, anon))
+      val err = failureOf(exitOf(tm.create(anon, None, ZIO.succeed("flood"), _ => ZIO.unit)))
+      err match
+        case e: TaskCapacityExceeded => e.kind shouldBe "stored-per-owner"
+        case other => fail(s"expected TaskCapacityExceeded but got $other")
+      runUnsafe(tm.result(victim.task.taskId, None)) shouldBe "precious"
+      runUnsafe(tm.stats).total shouldBe 4
+    finally runUnsafe(tm.shutdown)
+  }
+
+  "sweeper" should "leave at most one sweeper fiber in Fiber.roots for many terminal tasks" in {
+    val tm = newManager()
+    val before = rootFibers
+    try
+      val scope = TaskScope.session("many")
+      val ids = (1 to 50).map(_ =>
+        runUnsafe(tm.create(scope, Some(60_000L), ZIO.succeed("fast"), _ => ZIO.unit)).task.taskId
+      )
+      ids.foreach(id => runUnsafe(tm.result(id, Some("many"))) shouldBe "fast")
+      val stats = runUnsafe(tm.stats)
+      stats.total shouldBe 50
+      stats.running shouldBe 0
+      stats.sweeperActive shouldBe true
+      awaitRootsSettle(before)
+    finally runUnsafe(tm.shutdown)
+  }
+
+  it should "exit when the store drains and restart on the next create" in {
+    val tm = newManager(sweepIntervalMs = 50L)
+    val before = rootFibers
+    try
+      val scope = TaskScope.session("drain")
+      (1 to 3).foreach(_ =>
+        runUnsafe(tm.create(scope, Some(50L), ZIO.succeed("x"), _ => ZIO.unit))
+      )
+      runUnsafe(tm.stats).sweeperActive shouldBe true
+      val drained = awaitStats(tm)(s => s.total == 0 && !s.sweeperActive)
+      drained.perOwner shouldBe empty
+      drained.perPool shouldBe empty
+      awaitRootsSettle(before)
+      runUnsafe(tm.create(scope, Some(60_000L), ZIO.succeed("y"), _ => ZIO.unit))
+      runUnsafe(tm.stats).sweeperActive shouldBe true
+    finally runUnsafe(tm.shutdown)
+    awaitRootsSettle(before)
+  }
+
+  "shutdown" should "drain the store, interrupt running work and stop the sweeper" in {
+    val tm = newManager()
+    val before = rootFibers
+    val interrupted = runUnsafe(Ref.make(false))
+    runUnsafe(
+      tm.create(TaskScope.session("s"), None, ZIO.never.onInterrupt(interrupted.set(true)), _ => ZIO.unit)
+    )
+    completed(tm, TaskScope.bearer(Some("k")))
+    runUnsafe(tm.shutdown)
+    val stats = runUnsafe(tm.stats)
+    stats.total shouldBe 0
+    stats.running shouldBe 0
+    stats.sweeperActive shouldBe false
+    runUnsafe(
+      (ZIO.sleep(10.millis) *> interrupted.get)
+        .repeatUntil(identity)
+        .timeoutFail(new RuntimeException("running task was not interrupted"))(10.seconds)
+    )
+    awaitRootsSettle(before)
+  }
+
+  "releaseScope" should "remove and interrupt a session's tasks, leaving other owners alone" in {
+    val tm = newManager()
+    val interrupted = runUnsafe(Ref.make(false))
+    try
+      val mine = TaskScope.session("mine")
+      val running = runUnsafe(
+        tm.create(mine, None, ZIO.never.onInterrupt(interrupted.set(true)), _ => ZIO.unit)
+      )
+      val doneId = completed(tm, mine)
+      val otherId = completed(tm, TaskScope.session("other"))
+      val anonId = completed(tm, TaskScope.bearer(None))
+      runUnsafe(tm.releaseScope(mine))
+      runUnsafe(tm.get(running.task.taskId, Some("mine"))) shouldBe None
+      runUnsafe(tm.get(doneId, Some("mine"))) shouldBe None
+      runUnsafe(tm.get(otherId, Some("other"))).isDefined shouldBe true
+      runUnsafe(tm.get(anonId, None)).isDefined shouldBe true
+      runUnsafe(
+        (ZIO.sleep(10.millis) *> interrupted.get)
+          .repeatUntil(identity)
+          .timeoutFail(new RuntimeException("released task was not interrupted"))(10.seconds)
+      )
+      val stats = runUnsafe(tm.stats)
+      stats.total shouldBe 2
+      stats.running shouldBe 0
+      stats.perOwner.contains(mine.ownerKey) shouldBe false
+      // The shared anonymous bucket is never bulk-released.
+      runUnsafe(tm.releaseScope(TaskScope.bearer(None)))
+      runUnsafe(tm.get(anonId, None)).isDefined shouldBe true
+    finally runUnsafe(tm.shutdown)
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // F9: per-client buckets and per-pool ceilings
+  // ---------------------------------------------------------------------------------------------
+
+  "bearer tasks" should "bucket per client key: A at cap, B and anonymous still create" in {
+    val tm = newManager(maxConcurrent = 3)
+    val gate = runUnsafe(Promise.make[Nothing, Unit])
+    try
+      val never: ZIO[Any, Throwable, Any] = gate.await
+      val a = TaskScope.bearer(Some("A"))
+      (1 to 3).foreach(_ => runUnsafe(tm.create(a, None, never, _ => ZIO.unit)))
+      runUnsafe(tm.create(TaskScope.bearer(Some("B")), None, never, _ => ZIO.unit))
+      runUnsafe(tm.create(TaskScope.bearer(None), None, never, _ => ZIO.unit))
+      val err = failureOf(exitOf(tm.create(a, None, never, _ => ZIO.unit)))
+      err match
+        case e: TaskConcurrencyLimitExceeded =>
+          e.sessionId shouldBe None
+          e.limit shouldBe 3
+          e.getMessage should include("(none)")
+          e.getMessage should not include "client:A"
+          e.getMessage should not include "A:"
+        case other => fail(s"expected TaskConcurrencyLimitExceeded but got $other")
+      val stats = runUnsafe(tm.stats)
+      stats.perOwner(Some("client:A")).running shouldBe 3
+      stats.perOwner(Some("client:B")).running shouldBe 1
+      stats.perOwner(None).running shouldBe 1
+      stats.perPool(PoolKind.Bearer).running shouldBe 5
+    finally
+      runUnsafe(gate.succeed(()))
+      runUnsafe(tm.shutdown)
+  }
+
+  "pool running ceiling" should "be distinct from and larger than the per-owner cap" in {
+    val tm = newManager(maxConcurrent = 2, maxConcurrentTotal = 3)
+    val gate = runUnsafe(Promise.make[Nothing, Unit])
+    try
+      val never: ZIO[Any, Throwable, Any] = gate.await
+      runUnsafe(tm.create(TaskScope.bearer(Some("A")), None, never, _ => ZIO.unit))
+      runUnsafe(tm.create(TaskScope.bearer(Some("A")), None, never, _ => ZIO.unit))
+      runUnsafe(tm.create(TaskScope.bearer(Some("B")), None, never, _ => ZIO.unit))
+      val err = failureOf(exitOf(tm.create(TaskScope.bearer(Some("C")), None, never, _ => ZIO.unit)))
+      err match
+        case e: TaskCapacityExceeded =>
+          e.kind shouldBe "running"
+          e.limit shouldBe 3
+        case other => fail(s"expected TaskCapacityExceeded but got $other")
+      // The legacy-session pool is counted separately.
+      runUnsafe(tm.create(TaskScope.session("s1"), None, never, _ => ZIO.unit))
+      val stats = runUnsafe(tm.stats)
+      stats.perPool(PoolKind.Bearer).running shouldBe 3
+      stats.perPool(PoolKind.Session).running shouldBe 1
+    finally
+      runUnsafe(gate.succeed(()))
+      runUnsafe(tm.shutdown)
+  }
+
+  it should "not let a legacy-session flood block bearer tasks" in {
+    val tm = newManager(maxConcurrent = 1, maxConcurrentTotal = 2)
+    val gate = runUnsafe(Promise.make[Nothing, Unit])
+    try
+      val never: ZIO[Any, Throwable, Any] = gate.await
+      runUnsafe(tm.create(TaskScope.session("s1"), None, never, _ => ZIO.unit))
+      runUnsafe(tm.create(TaskScope.session("s2"), None, never, _ => ZIO.unit))
+      failureOf(exitOf(tm.create(TaskScope.session("s3"), None, never, _ => ZIO.unit))) shouldBe a[
+        TaskCapacityExceeded
+      ]
+      runUnsafe(tm.create(TaskScope.bearer(Some("modern")), None, never, _ => ZIO.unit))
+      runUnsafe(tm.stats).perPool(PoolKind.Bearer).running shouldBe 1
+    finally
+      runUnsafe(gate.succeed(()))
+      runUnsafe(tm.shutdown)
+  }
+
+  "ownerKeyFor" should "follow the operator policy" in {
+    val ctx = TaskOwnerContext(Some("10.0.0.1"), None, Map.empty)
+    val transport = newManager()
+    runUnsafe(transport.ownerKeyFor(ctx)) shouldBe Some("10.0.0.1")
+    runUnsafe(transport.ownerKeyFor(ctx.copy(transportClientKey = None))) shouldBe None
+
+    def custom(f: TaskOwnerContext => Option[String]): TaskManager[Any] =
+      TaskManager.makeUnsafe[Any](
+        TaskSettings(enabled = true, ownerKey = TaskOwnerKey.Custom(f)),
+        ZIO.succeed(java.util.UUID.randomUUID().toString)
+      )
+    runUnsafe(custom(c => c.clientInfo.map(_.name)).ownerKeyFor(ctx)) shouldBe None
+    val boom = exitOf(custom(_ => throw new IllegalStateException("no principal")).ownerKeyFor(ctx))
+    failureOf(boom).getMessage shouldBe "no principal"
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // F11: create is atomic under interruption
+  // ---------------------------------------------------------------------------------------------
+
+  "create" should "be atomic under interruption at every checkpoint" in {
+    for stage <- List("forked", "registered") do
+      val latch = runUnsafe(Promise.make[Nothing, Unit])
+      val gate = runUnsafe(Promise.make[Nothing, Unit])
+      val hook: String => UIO[Unit] = s => if s == stage then latch.succeed(()) *> gate.await else ZIO.unit
+      val tm = newManager(checkpoint = hook)
+      val before = rootFibers
+      val started = runUnsafe(Ref.make(false))
+      try
+        val exit = runUnsafe(
+          for
+            fiber <- tm.create(TaskScope.session("atomic"), None, started.set(true) *> ZIO.never, _ => ZIO.unit).fork
+            _ <- latch.await
+            // The interrupt is RECORDED while the create is masked; opening the gate lets the
+            // create observe it at its next check and roll back.
+            _ <- fiber.interruptFork
+            _ <- gate.succeed(())
+            exit <- fiber.await
+          yield exit
+        )
+        withClue(s"stage=$stage exit=$exit: ") {
+          exit.isInterrupted shouldBe true
+          exit.isSuccess shouldBe false
+        }
+        val stats = runUnsafe(tm.stats)
+        withClue(s"stage=$stage stats=$stats: ") {
+          stats.total shouldBe 0
+          stats.running shouldBe 0
+          stats.perOwner shouldBe empty
+        }
+        runUnsafe(tm.list(Some("atomic"), None)).tasks shouldBe Nil
+        // The parked task fiber must have been torn down and its body never started.
+        awaitRootsSettle(before)
+        runUnsafe(started.get) shouldBe false
+      finally runUnsafe(tm.shutdown)
+  }
+
+  it should "survive a 200-iteration interruption race with no residue" in {
+    val tm = newManager()
+    try
+      val outcomes = runUnsafe(
+        ZIO.foreach((1 to 200).toList) { i =>
+          for
+            fiber <- tm.create(TaskScope.session(s"race-${i % 7}"), None, ZIO.unit, _ => ZIO.unit).fork
+            _ <- ZIO.succeed(java.util.concurrent.locks.LockSupport.parkNanos((i % 50) * 1_000L))
+            _ <- fiber.interruptFork
+            exit <- fiber.await
+          yield exit
+        }
+      )
+      val registered = outcomes.count(_.isSuccess)
+      val rolledBack = outcomes.count(_.isInterrupted)
+      withClue(s"registered=$registered rolledBack=$rolledBack: ") {
+        (registered + rolledBack) shouldBe 200
+      }
+      // Every create either registered a task (which then ran to completion) or left nothing. An
+      // interrupt landing after the post-registration check (the documented residual) yields an
+      // interrupted exit with a fully registered task, so `total` may exceed the success count —
+      // but never the attempt count, and never with a non-terminal or index-inconsistent entry.
+      val stats = awaitStats(tm)(_.running == 0)
+      stats.total should be >= registered
+      stats.total should be <= 200
+      stats.perPool.get(PoolKind.Session).map(_.total).getOrElse(0) shouldBe stats.total
+      stats.perOwner.values.map(_.total).sum shouldBe stats.total
+      stats.perOwner.values.forall(_.running == 0) shouldBe true
+      val listed = (0 until 7).flatMap(k => runUnsafe(tm.list(Some(s"race-$k"), None)).tasks)
+      listed.size shouldBe stats.total
+      listed.forall(_.status == TaskStatus.Completed) shouldBe true
+    finally runUnsafe(tm.shutdown)
+  }
+
+  it should "still sweep an entry whose create is held past its TTL and stop counting it" in {
+    val hook: String => UIO[Unit] = s => if s == "registered" then ZIO.sleep(400.millis) else ZIO.unit
+    val tm = newManager(maxConcurrent = 1, sweepIntervalMs = 50L, checkpoint = hook)
+    val before = rootFibers
+    try
+      // forkDaemon: a plain fork would be interrupted when runUnsafe's parent fiber completes.
+      val fiber = runUnsafe(
+        tm.create(TaskScope.session("held"), Some(100L), ZIO.never, _ => ZIO.unit).forkDaemon
+      )
+      // The sweeper is claimed by the insert itself, so the TTL fires while the create is parked.
+      runUnsafe(ZIO.sleep(250.millis))
+      val held = runUnsafe(tm.stats)
+      withClue(s"stats while held: $held: ") {
+        held.total shouldBe 0
+        held.running shouldBe 0
+      }
+      // The owner's slot is free again — a concurrent create is admitted despite maxConcurrent = 1.
+      val other = runUnsafe(
+        tm.create(TaskScope.session("held"), Some(60_000L), ZIO.succeed("free"), _ => ZIO.unit)
+      )
+      runUnsafe(tm.result(other.task.taskId, Some("held"))) shouldBe "free"
+      val exit = runUnsafe(fiber.await)
+      failureOf(exit) shouldBe a[TaskNotFoundError]
+      awaitRootsSettle(before)
+    finally runUnsafe(tm.shutdown)
   }
 }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/manager/TaskManagerSpec.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/manager/TaskManagerSpec.scala
@@ -567,14 +567,18 @@ class TaskManagerSpec extends AnyFlatSpec with Matchers {
     val tm = newManager()
     val before = rootFibers
     val interrupted = runUnsafe(Ref.make(false))
+    val started = runUnsafe(Promise.make[Nothing, Unit])
     runUnsafe(
       tm.create(
         TaskScope.session("s"),
         None,
-        ZIO.never.onInterrupt(interrupted.set(true)),
+        (started.succeed(()) *> ZIO.never).onInterrupt(interrupted.set(true)),
         _ => ZIO.unit
       )
     )
+    // create returns before the task body starts. Await the signal inside onInterrupt so shutdown
+    // cannot cancel the parked task before this test's interruption callback has been installed.
+    runUnsafe(started.await.timeoutFail(new RuntimeException("task did not start"))(10.seconds))
     completed(tm, TaskScope.bearer(Some("k")))
     runUnsafe(tm.shutdown)
     val stats = runUnsafe(tm.stats)

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/manager/TaskManagerSpec.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/manager/TaskManagerSpec.scala
@@ -129,8 +129,11 @@ class TaskManagerSpec extends AnyFlatSpec with Matchers {
   it should "record terminal status for immediately completed effects" in {
     val tm = newManager()
     val createResult = runUnsafe(
-      tm.create(sessionId = Some("s1"), requestedTtlMs = None, run = ZIO.succeed("done"), _ =>
-        ZIO.unit
+      tm.create(
+        sessionId = Some("s1"),
+        requestedTtlMs = None,
+        run = ZIO.succeed("done"),
+        _ => ZIO.unit
       )
     )
     val taskId = createResult.task.taskId
@@ -339,7 +342,13 @@ class TaskManagerSpec extends AnyFlatSpec with Matchers {
 
   it should "bound the store across owners at the pool cap and charge the largest owner" in {
     // Stored caps normalise to >= the running caps, so the running ceilings are lowered too.
-    val tm = newManager(maxConcurrent = 8, maxConcurrentTotal = 8, maxStoredPerOwner = 8, maxStoredTotal = 8, minResultRetentionMs = 0L)
+    val tm = newManager(
+      maxConcurrent = 8,
+      maxConcurrentTotal = 8,
+      maxStoredPerOwner = 8,
+      maxStoredTotal = 8,
+      minResultRetentionMs = 0L
+    )
     try
       val a = TaskScope.session("A")
       val b = TaskScope.session("B")
@@ -361,8 +370,94 @@ class TaskManagerSpec extends AnyFlatSpec with Matchers {
     finally runUnsafe(tm.shutdown)
   }
 
+  it should "charge the creating owner's own stale results before anyone else's at the pool cap" in {
+    val tm = newManager(
+      maxConcurrent = 8,
+      maxConcurrentTotal = 8,
+      maxStoredPerOwner = 8,
+      maxStoredTotal = 8,
+      minResultRetentionMs = 0L
+    )
+    try
+      val a = TaskScope.session("A")
+      val b = TaskScope.session("B")
+      val aIds = (1 to 5).map(_ => completed(tm, a))
+      val bIds = (1 to 3).map(_ => completed(tm, b))
+      runUnsafe(tm.stats).total shouldBe 8
+      // B is NOT the largest owner, but B's own oldest result pays for B's next task.
+      val bNew = completed(tm, b)
+      val stats = runUnsafe(tm.stats)
+      stats.total shouldBe 8
+      stats.perOwner(a.ownerKey).total shouldBe 5
+      stats.perOwner(b.ownerKey).total shouldBe 3
+      runUnsafe(tm.get(bIds.head, Some("B"))) shouldBe None
+      bIds.tail.foreach(id => runUnsafe(tm.get(id, Some("B"))).isDefined shouldBe true)
+      aIds.foreach(id => runUnsafe(tm.get(id, Some("A"))).isDefined shouldBe true)
+      runUnsafe(tm.get(bNew, Some("B"))).isDefined shouldBe true
+    finally runUnsafe(tm.shutdown)
+  }
+
+  it should "never pick an owner whose results are all inside the grace as the pool-cap victim" in {
+    // Victim V holds 2 results older than the grace; flooders F1..F3 hold 2 fresh results each (6 >
+    // 2, so a 'largest owner by total' rule would have charged V). Owners are ranked by STALE
+    // entries only, so a flooder's fresh entries never nominate V — the only stale entries are V's
+    // own two, and once they are gone the pool is full of ungraced results and admission is
+    // refused rather than evicting anything younger than the grace.
+    val tm = newManager(
+      maxConcurrent = 8,
+      maxConcurrentTotal = 8,
+      maxStoredPerOwner = 8,
+      maxStoredTotal = 8,
+      minResultRetentionMs = 400L
+    )
+    try
+      val v = TaskScope.session("V")
+      val vIds = (1 to 2).map(_ => completed(tm, v))
+      runUnsafe(ZIO.sleep(500.millis)) // V's results age past the grace
+      val flooders = (1 to 3).map(i => TaskScope.session(s"F$i"))
+      flooders.foreach(f => (1 to 2).foreach(_ => completed(tm, f)))
+      runUnsafe(tm.stats).total shouldBe 8
+      // 9th and 10th creates: only V's two stale results are evictable, so V pays twice...
+      val n1 = completed(tm, TaskScope.session("F1"))
+      val n2 = completed(tm, TaskScope.session("F2"))
+      runUnsafe(tm.stats).total shouldBe 8
+      vIds.foreach(id => runUnsafe(tm.get(id, Some("V"))) shouldBe None)
+      runUnsafe(tm.get(n1, Some("F1"))).isDefined shouldBe true
+      runUnsafe(tm.get(n2, Some("F2"))).isDefined shouldBe true
+      // ...and then nothing is: every remaining result is inside the grace, so the flood is refused
+      // with -32003 rather than evicting a fresh result of anyone.
+      val err = failureOf(
+        exitOf(tm.create(TaskScope.session("F3"), None, ZIO.succeed("x"), _ => ZIO.unit))
+      )
+      err match
+        case e: TaskCapacityExceeded =>
+          e.kind shouldBe "stored"
+          e.limit shouldBe 8
+        case other => fail(s"expected TaskCapacityExceeded but got $other")
+      runUnsafe(tm.stats).total shouldBe 8
+    finally runUnsafe(tm.shutdown)
+  }
+
+  "TaskSettings" should "reject non-positive or inconsistent store bounds at construction" in {
+    an[IllegalArgumentException] should be thrownBy TaskSettings(maxConcurrentPerSession = 0)
+    an[IllegalArgumentException] should be thrownBy
+      TaskSettings(maxConcurrentPerSession = 4, maxConcurrentTotal = 3)
+    an[IllegalArgumentException] should be thrownBy TaskSettings(maxStoredPerOwner = 0)
+    an[IllegalArgumentException] should be thrownBy TaskSettings(maxStoredTotal = -1)
+    an[IllegalArgumentException] should be thrownBy TaskSettings(minResultRetentionMs = -1L)
+    an[IllegalArgumentException] should be thrownBy TaskSettings(sweepIntervalMs = 0L)
+    // Equal running caps are fine; stored caps below the running caps are normalised, not rejected.
+    noException should be thrownBy
+      TaskSettings(maxConcurrentPerSession = 2, maxConcurrentTotal = 2, maxStoredTotal = 1)
+  }
+
   it should "reject when nothing is evictable" in {
-    val tm = newManager(maxConcurrent = 2, maxConcurrentTotal = 2, maxStoredTotal = 2, minResultRetentionMs = 60_000L)
+    val tm = newManager(
+      maxConcurrent = 2,
+      maxConcurrentTotal = 2,
+      maxStoredTotal = 2,
+      minResultRetentionMs = 60_000L
+    )
     val gate = runUnsafe(Promise.make[Nothing, Unit])
     try
       val never: ZIO[Any, Throwable, Any] = gate.await
@@ -384,7 +479,13 @@ class TaskManagerSpec extends AnyFlatSpec with Matchers {
       runUnsafe(tm.shutdown)
 
     // Stored cap with a completed-but-young entry: rejected as "stored", store unchanged.
-    val tm2 = newManager(maxConcurrent = 3, maxConcurrentTotal = 3, maxStoredPerOwner = 3, maxStoredTotal = 3, minResultRetentionMs = 60_000L)
+    val tm2 = newManager(
+      maxConcurrent = 3,
+      maxConcurrentTotal = 3,
+      maxStoredPerOwner = 3,
+      maxStoredTotal = 3,
+      minResultRetentionMs = 60_000L
+    )
     val gate2 = runUnsafe(Promise.make[Nothing, Unit])
     try
       val never: ZIO[Any, Throwable, Any] = gate2.await
@@ -450,9 +551,7 @@ class TaskManagerSpec extends AnyFlatSpec with Matchers {
     val before = rootFibers
     try
       val scope = TaskScope.session("drain")
-      (1 to 3).foreach(_ =>
-        runUnsafe(tm.create(scope, Some(50L), ZIO.succeed("x"), _ => ZIO.unit))
-      )
+      (1 to 3).foreach(_ => runUnsafe(tm.create(scope, Some(50L), ZIO.succeed("x"), _ => ZIO.unit)))
       runUnsafe(tm.stats).sweeperActive shouldBe true
       val drained = awaitStats(tm)(s => s.total == 0 && !s.sweeperActive)
       drained.perOwner shouldBe empty
@@ -469,7 +568,12 @@ class TaskManagerSpec extends AnyFlatSpec with Matchers {
     val before = rootFibers
     val interrupted = runUnsafe(Ref.make(false))
     runUnsafe(
-      tm.create(TaskScope.session("s"), None, ZIO.never.onInterrupt(interrupted.set(true)), _ => ZIO.unit)
+      tm.create(
+        TaskScope.session("s"),
+        None,
+        ZIO.never.onInterrupt(interrupted.set(true)),
+        _ => ZIO.unit
+      )
     )
     completed(tm, TaskScope.bearer(Some("k")))
     runUnsafe(tm.shutdown)
@@ -556,7 +660,8 @@ class TaskManagerSpec extends AnyFlatSpec with Matchers {
       runUnsafe(tm.create(TaskScope.bearer(Some("A")), None, never, _ => ZIO.unit))
       runUnsafe(tm.create(TaskScope.bearer(Some("A")), None, never, _ => ZIO.unit))
       runUnsafe(tm.create(TaskScope.bearer(Some("B")), None, never, _ => ZIO.unit))
-      val err = failureOf(exitOf(tm.create(TaskScope.bearer(Some("C")), None, never, _ => ZIO.unit)))
+      val err =
+        failureOf(exitOf(tm.create(TaskScope.bearer(Some("C")), None, never, _ => ZIO.unit)))
       err match
         case e: TaskCapacityExceeded =>
           e.kind shouldBe "running"
@@ -613,14 +718,22 @@ class TaskManagerSpec extends AnyFlatSpec with Matchers {
     for stage <- List("forked", "registered") do
       val latch = runUnsafe(Promise.make[Nothing, Unit])
       val gate = runUnsafe(Promise.make[Nothing, Unit])
-      val hook: String => UIO[Unit] = s => if s == stage then latch.succeed(()) *> gate.await else ZIO.unit
+      val hook: String => UIO[Unit] =
+        s => if s == stage then latch.succeed(()) *> gate.await else ZIO.unit
       val tm = newManager(checkpoint = hook)
       val before = rootFibers
       val started = runUnsafe(Ref.make(false))
       try
         val exit = runUnsafe(
           for
-            fiber <- tm.create(TaskScope.session("atomic"), None, started.set(true) *> ZIO.never, _ => ZIO.unit).fork
+            fiber <- tm
+              .create(
+                TaskScope.session("atomic"),
+                None,
+                started.set(true) *> ZIO.never,
+                _ => ZIO.unit
+              )
+              .fork
             _ <- latch.await
             // The interrupt is RECORDED while the create is masked; opening the gate lets the
             // create observe it at its next check and roll back.
@@ -652,7 +765,9 @@ class TaskManagerSpec extends AnyFlatSpec with Matchers {
       val outcomes = runUnsafe(
         ZIO.foreach((1 to 200).toList) { i =>
           for
-            fiber <- tm.create(TaskScope.session(s"race-${i % 7}"), None, ZIO.unit, _ => ZIO.unit).fork
+            fiber <- tm
+              .create(TaskScope.session(s"race-${i % 7}"), None, ZIO.unit, _ => ZIO.unit)
+              .fork
             _ <- ZIO.succeed(java.util.concurrent.locks.LockSupport.parkNanos((i % 50) * 1_000L))
             _ <- fiber.interruptFork
             exit <- fiber.await
@@ -681,7 +796,8 @@ class TaskManagerSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "still sweep an entry whose create is held past its TTL and stop counting it" in {
-    val hook: String => UIO[Unit] = s => if s == "registered" then ZIO.sleep(400.millis) else ZIO.unit
+    val hook: String => UIO[Unit] =
+      s => if s == "registered" then ZIO.sleep(400.millis) else ZIO.unit
     val tm = newManager(maxConcurrent = 1, sweepIntervalMs = 50L, checkpoint = hook)
     val before = rootFibers
     try
@@ -689,13 +805,10 @@ class TaskManagerSpec extends AnyFlatSpec with Matchers {
       val fiber = runUnsafe(
         tm.create(TaskScope.session("held"), Some(100L), ZIO.never, _ => ZIO.unit).forkDaemon
       )
-      // The sweeper is claimed by the insert itself, so the TTL fires while the create is parked.
-      runUnsafe(ZIO.sleep(250.millis))
-      val held = runUnsafe(tm.stats)
-      withClue(s"stats while held: $held: ") {
-        held.total shouldBe 0
-        held.running shouldBe 0
-      }
+      // The sweeper is claimed by the insert itself, so the TTL fires while the create is still
+      // parked in the hook (400 ms); poll rather than sleep so a scheduling stall cannot flake it.
+      val held = awaitStats(tm)(s => s.total == 0 && s.running == 0)
+      held.sweeperActive shouldBe false
       // The owner's slot is free again — a concurrent create is admitted despite maxConcurrent = 1.
       val other = runUnsafe(
         tm.create(TaskScope.session("held"), Some(60_000L), ZIO.succeed("free"), _ => ZIO.unit)

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/LifecycleSoakTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/LifecycleSoakTest.scala
@@ -20,10 +20,15 @@ import com.tjclp.fastmcp.server.transport.JvmTransportBackend.given
 class LifecycleSoakTest extends AnyFunSuite with Matchers:
 
   object SoakServer:
+
     @Tool(name = Some("blocky"), description = Some("Long-running"), taskSupport = Some("optional"))
     def blocky(): ZIO[Any, Throwable, String] = ZIO.sleep(30.seconds).as("blocky")
 
-    @Tool(name = Some("quick"), description = Some("Completes at once"), taskSupport = Some("optional"))
+    @Tool(
+      name = Some("quick"),
+      description = Some("Completes at once"),
+      taskSupport = Some("optional")
+    )
     def quick(): String = "quick"
 
   private val SessionIdHeader = "mcp-session-id"
@@ -167,4 +172,3 @@ class LifecycleSoakTest extends AnyFunSuite with Matchers:
       (after - before) should be <= 5
     }
   }
-

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/LifecycleSoakTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/LifecycleSoakTest.scala
@@ -23,6 +23,9 @@ class LifecycleSoakTest extends AnyFunSuite with Matchers:
     @Tool(name = Some("blocky"), description = Some("Long-running"), taskSupport = Some("optional"))
     def blocky(): ZIO[Any, Throwable, String] = ZIO.sleep(30.seconds).as("blocky")
 
+    @Tool(name = Some("quick"), description = Some("Completes at once"), taskSupport = Some("optional"))
+    def quick(): String = "quick"
+
   private val SessionIdHeader = "mcp-session-id"
 
   private val initFrame =
@@ -45,7 +48,10 @@ class LifecycleSoakTest extends AnyFunSuite with Matchers:
     )
 
   private def post(routes: Routes[Any, Response], body: String, sid: Option[String]): Response =
-    val base = Request.post(URL(Path.root / "mcp"), Body.fromString(body))
+    val base = Request
+      .post(URL(Path.root / "mcp"), Body.fromString(body))
+      .addHeader(Header.Custom("content-type", "application/json"))
+      .addHeader(Header.Custom("accept", "application/json, text/event-stream"))
     val req = sid.fold(base)(s => base.addHeader(Header.Custom(SessionIdHeader, s)))
     runUnsafe(ZIO.scoped(routes.runZIO(req)))
 
@@ -57,6 +63,14 @@ class LifecycleSoakTest extends AnyFunSuite with Matchers:
     resp.rawHeader(SessionIdHeader).getOrElse(fail("initialize did not return a session id"))
 
   private def rootFibers: Int = runUnsafe(Fiber.roots.map(_.size))
+
+  /** Poll rather than sleep-then-assert: interruption finalizers settle at their own pace. */
+  private def awaitRootsSettle(before: Int, tolerance: Int = 5): Int =
+    runUnsafe(
+      (ZIO.sleep(25.millis) *> Fiber.roots.map(_.size))
+        .repeatUntil(_ - before <= tolerance)
+        .timeoutFail(new RuntimeException("root fibers did not settle"))(10.seconds)
+    )
 
   test("dropped subscriptions/listen streams leave no fibers behind") {
     val routes = buildRoutes()
@@ -122,3 +136,35 @@ class LifecycleSoakTest extends AnyFunSuite with Matchers:
       (after - before) should be <= 5
     }
   }
+
+  test("N terminal tasks leave no sleeping eviction fibers behind") {
+    val routes = buildRoutes()
+    val sid = initSession(routes)
+    def augmented(id: Int): String =
+      s"""{"jsonrpc":"2.0","id":$id,"method":"tools/call","params":{"name":"quick","arguments":{},"task":{"ttl":60000}}}"""
+    val TaskIdPattern = """"taskId":"([^"]+)"""".r
+
+    val before = rootFibers
+    val taskIds = (1 to 30).toList.map { i =>
+      val body = bodyOf(post(routes, augmented(300 + i), Some(sid)))
+      TaskIdPattern.findFirstMatchIn(body).map(_.group(1)).getOrElse(fail(s"no taskId in: $body"))
+    }
+    // Fence on every result: all 30 entries are terminal and retained (60 s TTL).
+    taskIds.foreach { taskId =>
+      val reply = bodyOf(
+        post(
+          routes,
+          s"""{"jsonrpc":"2.0","id":400,"method":"tasks/result","params":{"taskId":"$taskId"}}""",
+          Some(sid)
+        )
+      )
+      reply should include("quick")
+    }
+    // Pre-fix each retained task pinned one sleeping eviction fiber for its whole TTL; now a single
+    // sweeper covers the store.
+    val after = awaitRootsSettle(before)
+    withClue(s"root fibers before=$before after=$after: ") {
+      (after - before) should be <= 5
+    }
+  }
+

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/TaskHttpTransportTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/TaskHttpTransportTest.scala
@@ -15,27 +15,43 @@ import com.tjclp.fastmcp.server.transport.JvmTransportBackend.given
 
 /** The task lifecycle over streamable HTTP, end to end through the in-memory routes harness —
   * successor to the deleted `TaskAugmentedHttpTransportTest`. Covers capability advertisement,
-  * per-tool `execution.taskSupport` negotiation (both `-32601` rejections), create → poll →
-  * result, error/multi-content preservation through a task, cancellation, the per-session
-  * concurrency cap, unknown-task codes (`-32602` — 0.4.0 parity, regressed pre-C1), and
-  * cross-session isolation.
+  * per-tool `execution.taskSupport` negotiation (both `-32601` rejections), create → poll → result,
+  * error/multi-content preservation through a task, cancellation, the per-session concurrency cap,
+  * unknown-task codes (`-32602` — 0.4.0 parity, regressed pre-C1), and cross-session isolation.
   */
 class TaskHttpTransportTest extends AnyFunSuite with Matchers:
 
   object TaskServer:
-    @Tool(name = Some("slow"), description = Some("Completes after a beat"), taskSupport = Some("optional"))
+
+    @Tool(
+      name = Some("slow"),
+      description = Some("Completes after a beat"),
+      taskSupport = Some("optional")
+    )
     def slow(): ZIO[Any, Throwable, String] = ZIO.sleep(200.millis).as("slow done")
 
-    @Tool(name = Some("must-task"), description = Some("Requires task augmentation"), taskSupport = Some("required"))
+    @Tool(
+      name = Some("must-task"),
+      description = Some("Requires task augmentation"),
+      taskSupport = Some("required")
+    )
     def mustTask(): String = "must done"
 
     @Tool(name = Some("plain"), description = Some("No task support"))
     def plain(): String = "plain done"
 
-    @Tool(name = Some("rich-content"), description = Some("Multi-content result"), taskSupport = Some("optional"))
+    @Tool(
+      name = Some("rich-content"),
+      description = Some("Multi-content result"),
+      taskSupport = Some("optional")
+    )
     def richContent(): List[Content] = List(TextContent("a"), TextContent("b"))
 
-    @Tool(name = Some("broken-task"), description = Some("Always throws"), taskSupport = Some("optional"))
+    @Tool(
+      name = Some("broken-task"),
+      description = Some("Always throws"),
+      taskSupport = Some("optional")
+    )
     def brokenTask(): String = throw new RuntimeException("task boom")
 
     @Tool(name = Some("blocky"), description = Some("Long-running"), taskSupport = Some("optional"))
@@ -352,7 +368,8 @@ class TaskHttpTransportTest extends AnyFunSuite with Matchers:
     val routes = buildRoutes(maxConcurrent = 8, maxStoredPerOwner = 8, minResultRetentionMs = 0L)
     val sid = initSession(routes)
     val ids = (1 to 20).map { i =>
-      val taskId = extractTaskId(bodyOf(post(routes, augmentedCall(600 + i, "rich-content"), Some(sid))))
+      val taskId =
+        extractTaskId(bodyOf(post(routes, augmentedCall(600 + i, "rich-content"), Some(sid))))
       // Fence: tasks/result returns only once the entry is terminal, so the next create sees an
       // evictable predecessor rather than racing the tool body.
       bodyOf(post(routes, tasksResult(700 + i, taskId), Some(sid))) should include(""""text":"a"""")

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/TaskHttpTransportTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/TaskHttpTransportTest.scala
@@ -70,7 +70,10 @@ class TaskHttpTransportTest extends AnyFunSuite with Matchers:
 
   private def buildRoutes(
       maxConcurrent: Int = 64,
-      stateless: Boolean = false
+      stateless: Boolean = false,
+      maxConcurrentTotal: Int = 1024,
+      maxStoredPerOwner: Int = 256,
+      minResultRetentionMs: Long = 30_000L
   ): Routes[Any, Response] =
     val server = McpServer.typed[Any](
       "TaskT",
@@ -80,7 +83,10 @@ class TaskHttpTransportTest extends AnyFunSuite with Matchers:
         tasks = TaskSettings(
           enabled = true,
           pollIntervalMs = 50,
-          maxConcurrentPerSession = maxConcurrent
+          maxConcurrentPerSession = maxConcurrent,
+          maxConcurrentTotal = maxConcurrentTotal,
+          maxStoredPerOwner = maxStoredPerOwner,
+          minResultRetentionMs = minResultRetentionMs
         )
       )
     )
@@ -96,7 +102,10 @@ class TaskHttpTransportTest extends AnyFunSuite with Matchers:
     runUnsafe(ZIO.scoped(routes.runZIO(req)))
 
   private def post(routes: Routes[Any, Response], body: String, sid: Option[String]): Response =
-    val base = Request.post(URL(Path.root / "mcp"), Body.fromString(body))
+    val base = Request
+      .post(URL(Path.root / "mcp"), Body.fromString(body))
+      .addHeader(Header.Custom("content-type", "application/json"))
+      .addHeader(Header.Custom("accept", "application/json, text/event-stream"))
     val req = sid.fold(base)(s => base.addHeader(Header.Custom(SessionIdHeader, s)))
     run(routes, req)
 
@@ -337,4 +346,39 @@ class TaskHttpTransportTest extends AnyFunSuite with Matchers:
     result should include(""""code":-32602""")
     val cancel = bodyOf(post(routes, tasksCancel(43, taskId), Some(sid)))
     cancel should include(""""code":-32602""")
+  }
+
+  test("a session that loops fast task calls never holds more than maxStoredPerOwner entries") {
+    val routes = buildRoutes(maxConcurrent = 8, maxStoredPerOwner = 8, minResultRetentionMs = 0L)
+    val sid = initSession(routes)
+    val ids = (1 to 20).map { i =>
+      val taskId = extractTaskId(bodyOf(post(routes, augmentedCall(600 + i, "rich-content"), Some(sid))))
+      // Fence: tasks/result returns only once the entry is terminal, so the next create sees an
+      // evictable predecessor rather than racing the tool body.
+      bodyOf(post(routes, tasksResult(700 + i, taskId), Some(sid))) should include(""""text":"a"""")
+      taskId
+    }
+    val listed = bodyOf(post(routes, tasksList(800), Some(sid)))
+    val listedIds = TaskIdPattern.findAllMatchIn(listed).map(_.group(1)).toSet
+    listedIds.size should be <= 8
+    listedIds should contain allElementsOf ids.takeRight(8)
+    ids.take(12).foreach { old =>
+      val reply = bodyOf(post(routes, tasksGet(900, old), Some(sid)))
+      reply should include(""""code":-32602""")
+      reply should include("Unknown task")
+    }
+  }
+
+  test("pool capacity answers -32003 Task capacity exceeded across sessions") {
+    val routes = buildRoutes(maxConcurrent = 1, maxConcurrentTotal = 1)
+    val sid1 = initSession(routes)
+    extractTaskId(bodyOf(post(routes, augmentedCall(60, "blocky"), Some(sid1))))
+    val sid2 = initSession(routes)
+    val rejected = bodyOf(post(routes, augmentedCall(61, "blocky"), Some(sid2)))
+    rejected should include(""""code":-32003""")
+    rejected should include("Task capacity exceeded (running, limit 1)")
+    // The per-owner cap on the first session is still the caller's own fault: -32602.
+    val own = bodyOf(post(routes, augmentedCall(62, "blocky"), Some(sid1)))
+    own should include(""""code":-32602""")
+    own should include("concurrency limit")
   }

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/core/Protocol.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/core/Protocol.scala
@@ -59,6 +59,12 @@ object ErrorCodes:
   val TransportError: Int = -32000
   val SessionNotFound: Int = -32001
 
+  /** Server-side capacity exhausted (task pool running ceiling, owner/pool stored-entry caps with
+    * nothing evictable). A server condition rather than a request fault, so clients may retry
+    * later; distinct from `InvalidParams`, which stays the caller's own per-owner cap.
+    */
+  val CapacityExceeded: Int = -32003
+
 /** Opaque pagination cursor. Wire shape is a string; treating it as opaque keeps cursor
   * production/consumption sites from leaking encoding choices.
   */

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/core/Tasks.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/core/Tasks.scala
@@ -67,6 +67,35 @@ object TaskSupport:
       case "required" => Right(TaskSupport.Required)
       case other => Left(s"Invalid taskSupport value: $other")
 
+/** Inputs available to [[TaskOwnerKey.Custom]] when deriving the per-client bucket of a modern
+  * bearer task. Only `transportClientKey` is trustworthy (it is supplied by the transport, e.g. the
+  * peer address); `clientInfo` and `meta` are attacker-controlled request content and must not be
+  * used as a bucket key unless an authenticating proxy rewrites them.
+  */
+final case class TaskOwnerContext(
+    transportClientKey: Option[String],
+    clientInfo: Option[wire.Implementation],
+    meta: Map[String, zio.json.ast.Json]
+)
+
+/** Policy for deriving the per-client bucket key of a modern (2026-07-28) bearer task. Legacy tasks
+  * are always bucketed by their protocol session id.
+  */
+sealed trait TaskOwnerKey
+
+object TaskOwnerKey:
+
+  /** Default: the transport-supplied `Session.clientKey`; `None` collapses to one anonymous bucket
+    * bounded by `TaskSettings.maxConcurrentPerSession`.
+    */
+  case object Transport extends TaskOwnerKey
+
+  /** Operator hook, e.g. an authenticated principal behind a reverse proxy. A throwing `f` fails
+    * the create with `-32603` — it never silently collapses to the shared bucket. Two `Custom`
+    * instances compare by reference.
+    */
+  final case class Custom(f: TaskOwnerContext => Option[String]) extends TaskOwnerKey
+
 /** Lifecycle status for a task. Terminal states are absorbing. */
 enum TaskStatus:
   case Working, InputRequired, Completed, Failed, Cancelled

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServerSettings.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServerSettings.scala
@@ -43,14 +43,17 @@ import com.tjclp.fastmcp.core.Tasks
   *   unknown); if none qualifies the create is rejected with `-32003`. Normalised to `>=
   *   maxConcurrentPerSession`.
   * @param maxStoredTotal
-  *   Stored entries per pool, terminal included. At the cap the oldest eligible terminal entry of
-  *   the pool's LARGEST owner is evicted (the flooder pays); else `-32003`. Normalised to `>=
+  *   Stored entries per pool, terminal included. At the cap the creating owner's own oldest
+  *   eligible entry is evicted first, then the oldest eligible entry of the owner holding the MOST
+  *   eligible (stale, terminal) entries — the flooder pays for its own flood, and an owner whose
+  *   results are all inside the retention grace is never a victim; else `-32003`. Normalised to `>=
   *   maxConcurrentTotal`.
   * @param minResultRetentionMs
   *   A terminal result younger than this is never evicted by a cap (only by its own TTL), so a
   *   client always gets at least this long to collect a result (6x the default poll interval).
   * @param sweepIntervalMs
-  *   Upper bound on the single TTL sweeper's sleep; a TTL is honoured within this slack.
+  *   Upper bound on the single TTL sweeper's sleep; a TTL is honoured within this slack. Expiry and
+  *   the retention grace are measured on the monotonic clock (wire timestamps stay wall-clock).
   * @param ownerKey
   *   How modern bearer tasks are bucketed per client. `Transport` (default) uses the
   *   transport-supplied `Session.clientKey` (the peer address on the shipped HTTP backends; `None`
@@ -70,7 +73,16 @@ case class TaskSettings(
     minResultRetentionMs: Long = 30_000L,
     sweepIntervalMs: Long = 1_000L,
     ownerKey: com.tjclp.fastmcp.core.TaskOwnerKey = com.tjclp.fastmcp.core.TaskOwnerKey.Transport
-)
+):
+  require(maxConcurrentPerSession >= 1, "TaskSettings.maxConcurrentPerSession must be >= 1")
+  require(
+    maxConcurrentTotal >= maxConcurrentPerSession,
+    "TaskSettings.maxConcurrentTotal must be >= maxConcurrentPerSession"
+  )
+  require(maxStoredPerOwner >= 1, "TaskSettings.maxStoredPerOwner must be >= 1")
+  require(maxStoredTotal >= 1, "TaskSettings.maxStoredTotal must be >= 1")
+  require(minResultRetentionMs >= 0L, "TaskSettings.minResultRetentionMs must be >= 0")
+  require(sweepIntervalMs >= 1L, "TaskSettings.sweepIntervalMs must be >= 1")
 
 /** Settings for an MCP server. HTTP-specific fields (`stateless`, `keepAliveInterval`,
   * `disallowDelete`, `httpEndpoint`) are ignored under stdio transports.

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServerSettings.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServerSettings.scala
@@ -14,6 +14,14 @@ import com.tjclp.fastmcp.core.Tasks
   * adapter — where all clients share one session identity — legacy task requests are refused with
   * `-32601`.
   *
+  * Store bounds. Every task is charged to an OWNER (the legacy protocol session id, or the modern
+  * client key derived by `ownerKey`) and to a POOL (legacy-session tasks and modern bearer tasks
+  * are counted separately, so a flood of freely minted legacy sessions can never starve bearer
+  * clients and vice versa). Running caps reject; stored caps first evict the oldest completed entry
+  * older than `minResultRetentionMs` and reject only when nothing is evictable. A legacy session's
+  * tasks are released (running ones interrupted) when the transport terminates the session
+  * (`DELETE`, idle eviction).
+  *
   * @param enabled
   *   Master switch. When false, `tasks` capability is not advertised and `params.task` is ignored.
   * @param defaultTtlMs
@@ -23,16 +31,45 @@ import com.tjclp.fastmcp.core.Tasks
   * @param pollIntervalMs
   *   `pollInterval` value advertised back to clients in `tasks/get` responses.
   * @param maxConcurrentPerSession
-  *   Resource cap; additional task creations beyond this are rejected with `-32602`. Legacy tasks
-  *   are counted per protocol session; modern bearer tasks all share one global bucket under this
-  *   same limit.
+  *   Running (non-terminal) tasks per OWNER: the legacy protocol session id, or the modern client
+  *   key derived by `ownerKey`; keyless modern requests share one anonymous bucket under this same
+  *   limit. Exceeding it is the caller's own fault: `-32602`.
+  * @param maxConcurrentTotal
+  *   Ceiling on running tasks per POOL (legacy-session pool and modern-bearer pool, counted
+  *   separately). Distinct from and larger than the per-owner cap. `-32003` when exceeded.
+  * @param maxStoredPerOwner
+  *   Stored entries per owner, terminal included. At the cap the owner's oldest terminal entry
+  *   older than `minResultRetentionMs` is evicted to admit the new task (its result becomes
+  *   unknown); if none qualifies the create is rejected with `-32003`. Normalised to `>=
+  *   maxConcurrentPerSession`.
+  * @param maxStoredTotal
+  *   Stored entries per pool, terminal included. At the cap the oldest eligible terminal entry of
+  *   the pool's LARGEST owner is evicted (the flooder pays); else `-32003`. Normalised to `>=
+  *   maxConcurrentTotal`.
+  * @param minResultRetentionMs
+  *   A terminal result younger than this is never evicted by a cap (only by its own TTL), so a
+  *   client always gets at least this long to collect a result (6x the default poll interval).
+  * @param sweepIntervalMs
+  *   Upper bound on the single TTL sweeper's sleep; a TTL is honoured within this slack.
+  * @param ownerKey
+  *   How modern bearer tasks are bucketed per client. `Transport` (default) uses the
+  *   transport-supplied `Session.clientKey` (the peer address on the shipped HTTP backends; `None`
+  *   -> one anonymous bucket). `Custom(f)` lets an operator behind an authenticating proxy derive a
+  *   key; `_meta`/`clientInfo` are client-controlled and must not be used as a key unless the proxy
+  *   rewrites them.
   */
 case class TaskSettings(
     enabled: Boolean = false,
     defaultTtlMs: Long = 3_600_000L,
     maxTtlMs: Long = 86_400_000L,
     pollIntervalMs: Long = Tasks.DefaultPollIntervalMs,
-    maxConcurrentPerSession: Int = 64
+    maxConcurrentPerSession: Int = 64,
+    maxConcurrentTotal: Int = 1024,
+    maxStoredPerOwner: Int = 256,
+    maxStoredTotal: Int = 4096,
+    minResultRetentionMs: Long = 30_000L,
+    sweepIntervalMs: Long = 1_000L,
+    ownerKey: com.tjclp.fastmcp.core.TaskOwnerKey = com.tjclp.fastmcp.core.TaskOwnerKey.Transport
 )
 
 /** Settings for an MCP server. HTTP-specific fields (`stateless`, `keepAliveInterval`,

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/TaskManager.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/TaskManager.scala
@@ -12,20 +12,54 @@ private[fastmcp] final case class TaskSnapshot(
     outcome: Option[Exit[Throwable, Any]]
 )
 
+/** Which store pool a task is charged to. Legacy protocol sessions can be minted freely by any
+  * client, so their tasks are counted apart from modern bearer tasks: a legacy-session flood can
+  * fill only the legacy pool and can never starve bearer clients (and vice versa).
+  */
+private[fastmcp] enum PoolKind:
+  case Session, Bearer
+
+/** Identity a task is created under.
+  *
+  * @param sessionId
+  *   visibility scope: `Some(sid)` = legacy task visible only to that protocol session; `None` =
+  *   modern bearer task visible to bearer-scope callers presenting its id
+  * @param ownerKey
+  *   accounting bucket for the running / stored caps. Legacy tasks use the session id; bearer tasks
+  *   use the transport-supplied client key (`None` = the shared anonymous bucket)
+  */
+final case class TaskScope(sessionId: Option[String], ownerKey: Option[String]):
+
+  private[fastmcp] def pool: PoolKind =
+    if sessionId.isDefined then PoolKind.Session else PoolKind.Bearer
+
+object TaskScope:
+
+  def session(sessionId: String): TaskScope =
+    TaskScope(Some(sessionId), Some(s"session:$sessionId"))
+
+  def bearer(clientKey: Option[String]): TaskScope =
+    TaskScope(None, clientKey.map(k => s"client:$k"))
+
 /** Internal representation of a task's mutable state. Held inside the [[TaskManager]]'s [[Ref]];
   * never escapes the manager.
   */
 private final case class TaskEntry(
     taskId: String,
     sessionId: Option[String],
+    ownerKey: Option[String],
+    pool: PoolKind,
     createdAtMs: Long,
     lastUpdatedAtMs: Long,
     ttlMs: Option[Long],
+    expiresAtMs: Long,
     pollIntervalMs: Long,
     status: TaskStatus,
     statusMessage: Option[String],
     fiber: Fiber.Runtime[Throwable, Any],
-    result: Promise[Throwable, Any]
+    result: Promise[Throwable, Any],
+    /** Monotonic insertion number; breaks millisecond ties so eviction is FIFO among equals. */
+    seq: Long = 0L
 ):
 
   def toTask: Task = Task(
@@ -38,6 +72,98 @@ private final case class TaskEntry(
     pollInterval = Some(pollIntervalMs)
   )
 
+/** Running (non-terminal) and total (terminal included) entry counts. */
+private[fastmcp] final case class Counts(running: Int, total: Int)
+
+/** Test-visible view of the store's indices. */
+private[fastmcp] final case class TaskStoreStats(
+    total: Int,
+    running: Int,
+    sweeperActive: Boolean,
+    perOwner: Map[Option[String], Counts],
+    perPool: Map[PoolKind, Counts]
+)
+
+/** The task store: entries plus O(1) per-owner and per-pool indices, and the sweeper claim flag.
+  * Every mutation goes through these methods so the indices stay consistent with `entries`.
+  */
+private final case class TaskStore(
+    entries: Map[String, TaskEntry],
+    owners: Map[Option[String], Counts],
+    pools: Map[PoolKind, Counts],
+    sweeperActive: Boolean,
+    nextSeq: Long
+):
+
+  def insert(entry: TaskEntry): TaskStore =
+    val e = entry.copy(seq = nextSeq)
+    copy(
+      entries = entries.updated(e.taskId, e),
+      owners = owners.updated(e.ownerKey, bump(owners.get(e.ownerKey), 1, 1)),
+      pools = pools.updated(e.pool, bump(pools.get(e.pool), 1, 1)),
+      nextSeq = nextSeq + 1
+    )
+
+  /** `prev` -> `next` status transition. Decrements `running` iff `prev` was non-terminal. */
+  def markTerminal(prev: TaskEntry, next: TaskEntry): TaskStore =
+    val dRunning = if prev.status.isTerminal then 0 else -1
+    copy(
+      entries = entries.updated(next.taskId, next),
+      owners = owners.updated(prev.ownerKey, bump(owners.get(prev.ownerKey), dRunning, 0)),
+      pools = pools.updated(prev.pool, bump(pools.get(prev.pool), dRunning, 0))
+    )
+
+  def remove(es: Iterable[TaskEntry]): TaskStore =
+    es.foldLeft(this) { (s, e) =>
+      if !s.entries.contains(e.taskId) then s
+      else
+        val dRunning = if e.status.isTerminal then 0 else -1
+        s.copy(
+          entries = s.entries.removed(e.taskId),
+          owners = drop(s.owners, e.ownerKey, bump(s.owners.get(e.ownerKey), dRunning, -1)),
+          pools = drop(s.pools, e.pool, bump(s.pools.get(e.pool), dRunning, -1))
+        )
+    }
+
+  /** Oldest terminal entry of `owner` (any owner of `pool` when `owner` is `None`) whose last
+    * update is at or before `cutoff`, ordered by (lastUpdatedAtMs, insertion order).
+    */
+  def evictable(pool: PoolKind, owner: Option[Option[String]], cutoff: Long): Option[TaskEntry] =
+    val candidates = entries.values.iterator.filter { e =>
+      e.pool == pool && e.status.isTerminal && e.lastUpdatedAtMs <= cutoff &&
+      owner.forall(_ == e.ownerKey)
+    }
+    if candidates.isEmpty then None
+    else Some(candidates.minBy(e => (e.lastUpdatedAtMs, e.seq)))
+
+  /** Owner with the most stored entries in `pool` (ties broken lexicographically on the key). */
+  def largestOwner(pool: PoolKind): Option[Option[String]] =
+    val totals = entries.values.iterator
+      .filter(_.pool == pool)
+      .foldLeft(Map.empty[Option[String], Int])((acc, e) =>
+        acc.updated(e.ownerKey, acc.getOrElse(e.ownerKey, 0) + 1)
+      )
+    if totals.isEmpty then None
+    else Some(totals.maxBy { case (key, n) => (n, key.getOrElse("")) }._1)
+
+  def stats: TaskStoreStats =
+    val pool = pools.values.foldLeft(Counts(0, 0))((a, c) =>
+      Counts(a.running + c.running, a.total + c.total)
+    )
+    TaskStoreStats(pool.total, pool.running, sweeperActive, owners, pools)
+
+  private def bump(c: Option[Counts], dRunning: Int, dTotal: Int): Counts =
+    val base = c.getOrElse(Counts(0, 0))
+    Counts(base.running + dRunning, base.total + dTotal)
+
+  private def drop[K](m: Map[K, Counts], k: K, next: Counts): Map[K, Counts] =
+    if next.total <= 0 then m.removed(k) else m.updated(k, next)
+
+private object TaskStore:
+
+  val empty: TaskStore =
+    TaskStore(Map.empty, Map.empty, Map.empty, sweeperActive = false, nextSeq = 0L)
+
 /** Concurrent index of MCP tasks for a single server.
   *
   * Each task wraps a ZIO effect representing a long-running tool invocation. The manager:
@@ -49,8 +175,19 @@ private final case class TaskEntry(
   *     atomically when the fiber finishes,
   *   - blocks `tasks/result` waiters via a [[Promise]] until the task reaches a terminal status,
   *   - interrupts the fiber on `tasks/cancel`,
-  *   - schedules TTL-based cleanup on a separate daemon fiber (expiry interrupts still-running work
-  *     — an expired task never lingers as an invisible fiber).
+  *   - sweeps TTL-expired entries with ONE lazily started, self-terminating daemon fiber (expiry
+  *     interrupts still-running work — an expired task never lingers as an invisible fiber, and N
+  *     terminal tasks never hold N sleeping fibers).
+  *
+  * Bounds. Every task is charged to an owner ([[TaskScope.ownerKey]]) and a pool ([[PoolKind]]).
+  * Admission is a single `Ref.modify`: per-owner running cap (`-32602`), per-pool running ceiling
+  * (`-32003`), per-owner and per-pool stored caps that evict the oldest terminal entry older than
+  * `minResultRetentionMs` (the pool cap charges the pool's largest owner) and reject with `-32003`
+  * when nothing is evictable. Rejections never mutate the store.
+  *
+  * Atomicity. `create` runs under `uninterruptibleMask`; an interrupt of the creating fiber (client
+  * abort, `notifications/cancelled`) is detected before admission and again after registration and
+  * rolls the registration back, so no unregistered entry or parked fiber is ever left behind.
   *
   * Session isolation: legacy tasks created with a `sessionId` are visible only to that initialized
   * session. A `None` owner is a modern bearer task, visible only to bearer-scope (modern) callers
@@ -63,21 +200,34 @@ private final case class TaskEntry(
   *   `executionRuntime` (the runtime captured at `runHttp[R]()` entry), so the forked daemon fiber
   *   inherits `R` automatically and discharges it at fiber start.
   */
-class TaskManager[R](
+class TaskManager[R] private[manager] (
     settings: TaskSettings,
-    tasksRef: Ref[Map[String, TaskEntry]],
-    newId: UIO[String]
+    storeRef: Ref[TaskStore],
+    newId: UIO[String],
+    sweeperRef: Ref[Option[Fiber.Runtime[Nothing, Unit]]],
+    /** Test hook invoked at `"forked"` (task fiber parked, nothing registered) and `"registered"`
+      * (entry admitted, gate still closed). `_ => ZIO.unit` in production.
+      */
+    private[fastmcp] val checkpoint: String => UIO[Unit]
 ):
+
+  private val perOwnerRunning: Int = settings.maxConcurrentPerSession
+  private val perOwnerStored: Int = math.max(settings.maxStoredPerOwner, perOwnerRunning)
+  private val poolRunning: Int = settings.maxConcurrentTotal
+  private val poolStored: Int = math.max(settings.maxStoredTotal, poolRunning)
 
   /** Create a task wrapping `run`. Returns immediately with a [[CreateTaskResult]]; the underlying
     * effect executes on a background daemon fiber.
     *
-    * Fails with [[TaskConcurrencyLimitExceeded]] when the session already has
-    * `settings.maxConcurrentPerSession` non-terminal tasks. Other failures bubble through as
-    * `Throwable`.
+    * Fails with [[TaskConcurrencyLimitExceeded]] (`-32602`) when the owner already has
+    * `settings.maxConcurrentPerSession` running tasks, and with [[TaskCapacityExceeded]] (`-32003`)
+    * when the pool's running ceiling or a stored-entry cap is hit with nothing evictable. Other
+    * failures bubble through as `Throwable`.
     *
-    * @param sessionId
-    *   Owning session for isolation, if any.
+    * Registration is all-or-nothing with respect to interruption of the calling fiber.
+    *
+    * @param scope
+    *   Visibility scope + accounting owner ([[TaskScope.session]] / [[TaskScope.bearer]]).
     * @param requestedTtlMs
     *   Requestor-supplied TTL in millis. Clamped to `settings.maxTtlMs`; defaulted to
     *   `settings.defaultTtlMs` if `None`.
@@ -89,72 +239,190 @@ class TaskManager[R](
     *   `notifications/tasks/status`. Errors in the callback are swallowed.
     */
   def create(
+      scope: TaskScope,
+      requestedTtlMs: Option[Long],
+      run: ZIO[R, Throwable, Any],
+      onStatusChange: Task => UIO[Unit]
+  ): ZIO[R, Throwable, CreateTaskResult] =
+    ZIO.uninterruptibleMask { _ =>
+      for
+        taskId <- newId
+        promise <- Promise.make[Throwable, Any]
+        start <- Promise.make[Nothing, Boolean]
+        nowMs <- ZIO.succeed(System.currentTimeMillis())
+        ttlMs = effectiveTtl(requestedTtlMs)
+        // acquireReleaseExitWith runs the release uninterruptibly, so the status update + promise
+        // completion always happen, even if the fiber is interrupted via tasks/cancel. A closed
+        // gate (`false`) means the registration was rolled back: the fiber self-interrupts and its
+        // release no-ops against the missing entry.
+        // `forkDaemon` inherits the current runtime — in production this is the server's
+        // `executionRuntime` captured at `runHttp[R]()` entry, so any `R` the run effect requires
+        // is already discharged by the inherited environment.
+        wrapped =
+          ZIO.acquireReleaseExitWith(ZIO.unit)((_, exit: Exit[Throwable, Any]) =>
+            recordTerminal(taskId, exit, promise, onStatusChange)
+          )(_ => start.await.flatMap(go => if go then run else ZIO.interrupt))
+        // A child forked inside the mask inherits the mask's uninterruptibility; `.interruptible`
+        // is mandatory or tasks/cancel and TTL expiry would never land.
+        fiber <- wrapped.interruptible.forkDaemon
+        result <- registerOrRollback(taskId, scope, ttlMs, nowMs, fiber, promise, start)
+          .onExit(exit => ZIO.unless(exit.isSuccess)(rollback(taskId) *> start.succeed(false)).unit)
+      yield result
+    }
+
+  /** Backward-compatible overload: `Some(sid)` = legacy session task, `None` = anonymous bearer
+    * task.
+    */
+  def create(
       sessionId: Option[String],
       requestedTtlMs: Option[Long],
       run: ZIO[R, Throwable, Any],
       onStatusChange: Task => UIO[Unit]
   ): ZIO[R, Throwable, CreateTaskResult] =
+    create(
+      sessionId.fold(TaskScope.bearer(None))(TaskScope.session),
+      requestedTtlMs,
+      run,
+      onStatusChange
+    )
+
+  private def registerOrRollback(
+      taskId: String,
+      scope: TaskScope,
+      ttlMs: Option[Long],
+      nowMs: Long,
+      fiber: Fiber.Runtime[Throwable, Any],
+      promise: Promise[Throwable, Any],
+      start: Promise[Nothing, Boolean]
+  ): IO[Throwable, CreateTaskResult] =
     for
-      taskId <- newId
-      promise <- Promise.make[Throwable, Any]
-      start <- Promise.make[Nothing, Unit]
-      nowMs <- ZIO.succeed(System.currentTimeMillis())
-      ttlMs = effectiveTtl(requestedTtlMs)
-      // acquireReleaseExitWith runs the release uninterruptibly, so the status update + promise
-      // completion always happen, even if the fiber is interrupted via tasks/cancel.
-      // `forkDaemon` inherits the current runtime — in production this is the server's
-      // `executionRuntime` captured at `runHttp[R]()` entry, so any `R` the run effect requires is
-      // already discharged by the inherited environment.
-      wrapped =
-        ZIO.acquireReleaseExitWith(ZIO.unit)((_, exit: Exit[Throwable, Any]) =>
-          recordTerminal(taskId, exit, promise, onStatusChange)
-        )(_ => start.await *> run)
-      fiber <- wrapped.forkDaemon
+      _ <- checkpoint("forked")
+      // A pending interrupt recorded while masked (client abort / notifications/cancelled)? Bail
+      // out BEFORE admission so the interrupt never costs anyone an evicted result.
+      _ <- failIfInterruptPending
       entry = TaskEntry(
         taskId = taskId,
-        sessionId = sessionId,
+        sessionId = scope.sessionId,
+        ownerKey = scope.ownerKey,
+        pool = scope.pool,
         createdAtMs = nowMs,
         lastUpdatedAtMs = nowMs,
         ttlMs = ttlMs,
+        expiresAtMs = nowMs + ttlMs.getOrElse(settings.defaultTtlMs),
         pollIntervalMs = settings.pollIntervalMs,
         status = TaskStatus.Working,
         statusMessage = Some("The operation is now in progress."),
         fiber = fiber,
         result = promise
       )
-      accepted <- tasksRef.modify { all =>
-        val runningForSession =
-          all.values.count(e => e.sessionId == sessionId && !e.status.isTerminal)
-        if runningForSession >= settings.maxConcurrentPerSession then (false, all)
-        else (true, all.updated(taskId, entry))
-      }
-      _ <-
-        if accepted then ZIO.unit
+      admission <- storeRef.modify(admit(entry, nowMs))
+      result <- admission match
+        case Left(err) => promise.fail(err) *> ZIO.fail(err)
+        case Right(startSweeper) =>
+          for
+            _ <- ZIO.when(startSweeper)(startSweeperFiber)
+            _ <- checkpoint("registered")
+            // Interrupted between admission and here? The onExit guard in `create` rolls back.
+            _ <- failIfInterruptPending
+            store <- storeRef.get
+            created <-
+              // Swept while the create was held (TTL 0 / a slow hook): return no dead handle.
+              if !store.entries.contains(taskId) then ZIO.fail(new TaskNotFoundError(taskId))
+              else start.succeed(true).as(CreateTaskResult(entry.toTask))
+          yield created
+    yield result
+
+  /** Interrupts are recorded (not acted upon) while masked; `Descriptor.interrupters` exposes them
+    * — the same check `ZIO.allowInterrupt` uses. `ZIO.interrupt` here fails the effect with an
+    * interruption cause that takes effect once the mask ends.
+    */
+  private val failIfInterruptPending: UIO[Unit] =
+    ZIO.descriptorWith(d => if d.interrupters.nonEmpty then ZIO.interrupt else ZIO.unit)
+
+  private def rollback(taskId: String): UIO[Unit] =
+    storeRef.update(s => s.entries.get(taskId).fold(s)(e => s.remove(List(e))))
+
+  /** Single-`modify` admission. `Right(startSweeper)` when the entry was inserted (after any cap
+    * evictions), `Left(err)` when rejected — in which case the store is returned untouched.
+    */
+  private def admit(entry: TaskEntry, nowMs: Long)(
+      s: TaskStore
+  ): (Either[Throwable, Boolean], TaskStore) =
+    val owner = entry.ownerKey
+    val pool = entry.pool
+    val oc = s.owners.getOrElse(owner, Counts(0, 0))
+    val pc = s.pools.getOrElse(pool, Counts(0, 0))
+    val cutoff = nowMs - settings.minResultRetentionMs
+    if s.entries.contains(entry.taskId) then
+      (Left(new IllegalStateException(s"duplicate task id ${entry.taskId}")), s)
+    else if oc.running >= perOwnerRunning then
+      // Never echo a derived client key: the session id is the only owner name on the wire.
+      (Left(TaskConcurrencyLimitExceeded(entry.sessionId, perOwnerRunning)), s)
+    else if pc.running >= poolRunning then (Left(TaskCapacityExceeded("running", poolRunning)), s)
+    else
+      val ownerEvict =
+        if oc.total >= perOwnerStored then s.evictable(pool, Some(owner), cutoff) else None
+      if oc.total >= perOwnerStored && ownerEvict.isEmpty then
+        (Left(TaskCapacityExceeded("stored-per-owner", perOwnerStored)), s)
+      else
+        val s1 = s.remove(ownerEvict.toList)
+        val p1 = s1.pools.getOrElse(pool, Counts(0, 0))
+        val poolEvict =
+          if p1.total >= poolStored then
+            s1.largestOwner(pool)
+              .flatMap(big => s1.evictable(pool, Some(big), cutoff))
+              .orElse(s1.evictable(pool, None, cutoff))
+          else None
+        if p1.total >= poolStored && poolEvict.isEmpty then
+          (Left(TaskCapacityExceeded("stored", poolStored)), s)
         else
-          val err = TaskConcurrencyLimitExceeded(
-            sessionId,
-            settings.maxConcurrentPerSession
-          )
-          promise.fail(err).unit *>
-            fiber.interrupt.ignore *>
-            ZIO.fail(err)
-      _ <- start.succeed(())
-      _ <- ttlMs.fold(ZIO.unit)(t => scheduleEviction(taskId, t).forkDaemon.unit)
-    yield CreateTaskResult(entry.toTask)
+          val next = s1.remove(poolEvict.toList).insert(entry)
+          (Right(!s.sweeperActive), next.copy(sweeperActive = true))
+
+  // ------- sweeper -------
+
+  /** One iteration: drop expired entries (interrupting still-running ones), then sleep to the
+    * nearest deadline (capped by `sweepIntervalMs`) and repeat. Releases its claim and exits, in
+    * the same `modify` that observes the drain, when the store is empty.
+    */
+  private def sweepLoop: UIO[Unit] =
+    ZIO.succeed(System.currentTimeMillis()).flatMap { now =>
+      storeRef
+        .modify { s =>
+          val expired = s.entries.values.filter(_.expiresAtMs <= now).toList
+          val rest = s.remove(expired)
+          if rest.entries.isEmpty then ((expired, None), rest.copy(sweeperActive = false))
+          else ((expired, Some(rest.entries.values.iterator.map(_.expiresAtMs).min)), rest)
+        }
+        .flatMap { case (expired, next) =>
+          // interruptFork: never block the sweeper on a task body; the task's release then no-ops
+          // against the removed entry. Parked (never-started) fibers die the same way.
+          ZIO.foreachDiscard(expired.filter(!_.status.isTerminal))(_.fiber.interruptFork) *>
+            next.fold(ZIO.unit) { deadline =>
+              val sleepMs = math.max(1L, math.min(deadline - now, settings.sweepIntervalMs))
+              ZIO.sleep(Duration.fromMillis(sleepMs)) *> sweepLoop
+            }
+        }
+    }
+
+  private def startSweeperFiber: UIO[Unit] =
+    sweepLoop.interruptible.forkDaemon.flatMap(f => sweeperRef.set(Some(f)))
+
+  // ------- queries -------
 
   /** Look up a task by ID, returning `None` if the ID is unknown or owned by a different session
     * than the caller's.
     */
   def get(taskId: String, sessionId: Option[String]): UIO[Option[Task]] =
-    tasksRef.get.map(visible(_, taskId, sessionId).map(_.toTask))
+    storeRef.get.map(s => visible(s.entries, taskId, sessionId).map(_.toTask))
 
   /** Non-blocking detailed view used by the 2026 Tasks extension. */
   private[fastmcp] def snapshot(
       taskId: String,
       sessionId: Option[String]
   ): UIO[Option[TaskSnapshot]] =
-    tasksRef.get.flatMap { all =>
-      visible(all, taskId, sessionId) match
+    storeRef.get.flatMap { s =>
+      visible(s.entries, taskId, sessionId) match
         case None => ZIO.none
         case Some(entry) if entry.status.isTerminal =>
           entry.result.await.exit.map(outcome => Some(TaskSnapshot(entry.toTask, Some(outcome))))
@@ -168,8 +436,8 @@ class TaskManager[R](
     */
   def list(sessionId: Option[String], cursor: Option[String]): UIO[ListTasksResult] =
     val _ = cursor // unused in MVP; opaque cursor support deferred
-    tasksRef.get.map { all =>
-      val visibleTasks = all.values
+    storeRef.get.map { s =>
+      val visibleTasks = s.entries.values
         .filter(e => sessionVisible(e, sessionId))
         .toList
         .sortBy(-_.createdAtMs)
@@ -184,8 +452,8 @@ class TaskManager[R](
     * `Cancelled` (or whatever terminal state it raced to).
     */
   def cancel(taskId: String, sessionId: Option[String]): UIO[Either[String, Task]] =
-    tasksRef.get.flatMap { all =>
-      visible(all, taskId, sessionId) match
+    storeRef.get.flatMap { s =>
+      visible(s.entries, taskId, sessionId) match
         case None =>
           ZIO.succeed(Left("Task not found"))
         case Some(entry) if entry.status.isTerminal =>
@@ -196,12 +464,12 @@ class TaskManager[R](
           )
         case Some(entry) =>
           // Interrupt the fiber. `Fiber.interrupt` awaits the fiber's exit, including its
-          // release block (recordTerminal). After that, tasksRef should reflect Cancelled, but
+          // release block (recordTerminal). After that, the store should reflect Cancelled, but
           // under heavy concurrent test load the read can occasionally observe the pre-update
           // entry. Synthesize a Cancelled view if so — the fiber is definitionally cancelled at
           // this point regardless of what the Ref happens to show.
-          entry.fiber.interrupt *> tasksRef.get.map { latest =>
-            latest.get(taskId) match
+          entry.fiber.interrupt *> storeRef.get.map { latest =>
+            latest.entries.get(taskId) match
               case Some(e) if e.status.isTerminal => Right(e.toTask)
               case _ =>
                 Right(
@@ -221,11 +489,53 @@ class TaskManager[R](
     * as `tasks/get`).
     */
   def result(taskId: String, sessionId: Option[String]): IO[Throwable, Any] =
-    tasksRef.get.flatMap { all =>
-      visible(all, taskId, sessionId) match
+    storeRef.get.flatMap { s =>
+      visible(s.entries, taskId, sessionId) match
         case None => ZIO.fail(new TaskNotFoundError(taskId))
         case Some(entry) => entry.result.await
     }
+
+  // ------- lifecycle -------
+
+  /** Drop every task charged to `scope.ownerKey`, interrupting the running ones. Registered by the
+    * legacy task path as a session finalizer, so a `DELETE`d or idle-evicted session no longer pins
+    * invisible tasks until their TTL. The anonymous bearer bucket (`ownerKey = None`) is shared and
+    * is never bulk-released.
+    */
+  def releaseScope(scope: TaskScope): UIO[Unit] =
+    scope.ownerKey match
+      case None => ZIO.unit
+      case Some(key) =>
+        storeRef
+          .modify { s =>
+            val mine = s.entries.values.filter(_.ownerKey.contains(key)).toList
+            (mine, s.remove(mine))
+          }
+          .flatMap(mine =>
+            ZIO.foreachDiscard(mine.filter(!_.status.isTerminal))(_.fiber.interruptFork)
+          )
+
+  /** Drain the store (interrupting running tasks) and stop the sweeper, awaiting its exit. For
+    * embedders that stop a server without exiting the process, and for test cleanup — the sweeper
+    * is a daemon fiber and otherwise exits on its own once the store drains.
+    */
+  def shutdown: UIO[Unit] =
+    for
+      drained <- storeRef.getAndSet(TaskStore.empty)
+      _ <- ZIO.foreachDiscard(drained.entries.values.filter(!_.status.isTerminal))(
+        _.fiber.interruptFork
+      )
+      sweeper <- sweeperRef.getAndSet(None)
+      _ <- ZIO.foreachDiscard(sweeper)(_.interrupt)
+    yield ()
+
+  /** Resolve the bucket key of a modern bearer task per `settings.ownerKey`. */
+  def ownerKeyFor(ctx: TaskOwnerContext): IO[Throwable, Option[String]] =
+    settings.ownerKey match
+      case TaskOwnerKey.Transport => ZIO.succeed(ctx.transportClientKey)
+      case TaskOwnerKey.Custom(f) => ZIO.attempt(f(ctx))
+
+  private[fastmcp] def stats: UIO[TaskStoreStats] = storeRef.get.map(_.stats)
 
   // ------- internals -------
 
@@ -264,16 +574,16 @@ class TaskManager[R](
         (TaskStatus.Failed, firstFailureMsg.filter(_.nonEmpty))
     val nowMs = System.currentTimeMillis()
     for
-      updated <- tasksRef.modify { all =>
-        all.get(taskId) match
-          case None => (None, all)
+      updated <- storeRef.modify { s =>
+        s.entries.get(taskId) match
+          case None => (None, s)
           case Some(entry) =>
             val next = entry.copy(
               status = status,
               statusMessage = message,
               lastUpdatedAtMs = nowMs
             )
-            (Some(next), all.updated(taskId, next))
+            (Some(next), s.markTerminal(entry, next))
       }
       _ <- exit match
         case Exit.Success(value) => promise.succeed(value).unit
@@ -281,21 +591,10 @@ class TaskManager[R](
       _ <- ZIO.foreachDiscard(updated)(e => onStatusChange(e.toTask).ignore)
     yield ()
 
-  private def scheduleEviction(taskId: String, ttlMs: Long): UIO[Unit] =
-    ZIO.sleep(Duration.fromMillis(ttlMs)) *>
-      tasksRef
-        .modify(all => (all.get(taskId), all.removed(taskId)))
-        .flatMap {
-          // A task that outlives its TTL while still working must not keep running invisibly:
-          // interrupt it. recordTerminal (the fiber's release) then no-ops against the removed
-          // entry, and nobody can be awaiting the promise — the entry is already unreachable.
-          case Some(entry) if !entry.status.isTerminal => entry.fiber.interrupt.unit
-          case _ => ZIO.unit
-        }
-
-/** Raised by [[TaskManager.create]] when the calling session is already running
-  * `settings.maxConcurrentPerSession` tasks. Dispatch layers catch this and surface a
-  * spec-compliant JSON-RPC error.
+/** Raised by [[TaskManager.create]] when the calling owner (legacy session, or modern client
+  * bucket) is already running `settings.maxConcurrentPerSession` tasks. Dispatch layers catch this
+  * and surface a spec-compliant JSON-RPC error. `sessionId` is `None` for bearer tasks — a derived
+  * client key is never echoed on the wire.
   */
 final class TaskConcurrencyLimitExceeded(
     val sessionId: Option[String],
@@ -307,6 +606,16 @@ final class TaskConcurrencyLimitExceeded(
   // Cap exceeded is a request-rejection (-32602), not a generic server error.
   def toMcpError: McpError = McpError.invalidParams(getMessage)
 
+/** Raised by [[TaskManager.create]] when server-side capacity is exhausted: the pool's running
+  * ceiling (`kind = "running"`), or an owner / pool stored-entry cap with nothing evictable
+  * (`"stored-per-owner"` / `"stored"`). Maps to `-32003` — a server condition, not a request fault,
+  * so clients may retry later.
+  */
+final class TaskCapacityExceeded(val kind: String, val limit: Int)
+    extends RuntimeException(s"Task capacity exceeded ($kind, limit $limit)")
+    with McpErrorCarrier:
+  def toMcpError: McpError = McpError(ErrorCodes.CapacityExceeded, getMessage)
+
 /** Unknown / cross-session task id from `tasks/result`. Maps to JSON-RPC `-32602` so it agrees with
   * `tasks/get`'s "Unknown task" error.
   */
@@ -317,15 +626,34 @@ final class TaskNotFoundError(val taskId: String)
 
 object TaskManager:
 
+  private val noCheckpoint: String => UIO[Unit] = _ => ZIO.unit
+
   /** Allocate a new manager with empty state. `newId` supplies task ids; production passes the
     * platform backend's CSPRNG (`TransportBackend.randomId()`) because task ids are bearer handles
     * and shared code has no `SecureRandom`.
     */
   def make[R](settings: TaskSettings, newId: UIO[String]): UIO[TaskManager[R]] =
-    Ref.make(Map.empty[String, TaskEntry]).map(new TaskManager[R](settings, _, newId))
+    for
+      store <- Ref.make(TaskStore.empty)
+      sweeper <- Ref.make(Option.empty[Fiber.Runtime[Nothing, Unit]])
+    yield new TaskManager[R](settings, store, newId, sweeper, noCheckpoint)
 
   /** Synchronous constructor for non-ZIO call sites (tests). Internally identical to [[make]]. */
   def makeUnsafe[R](settings: TaskSettings, newId: UIO[String]): TaskManager[R] =
+    makeUnsafe(settings, newId, noCheckpoint)
+
+  /** Test constructor with a checkpoint hook (see [[TaskManager.checkpoint]]). */
+  private[fastmcp] def makeUnsafe[R](
+      settings: TaskSettings,
+      newId: UIO[String],
+      checkpoint: String => UIO[Unit]
+  ): TaskManager[R] =
     Unsafe.unsafe { implicit unsafe =>
-      new TaskManager[R](settings, Ref.unsafe.make(Map.empty[String, TaskEntry]), newId)
+      new TaskManager[R](
+        settings,
+        Ref.unsafe.make(TaskStore.empty),
+        newId,
+        Ref.unsafe.make(Option.empty[Fiber.Runtime[Nothing, Unit]]),
+        checkpoint
+      )
     }

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/TaskManager.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/TaskManager.scala
@@ -51,8 +51,13 @@ private final case class TaskEntry(
     pool: PoolKind,
     createdAtMs: Long,
     lastUpdatedAtMs: Long,
+    /** Monotonic ([[TaskManager.monotonicMs]]) twin of `lastUpdatedAtMs`; drives the retention
+      * grace and eviction order so a wall-clock step never reorders or un-ages entries.
+      */
+    lastUpdatedMonoMs: Long,
     ttlMs: Option[Long],
-    expiresAtMs: Long,
+    /** Monotonic deadline; the sweeper compares it against [[TaskManager.monotonicMs]]. */
+    expiresAtMonoMs: Long,
     pollIntervalMs: Long,
     status: TaskStatus,
     statusMessage: Option[String],
@@ -125,21 +130,28 @@ private final case class TaskStore(
         )
     }
 
-  /** Oldest terminal entry of `owner` (any owner of `pool` when `owner` is `None`) whose last
-    * update is at or before `cutoff`, ordered by (lastUpdatedAtMs, insertion order).
+  /** Terminal entries of `pool` whose last update (monotonic) is at or before `cutoff` — the only
+    * entries a stored cap may evict.
+    */
+  private def stale(pool: PoolKind, cutoff: Long): Iterator[TaskEntry] =
+    entries.values.iterator.filter(e =>
+      e.pool == pool && e.status.isTerminal && e.lastUpdatedMonoMs <= cutoff
+    )
+
+  /** Oldest stale entry of `owner` (any owner of `pool` when `owner` is `None`), ordered by
+    * (lastUpdatedMonoMs, insertion order).
     */
   def evictable(pool: PoolKind, owner: Option[Option[String]], cutoff: Long): Option[TaskEntry] =
-    val candidates = entries.values.iterator.filter { e =>
-      e.pool == pool && e.status.isTerminal && e.lastUpdatedAtMs <= cutoff &&
-      owner.forall(_ == e.ownerKey)
-    }
+    val candidates = stale(pool, cutoff).filter(e => owner.forall(_ == e.ownerKey))
     if candidates.isEmpty then None
-    else Some(candidates.minBy(e => (e.lastUpdatedAtMs, e.seq)))
+    else Some(candidates.minBy(e => (e.lastUpdatedMonoMs, e.seq)))
 
-  /** Owner with the most stored entries in `pool` (ties broken lexicographically on the key). */
-  def largestOwner(pool: PoolKind): Option[Option[String]] =
-    val totals = entries.values.iterator
-      .filter(_.pool == pool)
+  /** Owner holding the most STALE (evictable) entries in `pool`, ties broken lexicographically on
+    * the key. Ranking on evictable rather than total entries means an owner whose entries are all
+    * running or still inside the retention grace never nominates a victim.
+    */
+  def largestStaleOwner(pool: PoolKind, cutoff: Long): Option[Option[String]] =
+    val totals = stale(pool, cutoff)
       .foldLeft(Map.empty[Option[String], Int])((acc, e) =>
         acc.updated(e.ownerKey, acc.getOrElse(e.ownerKey, 0) + 1)
       )
@@ -182,8 +194,14 @@ private object TaskStore:
   * Bounds. Every task is charged to an owner ([[TaskScope.ownerKey]]) and a pool ([[PoolKind]]).
   * Admission is a single `Ref.modify`: per-owner running cap (`-32602`), per-pool running ceiling
   * (`-32003`), per-owner and per-pool stored caps that evict the oldest terminal entry older than
-  * `minResultRetentionMs` (the pool cap charges the pool's largest owner) and reject with `-32003`
-  * when nothing is evictable. Rejections never mutate the store.
+  * `minResultRetentionMs` and reject with `-32003` when nothing is evictable. The pool cap charges
+  * the creating owner's own stale results first, then the owner holding the most stale results — so
+  * the flooder pays for its own flood, and an owner whose entries are all running or inside the
+  * grace is never a victim. Rejections never mutate the store.
+  *
+  * Clocks. Wire timestamps (`createdAt`, `lastUpdatedAt`) are wall-clock; expiry, the retention
+  * grace and eviction order use the monotonic clock ([[TaskManager.monotonicMs]]) so an NTP step or
+  * VM resume neither sweeps running tasks early nor extends retention.
   *
   * Atomicity. `create` runs under `uninterruptibleMask`; an interrupt of the creating fiber (client
   * abort, `notifications/cancelled`) is detected before admission and again after registration and
@@ -250,6 +268,7 @@ class TaskManager[R] private[manager] (
         promise <- Promise.make[Throwable, Any]
         start <- Promise.make[Nothing, Boolean]
         nowMs <- ZIO.succeed(System.currentTimeMillis())
+        nowMono <- ZIO.succeed(TaskManager.monotonicMs())
         ttlMs = effectiveTtl(requestedTtlMs)
         // acquireReleaseExitWith runs the release uninterruptibly, so the status update + promise
         // completion always happen, even if the fiber is interrupted via tasks/cancel. A closed
@@ -265,7 +284,7 @@ class TaskManager[R] private[manager] (
         // A child forked inside the mask inherits the mask's uninterruptibility; `.interruptible`
         // is mandatory or tasks/cancel and TTL expiry would never land.
         fiber <- wrapped.interruptible.forkDaemon
-        result <- registerOrRollback(taskId, scope, ttlMs, nowMs, fiber, promise, start)
+        result <- registerOrRollback(taskId, scope, ttlMs, nowMs, nowMono, fiber, promise, start)
           .onExit(exit => ZIO.unless(exit.isSuccess)(rollback(taskId) *> start.succeed(false)).unit)
       yield result
     }
@@ -291,6 +310,7 @@ class TaskManager[R] private[manager] (
       scope: TaskScope,
       ttlMs: Option[Long],
       nowMs: Long,
+      nowMono: Long,
       fiber: Fiber.Runtime[Throwable, Any],
       promise: Promise[Throwable, Any],
       start: Promise[Nothing, Boolean]
@@ -307,15 +327,16 @@ class TaskManager[R] private[manager] (
         pool = scope.pool,
         createdAtMs = nowMs,
         lastUpdatedAtMs = nowMs,
+        lastUpdatedMonoMs = nowMono,
         ttlMs = ttlMs,
-        expiresAtMs = nowMs + ttlMs.getOrElse(settings.defaultTtlMs),
+        expiresAtMonoMs = nowMono + ttlMs.getOrElse(settings.defaultTtlMs),
         pollIntervalMs = settings.pollIntervalMs,
         status = TaskStatus.Working,
         statusMessage = Some("The operation is now in progress."),
         fiber = fiber,
         result = promise
       )
-      admission <- storeRef.modify(admit(entry, nowMs))
+      admission <- storeRef.modify(admit(entry, nowMono))
       result <- admission match
         case Left(err) => promise.fail(err) *> ZIO.fail(err)
         case Right(startSweeper) =>
@@ -345,14 +366,14 @@ class TaskManager[R] private[manager] (
   /** Single-`modify` admission. `Right(startSweeper)` when the entry was inserted (after any cap
     * evictions), `Left(err)` when rejected — in which case the store is returned untouched.
     */
-  private def admit(entry: TaskEntry, nowMs: Long)(
+  private def admit(entry: TaskEntry, nowMono: Long)(
       s: TaskStore
   ): (Either[Throwable, Boolean], TaskStore) =
     val owner = entry.ownerKey
     val pool = entry.pool
     val oc = s.owners.getOrElse(owner, Counts(0, 0))
     val pc = s.pools.getOrElse(pool, Counts(0, 0))
-    val cutoff = nowMs - settings.minResultRetentionMs
+    val cutoff = nowMono - settings.minResultRetentionMs
     if s.entries.contains(entry.taskId) then
       (Left(new IllegalStateException(s"duplicate task id ${entry.taskId}")), s)
     else if oc.running >= perOwnerRunning then
@@ -367,11 +388,16 @@ class TaskManager[R] private[manager] (
       else
         val s1 = s.remove(ownerEvict.toList)
         val p1 = s1.pools.getOrElse(pool, Counts(0, 0))
+        // Pool cap: the creator's own stale results pay first, then the owner holding the most
+        // stale results. Never the owner with the most entries — a distributed flood of fresh
+        // entries must not be able to nominate a legitimate heavy user as the victim.
         val poolEvict =
           if p1.total >= poolStored then
-            s1.largestOwner(pool)
-              .flatMap(big => s1.evictable(pool, Some(big), cutoff))
-              .orElse(s1.evictable(pool, None, cutoff))
+            s1.evictable(pool, Some(owner), cutoff)
+              .orElse(
+                s1.largestStaleOwner(pool, cutoff)
+                  .flatMap(big => s1.evictable(pool, Some(big), cutoff))
+              )
           else None
         if p1.total >= poolStored && poolEvict.isEmpty then
           (Left(TaskCapacityExceeded("stored", poolStored)), s)
@@ -386,13 +412,13 @@ class TaskManager[R] private[manager] (
     * the same `modify` that observes the drain, when the store is empty.
     */
   private def sweepLoop: UIO[Unit] =
-    ZIO.succeed(System.currentTimeMillis()).flatMap { now =>
+    ZIO.succeed(TaskManager.monotonicMs()).flatMap { now =>
       storeRef
         .modify { s =>
-          val expired = s.entries.values.filter(_.expiresAtMs <= now).toList
+          val expired = s.entries.values.filter(_.expiresAtMonoMs <= now).toList
           val rest = s.remove(expired)
           if rest.entries.isEmpty then ((expired, None), rest.copy(sweeperActive = false))
-          else ((expired, Some(rest.entries.values.iterator.map(_.expiresAtMs).min)), rest)
+          else ((expired, Some(rest.entries.values.iterator.map(_.expiresAtMonoMs).min)), rest)
         }
         .flatMap { case (expired, next) =>
           // interruptFork: never block the sweeper on a task body; the task's release then no-ops
@@ -577,6 +603,7 @@ class TaskManager[R] private[manager] (
         val firstFailureMsg = cause.failureOption.flatMap(t => Option(t.getMessage))
         (TaskStatus.Failed, firstFailureMsg.filter(_.nonEmpty))
     val nowMs = System.currentTimeMillis()
+    val nowMono = TaskManager.monotonicMs()
     for
       updated <- storeRef.modify { s =>
         s.entries.get(taskId) match
@@ -585,7 +612,8 @@ class TaskManager[R] private[manager] (
             val next = entry.copy(
               status = status,
               statusMessage = message,
-              lastUpdatedAtMs = nowMs
+              lastUpdatedAtMs = nowMs,
+              lastUpdatedMonoMs = nowMono
             )
             (Some(next), s.markTerminal(entry, next))
       }
@@ -631,6 +659,11 @@ final class TaskNotFoundError(val taskId: String)
 object TaskManager:
 
   private val noCheckpoint: String => UIO[Unit] = _ => ZIO.unit
+
+  /** Monotonic milliseconds (`System.nanoTime`, available on JVM, Scala.js and Scala Native). Only
+    * differences are meaningful; never persisted or put on the wire.
+    */
+  private[manager] def monotonicMs(): Long = System.nanoTime() / 1_000_000L
 
   /** Allocate a new manager with empty state. `newId` supplies task ids; production passes the
     * platform backend's CSPRNG (`TransportBackend.randomId()`) because task ids are bearer handles

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/TaskManager.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/TaskManager.scala
@@ -515,18 +515,22 @@ class TaskManager[R] private[manager] (
             ZIO.foreachDiscard(mine.filter(!_.status.isTerminal))(_.fiber.interruptFork)
           )
 
-  /** Drain the store (interrupting running tasks) and stop the sweeper, awaiting its exit. For
+  /** Stop the sweeper (awaiting its exit), then drain the store, interrupting running tasks. For
     * embedders that stop a server without exiting the process, and for test cleanup — the sweeper
     * is a daemon fiber and otherwise exits on its own once the store drains.
+    *
+    * Order matters against a racing `create`: the drain resets `sweeperActive`, so a create that
+    * lands afterwards starts a fresh sweeper, and one that landed in between is drained here.
+    * Draining first could leave `sweeperActive = true` with no live sweeper.
     */
   def shutdown: UIO[Unit] =
     for
+      sweeper <- sweeperRef.getAndSet(None)
+      _ <- ZIO.foreachDiscard(sweeper)(_.interrupt)
       drained <- storeRef.getAndSet(TaskStore.empty)
       _ <- ZIO.foreachDiscard(drained.entries.values.filter(!_.status.isTerminal))(
         _.fiber.interruptFork
       )
-      sweeper <- sweeperRef.getAndSet(None)
-      _ <- ZIO.foreachDiscard(sweeper)(_.interrupt)
     yield ()
 
   /** Resolve the bucket key of a modern bearer task per `settings.ownerKey`. */

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/Session.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/Session.scala
@@ -24,6 +24,11 @@ final class Session private (
       * client each and keep the legacy task surface.
       */
     val supportsTasks: Boolean,
+    /** Transport-supplied client identity (peer address on the shipped HTTP backends), used to
+      * bucket modern bearer tasks per client. `None` when the transport cannot tell clients apart;
+      * never derived from request content.
+      */
+    val clientKey: Option[String],
     private val protocolVersionRef: Ref[String],
     private val logLevelRef: Ref[Option[LoggingLevel]],
     private val initializedRef: Ref[Boolean],
@@ -39,7 +44,8 @@ final class Session private (
     private val requestIdRef: FiberRef[Option[RequestId]],
     private val inputKeyOccurrencesRef: FiberRef[Option[Ref[Map[String, Int]]]],
     private val lastSeenRef: Ref[Long],
-    private val activeGetRef: Ref[Boolean]
+    private val activeGetRef: Ref[Boolean],
+    private val finalizersRef: Ref[Map[String, UIO[Unit]]]
 ):
 
   /** Millis timestamp of the last client activity (transports touch on every request). Drives idle
@@ -78,6 +84,24 @@ final class Session private (
   def subscribe(uri: String): UIO[Unit] = subscriptionsRef.update(_ + uri)
   def unsubscribe(uri: String): UIO[Unit] = subscriptionsRef.update(_ - uri)
   def isSubscribed(uri: String): UIO[Boolean] = subscriptionsRef.get.map(_.contains(uri))
+  def subscriptionCount: UIO[Int] = subscriptionsRef.get.map(_.size)
+
+  // --- termination ---
+
+  /** Register (or replace) a keyed finalizer run by [[terminate]]. Keyed so a component that
+    * re-registers on every request stays idempotent (e.g. the task manager releasing the session's
+    * tasks).
+    */
+  def addFinalizer(key: String)(f: UIO[Unit]): UIO[Unit] = finalizersRef.update(_.updated(key, f))
+
+  /** Terminate the session: run every registered finalizer once (failures ignored), then shut the
+    * outbound channel down. A strict superset of `outbound.shutdown`; transports call it on
+    * `DELETE` and idle eviction so session-bound state (tasks) does not outlive the session.
+    */
+  def terminate: UIO[Unit] =
+    finalizersRef
+      .getAndSet(Map.empty)
+      .flatMap(fs => ZIO.foreachDiscard(fs.values)(_.ignore)) *> outbound.shutdown
 
   /** Allocate the next id for a server-initiated request. Prefixed so server ids never collide with
     * client-issued ids on the same connection.
@@ -155,6 +179,11 @@ final class Session private (
 
   def clearInflight(id: RequestId): UIO[Unit] = inflight.update(_ - id)
 
+  /** Ids currently tracked in the in-flight registry (test seam: lets a cancellation test wait
+    * until `trackInflight` has run, since the dispatcher forks before tracking).
+    */
+  private[fastmcp] def inflightIds: UIO[Set[RequestId]] = inflight.get.map(_.keySet)
+
   /** Interrupt the in-flight fiber for `id`, if any (drives `notifications/cancelled`). The
     * `initialize` request is exempt — the spec forbids cancelling it.
     */
@@ -198,7 +227,11 @@ final class Session private (
 
 object Session:
 
-  def make(sessionId: String, supportsTasks: Boolean = true): UIO[Session] =
+  def make(
+      sessionId: String,
+      supportsTasks: Boolean = true,
+      clientKey: Option[String] = None
+  ): UIO[Session] =
     for
       pv <- Ref.make("")
       ll <- Ref.make(Option.empty[LoggingLevel])
@@ -220,9 +253,11 @@ object Session:
       )
       seen <- Ref.make(java.lang.System.currentTimeMillis())
       activeGet <- Ref.make(false)
+      finalizers <- Ref.make(Map.empty[String, UIO[Unit]])
     yield new Session(
       sessionId,
       supportsTasks,
+      clientKey,
       pv,
       ll,
       init,
@@ -238,5 +273,6 @@ object Session:
       requestId,
       inputOccurrences,
       seen,
-      activeGet
+      activeGet,
+      finalizers
     )

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/Session.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/Session.scala
@@ -45,7 +45,8 @@ final class Session private (
     private val inputKeyOccurrencesRef: FiberRef[Option[Ref[Map[String, Int]]]],
     private val lastSeenRef: Ref[Long],
     private val activeGetRef: Ref[Boolean],
-    private val finalizersRef: Ref[Map[String, UIO[Unit]]]
+    /** `Some(finalizers)` while live; `None` once [[terminate]] has run (the terminated latch). */
+    private val finalizersRef: Ref[Option[Map[String, UIO[Unit]]]]
 ):
 
   /** Millis timestamp of the last client activity (transports touch on every request). Drives idle
@@ -90,18 +91,38 @@ final class Session private (
 
   /** Register (or replace) a keyed finalizer run by [[terminate]]. Keyed so a component that
     * re-registers on every request stays idempotent (e.g. the task manager releasing the session's
-    * tasks).
+    * tasks). A finalizer registered AFTER the session was terminated runs immediately instead of
+    * being parked on a dead session — so a request whose registration completes after a racing
+    * `DELETE` / idle eviction still gets its state released.
     */
-  def addFinalizer(key: String)(f: UIO[Unit]): UIO[Unit] = finalizersRef.update(_.updated(key, f))
+  def addFinalizer(key: String)(f: UIO[Unit]): UIO[Unit] =
+    finalizersRef
+      .modify {
+        case Some(fs) => (false, Some(fs.updated(key, f)))
+        case None => (true, None)
+      }
+      .flatMap(late => ZIO.when(late)(f.ignore).unit)
 
-  /** Terminate the session: run every registered finalizer once (failures ignored), then shut the
-    * outbound channel down. A strict superset of `outbound.shutdown`; transports call it on
-    * `DELETE` and idle eviction so session-bound state (tasks) does not outlive the session.
+  /** True once [[terminate]] has run. */
+  def isTerminated: UIO[Boolean] = finalizersRef.get.map(_.isEmpty)
+
+  /** Terminate the session: latch the terminated flag, interrupt the session's in-flight request
+    * fibers (a request cannot outlive its session; `interruptFork` so a fiber parked in an
+    * uninterruptible region never blocks the caller), run every registered finalizer once (failures
+    * ignored), then shut the outbound channel down. Idempotent. A strict superset of
+    * `outbound.shutdown`; transports call it on `DELETE` and idle eviction so session-bound state
+    * (tasks) does not outlive the session.
     */
   def terminate: UIO[Unit] =
-    finalizersRef
-      .getAndSet(Map.empty)
-      .flatMap(fs => ZIO.foreachDiscard(fs.values)(_.ignore)) *> outbound.shutdown
+    finalizersRef.getAndSet(None).flatMap {
+      case None => ZIO.unit
+      case Some(fs) =>
+        inflight
+          .getAndSet(Map.empty)
+          .flatMap(fibers => ZIO.foreachDiscard(fibers.values)(_._2.interruptFork)) *>
+          ZIO.foreachDiscard(fs.values)(_.ignore) *>
+          outbound.shutdown
+    }
 
   /** Allocate the next id for a server-initiated request. Prefixed so server ids never collide with
     * client-issued ids on the same connection.
@@ -253,7 +274,7 @@ object Session:
       )
       seen <- Ref.make(java.lang.System.currentTimeMillis())
       activeGet <- Ref.make(false)
-      finalizers <- Ref.make(Map.empty[String, UIO[Unit]])
+      finalizers <- Ref.make(Option(Map.empty[String, UIO[Unit]]))
     yield new Session(
       sessionId,
       supportsTasks,

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/TaskRouting.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/TaskRouting.scala
@@ -8,6 +8,7 @@ import zio.json.ast.Json
 import com.tjclp.fastmcp.core.{
   ExtensionTaskHandle,
   Task,
+  TaskOwnerContext,
   TaskParams,
   TaskStatus,
   TaskStatusNotificationParams,
@@ -16,7 +17,7 @@ import com.tjclp.fastmcp.core.{
 }
 import com.tjclp.fastmcp.core.wire.EmptyResult
 import com.tjclp.fastmcp.jsonrpc.{JsonRpcMessage, McpError}
-import com.tjclp.fastmcp.server.manager.{TaskManager, TaskSnapshot, ToolManager}
+import com.tjclp.fastmcp.server.manager.{TaskManager, TaskScope, TaskSnapshot, ToolManager}
 
 private case class TaskIdParams(taskId: String)
 
@@ -36,6 +37,14 @@ private object TaskUpdateParams:
 /** Task routing supports both eras without mixing their wire shapes. Legacy requests explicitly
   * carry `params.task`; 2026 clients declare the Tasks extension and the server may return a task
   * handle without per-call augmentation.
+  *
+  * Accounting: legacy tasks are owned by their protocol session ([[TaskScope.session]]) and are
+  * released when the transport terminates that session ([[Session.terminate]]). Modern bearer tasks
+  * are owned by the client key derived from `TaskSettings.ownerKey` — by default the
+  * transport-supplied [[Session.clientKey]]; keyless requests share one anonymous bucket. Each
+  * owner has a running cap (`-32602`); each pool (legacy vs bearer) has running and stored ceilings
+  * (`-32003`), with completed results kept for at least `minResultRetentionMs` before a cap may
+  * evict them.
   */
 final class TaskMiddleware[R](
     taskManager: TaskManager[R],
@@ -47,8 +56,7 @@ final class TaskMiddleware[R](
     else
       (session, params) =>
         session.currentRequestContext.flatMap {
-          case Some(context) =>
-            modern(session, params, next, context.clientCapabilities.extensions)
+          case Some(context) => modern(session, params, next, context)
           case None => legacy(session, params, next)
         }
 
@@ -83,15 +91,20 @@ final class TaskMiddleware[R](
           case (true, TaskSupport.Optional | TaskSupport.Required) =>
             // runWithoutSink: the task fiber (forked inside create) outlives this POST, whose
             // sink queue is shut down when the SSE response ends — sends must go to outbound.
+            val scope = TaskScope.session(session.sessionId)
             session
               .runWithoutSink(
                 taskManager.create(
-                  sessionId = Some(session.sessionId),
+                  scope = scope,
                   requestedTtlMs = ttl,
                   run = next(session, params),
                   onStatusChange = task => session.send(statusNotification(task))
                 )
               )
+              // Session termination (DELETE / idle eviction) releases the session's tasks instead
+              // of pinning entries nobody can see until their TTL. Keyed, so re-registering per
+              // create is idempotent.
+              .tap(_ => session.addFinalizer("tasks")(taskManager.releaseScope(scope)))
               .mapBoth(
                 McpError.fromThrowable,
                 created => created.toJsonAST.getOrElse(Json.Obj())
@@ -106,7 +119,7 @@ final class TaskMiddleware[R](
       session: Session,
       params: Json,
       next: RequestHandler[R],
-      extensions: Option[Map[String, Json]]
+      context: RequestContext
   ): ZIO[R, McpError, Json] =
     decodeName(params) match
       case Left(err) => ZIO.fail(err)
@@ -118,7 +131,8 @@ final class TaskMiddleware[R](
         val hasLegacyAugmentation = params match
           case Json.Obj(fields) => fields.toMap.contains("task")
           case _ => false
-        val clientSupportsTasks = extensions.exists(_.contains(Tasks.ExtensionId))
+        val clientSupportsTasks =
+          context.clientCapabilities.extensions.exists(_.contains(Tasks.ExtensionId))
 
         if hasLegacyAugmentation then
           ZIO.fail(McpError.invalidParams("tools/call: `params.task` was removed in 2026-07-28"))
@@ -133,26 +147,35 @@ final class TaskMiddleware[R](
               )
             case TaskSupport.Optional if !clientSupportsTasks => next(session, params)
             case TaskSupport.Optional | TaskSupport.Required =>
+              // Bucket per client: only the transport-supplied key is trusted by default;
+              // `clientInfo` / `_meta` reach a Custom hook but are attacker-controlled.
+              val ownerContext =
+                TaskOwnerContext(session.clientKey, context.clientInfo, context.meta)
               // runWithoutSink for the same reason as the legacy branch: the ephemeral modern
               // session's outbound is never drained, but an offer to a live unbounded queue is
               // harmless and GC'd with the task — unlike an offer to a shutdown sink queue.
-              session
-                .runWithoutSink(
-                  taskManager.create(
-                    sessionId = None,
-                    requestedTtlMs = None,
-                    run = next(session, params),
-                    onStatusChange = _ => ZIO.unit
-                  )
-                )
-                .mapBoth(
-                  McpError.fromThrowable,
-                  created =>
-                    ExtensionTaskHandle
-                      .fromLegacy(created.task)
-                      .toJsonAST
-                      .getOrElse(Json.Obj())
-                )
+              taskManager
+                .ownerKeyFor(ownerContext)
+                .mapError(McpError.fromThrowable)
+                .flatMap { key =>
+                  session
+                    .runWithoutSink(
+                      taskManager.create(
+                        scope = TaskScope.bearer(key),
+                        requestedTtlMs = None,
+                        run = next(session, params),
+                        onStatusChange = _ => ZIO.unit
+                      )
+                    )
+                    .mapBoth(
+                      McpError.fromThrowable,
+                      created =>
+                        ExtensionTaskHandle
+                          .fromLegacy(created.task)
+                          .toJsonAST
+                          .getOrElse(Json.Obj())
+                    )
+                }
 
   private def decodeName(params: Json): Either[McpError, String] =
     params match

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/TaskRouting.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/TaskRouting.scala
@@ -92,19 +92,28 @@ final class TaskMiddleware[R](
             // runWithoutSink: the task fiber (forked inside create) outlives this POST, whose
             // sink queue is shut down when the SSE response ends — sends must go to outbound.
             val scope = TaskScope.session(session.sessionId)
-            session
-              .runWithoutSink(
-                taskManager.create(
-                  scope = scope,
-                  requestedTtlMs = ttl,
-                  run = next(session, params),
-                  onStatusChange = task => session.send(statusNotification(task))
+            // Session termination (DELETE / idle eviction) releases the session's tasks instead
+            // of pinning entries nobody can see until their TTL. Keyed (idempotent), registered
+            // BEFORE the create so an interrupt landing after registration can never leave a
+            // task without its release hook, and again AFTER it: on a session terminated in the
+            // meantime the late registration runs the release immediately.
+            val release = session.addFinalizer("tasks")(taskManager.releaseScope(scope))
+            (release *>
+              session
+                .runWithoutSink(
+                  taskManager.create(
+                    scope = scope,
+                    requestedTtlMs = ttl,
+                    run = next(session, params),
+                    onStatusChange = task => session.send(statusNotification(task))
+                  )
                 )
-              )
-              // Session termination (DELETE / idle eviction) releases the session's tasks instead
-              // of pinning entries nobody can see until their TTL. Keyed, so re-registering per
-              // create is idempotent.
-              .tap(_ => session.addFinalizer("tasks")(taskManager.releaseScope(scope)))
+                .tap(_ => release))
+              // Everything here is non-blocking Ref/Promise work: keeping the whole branch
+              // uninterruptible shrinks the window in which a registered task's handle is lost
+              // to the dispatcher's continuation. `create` still detects a pending interrupt and
+              // rolls back before the mask ends.
+              .uninterruptible
               .mapBoth(
                 McpError.fromThrowable,
                 created => created.toJsonAST.getOrElse(Json.Obj())
@@ -167,6 +176,7 @@ final class TaskMiddleware[R](
                         onStatusChange = _ => ZIO.unit
                       )
                     )
+                    .uninterruptible // see the legacy branch
                     .mapBoth(
                       McpError.fromThrowable,
                       created =>


### PR DESCRIPTION
## Summary

Hardens the MCP Tasks extension (`tasks.enabled = true`, off by default) against three availability weaknesses found by the 2026-09-04 security scan of `main` @ 906e694. An unauthenticated client that could reach the socket of a tasks-enabled server could (F8) pin an unbounded number of terminal task entries — each holding its result JSON plus a 24 h sleeping eviction fiber — by looping fast task calls with `ttl = 86400000`; (F9) fill the single 64-slot bucket every modern bearer client shared and so deny Tasks (and every `TaskSupport.Required` tool) to all other clients; and (F11) race `notifications/cancelled` or a connection abort into the non-atomic `TaskManager.create` to leave never-evicted `Working` zombies and parked fibers until restart.

This PR bounds the store per owner and per pool with grace-aware eviction and a new `-32003 Task capacity exceeded` error, replaces per-task eviction fibers with one lazily started sweeper on the monotonic clock, buckets bearer tasks per client through an operator-controlled `TaskOwnerKey`, makes `create` atomic under interruption, and gives `Session` a latched `terminate` that releases the session's tasks.

Part 3/6 of the TJC-2294 security stack; base: `tjc-2298-macro-overload-binding`. Linear: TJC-2297.

## Findings addressed

| ID | Severity | CWE | Title | Status |
|---|---|---|---|---|
| F8 | MEDIUM | CWE-770 | No bound on stored task entries; client-chosen TTL retains results and fibers for 24h | Fixed |
| F9 | MEDIUM | CWE-410 | Modern bearer tasks share one global concurrency bucket any client can exhaust | Fixed in this PR (router/manager) + wired in #92 (transports populate `Session.clientKey`) |
| F11 | LOW | CWE-460 | Interruptible task creation orphans never-evicted Working entries and parked fibers | Fixed |

All three hold only on deployments with `tasks.enabled = true` and at least one `taskSupport = optional|required` tool (no shipped example enables Tasks).

## What changed

Ten files, all under `fast-mcp-scala/`; 1,624 insertions / 137 deletions; no transport or macro files touched.

**Task store bounds and sweeper** — `shared/src/com/tjclp/fastmcp/server/manager/TaskManager.scala`
- New `TaskStore` with O(1) per-owner / per-pool `Counts(running, total)` indices (legacy-session pool and modern-bearer pool are counted separately) replacing the flat `Map` + O(n) scans.
- `admit()` is one `Ref.modify`: per-owner running cap (`-32602`, unchanged code) -> per-pool running ceiling (`-32003 running`) -> per-owner stored cap, evicting the owner's oldest terminal entry older than `minResultRetentionMs` else `-32003 stored-per-owner` -> per-pool stored cap, evicting the creating owner's own stale results first, then the oldest stale entry of the owner holding the MOST stale entries, else `-32003 stored`. Rejections never mutate the store.
- Per-task `forkDaemon` TTL sleepers are gone. `TaskEntry.expiresAtMonoMs` is fixed at insertion; `sweepLoop` is a single lazily started daemon fiber, claimed in the same `Ref.modify` as the insert, that removes expired entries, `interruptFork`s still-running ones, sleeps `min(nearest deadline, sweepIntervalMs)` and exits when the store drains. Expiry, grace and eviction order use `System.nanoTime` (`TaskManager.monotonicMs`); wire `createdAt`/`lastUpdatedAt` stay wall-clock.
- New `TaskScope(sessionId, ownerKey)` with `TaskScope.session(id)` / `TaskScope.bearer(clientKey)`; new `create(scope, ...)` (the old `create(sessionId: Option[String], ...)` overload is kept), `releaseScope`, `shutdown` (interrupts the sweeper first, then drains), `ownerKeyFor`.
- New `TaskCapacityExceeded(kind, limit)` -> `McpError(ErrorCodes.CapacityExceeded, "Task capacity exceeded (<kind>, limit N)")`.
- Primary constructor is now `private[manager]`; `make` / `makeUnsafe` keep their signatures; a `private[fastmcp] makeUnsafe(settings, newId, checkpoint)` seam exists for the interruption tests.

**Error code** — `shared/src/com/tjclp/fastmcp/core/Protocol.scala`
- `ErrorCodes.CapacityExceeded = -32003` (server condition, retryable; distinct from the caller's own `-32602` per-owner cap).

**Owner-key policy** — `shared/src/com/tjclp/fastmcp/core/Tasks.scala`
- `TaskOwnerContext(transportClientKey, clientInfo, meta)` and `sealed trait TaskOwnerKey` with `Transport` (default: the transport-supplied `Session.clientKey`; `None` -> one anonymous bucket) and `Custom(f: TaskOwnerContext => Option[String])` (a throwing `f` fails the create with `-32603` rather than collapsing into the shared bucket). `clientInfo` / `_meta` are documented as attacker-controlled.

**Settings** — `shared/src/com/tjclp/fastmcp/server/McpServerSettings.scala` (`TaskSettings` block only)
- New fields with defaults: `maxConcurrentTotal = 1024` (running ceiling per pool), `maxStoredPerOwner = 256`, `maxStoredTotal = 4096` (per pool), `minResultRetentionMs = 30_000`, `sweepIntervalMs = 1_000`, `ownerKey = TaskOwnerKey.Transport`. `maxConcurrentPerSession = 64` is re-documented as the per-OWNER running cap.
- Construction-time `require` guards: `maxConcurrentPerSession >= 1`, `maxConcurrentTotal >= maxConcurrentPerSession`, `maxStoredPerOwner >= 1`, `maxStoredTotal >= 1`, `minResultRetentionMs >= 0`, `sweepIntervalMs >= 1`. Stored caps below the running caps are normalised up, not rejected.

**Session termination seam** — `shared/src/com/tjclp/fastmcp/server/router/Session.scala`
- New `clientKey: Option[String]` field and `Session.make(sessionId, supportsTasks = true, clientKey = None)`.
- New `addFinalizer(key)(f)` (keyed, idempotent; on an already-terminated session the finalizer runs immediately), `terminate` (latched via `finalizersRef: Ref[Option[Map[...]]]`; `interruptFork`s in-flight request fibers, runs finalizers once, then `outbound.shutdown`), `isTerminated`, `subscriptionCount`, and a `private[fastmcp] inflightIds` test seam.

**Routing** — `shared/src/com/tjclp/fastmcp/server/router/TaskRouting.scala`
- Legacy branch: registers the `"tasks"` finalizer (`taskManager.releaseScope(scope)`) BEFORE the create and again after it, whole branch `.uninterruptible`.
- Modern branch: builds `TaskOwnerContext(session.clientKey, context.clientInfo, context.meta)` -> `taskManager.ownerKeyFor` -> `TaskScope.bearer(key)`; branch `.uninterruptible`. `modern(...)` now takes the full `RequestContext`.

**Tests** — `jvm/test/src/.../manager/TaskManagerSpec.scala`, `.../server/TaskTransportGuardTest.scala`, `.../transport/TaskHttpTransportTest.scala`, `.../transport/LifecycleSoakTest.scala` (see Tests).

## Behaviour changes (pre-1.0)

- New JSON-RPC error `-32003 Task capacity exceeded (<kind>, limit N)` with `kind` in `running | stored-per-owner | stored` when a pool ceiling or stored cap is hit and nothing is evictable. The caller's own per-owner running cap still answers `-32602`.
- Completed task results may now be evicted before their TTL: once older than `minResultRetentionMs` (30 s), the oldest terminal entry of an owner at `maxStoredPerOwner` (256), or of a pool at `maxStoredTotal` (4096), is dropped and subsequently answers `-32602 Unknown task`. Heavy legitimate users completing more than 256 tasks within one TTL are affected; tune `maxStoredPerOwner` / `minResultRetentionMs`.
- `maxConcurrentPerSession` is now enforced per owner key for modern bearer tasks instead of across all bearer tasks; a new per-pool running ceiling `maxConcurrentTotal` (1024) applies separately to the legacy-session pool and the bearer pool.
- TTL precision is now `min(remaining, sweepIntervalMs)` (1 s slack) instead of an exact per-task timer; a `ttl: 0` task may be swept before its create returns, in which case the create answers `-32602 Unknown task`.
- `TaskSettings(...)` throws `IllegalArgumentException` on non-positive or inconsistent bounds (previously any value was accepted).
- `TaskManager`'s primary constructor is no longer public; use `TaskManager.make` / `makeUnsafe`.
- `Session.terminate` interrupts the session's in-flight request fibers. On this branch nothing calls it yet (transports still call `outbound.shutdown`); once #92 swaps DELETE / idle eviction / cap eviction to `terminate`, a POST still running on a deleted or idle-evicted session gets no reply and that session's running tasks are interrupted.
- Additive API: `Session.clientKey`, `Session.addFinalizer`, `Session.terminate`, `Session.isTerminated`, `Session.subscriptionCount`, `TaskScope`, `TaskManager.create(scope, ...)`, `TaskManager.releaseScope`, `TaskManager.shutdown`, `TaskManager.ownerKeyFor`, `TaskOwnerContext`, `TaskOwnerKey`, `TaskCapacityExceeded`, `ErrorCodes.CapacityExceeded`.
- No wire-shape, transport, macro or conformance-visible change: official conformance stays 73/73 on both platforms.

## Fix criteria -> evidence

File paths are under `fast-mcp-scala/`; line numbers are on this branch (`tjc-2297-tasks-hardening`).

**F8.1 — stored entries (terminal included) bounded independently of client behaviour; store size and fiber count stay at/below the bound from one session and across many** — met
- `shared/.../manager/TaskManager.scala:95-177` `TaskStore` indices; `:369-406` `admit()` (owner running `:379-381`, pool running `:382`, owner stored `:384-387`, pool stored `:394-403`).
- `shared/.../server/McpServerSettings.scala` `TaskSettings` defaults + `require` block; `shared/.../core/Protocol.scala:66` `CapacityExceeded`; `TaskManager.scala:646-649` `TaskCapacityExceeded.toMcpError`.
- Tests: `TaskManagerSpec` `:330` "stored-entry cap should evict the owner's oldest terminal entry", `:343` "bound the store across owners at the pool cap and charge the largest owner", `:373` "charge the creating owner's own stale results before anyone else's at the pool cap", `:400` "never pick an owner whose results are all inside the grace as the pool-cap victim", `:454` "reject when nothing is evictable", `:509` "map TaskCapacityExceeded to -32003", `:515` "retention grace should protect a completed-but-unfetched result from a flooding co-owner", `:441` "TaskSettings should reject non-positive or inconsistent store bounds"; `TaskHttpTransportTest` `:367` "a session that loops fast task calls never holds more than maxStoredPerOwner entries" (20 augmented calls, cap 8 -> `tasks/list` <= 8, old ids `-32602`), `:389` "pool capacity answers -32003 Task capacity exceeded across sessions".
- Independent verifier reproduction (default settings, `ttl = 86400000`): 3000 fast tasks from one session -> store total 256, 2744 rejected `-32003 stored-per-owner`; 6000 sessions x 1 task -> total 4096; 500 further creates at the cap rejected in 33 ms total.

**F8.2 — terminal retention must not cost a live fiber per entry; N terminal tasks do not leave N sleeping fibers in `Fiber.roots`** — met
- `TaskManager.scala:59-60` `expiresAtMonoMs`; `:406` sweeper claimed in the admit modify; `:414-435` `sweepLoop` / `startSweeperFiber`; `:552-560` `shutdown`; `:666` `monotonicMs`.
- Tests: `TaskManagerSpec` `:532` "sweeper should leave at most one sweeper fiber in Fiber.roots for many terminal tasks" (50 tasks, ttl 60 s, roots delta <= 5), `:549` "exit when the store drains and restart on the next create", `:566` "shutdown should drain the store, interrupt running work and stop the sweeper", `:283` "TTL eviction should remove the entry and interrupt still-running work"; `LifecycleSoakTest` `:145` "N terminal tasks leave no sleeping eviction fibers behind" (30 augmented HTTP calls, roots delta <= 5). Verifier measured a `Fiber.roots` delta of exactly 1 while holding 256 and 4096 terminal entries.

**F9 — a modern client must not be able to prevent other clients from creating tasks; per-client key the operator can supply and/or a documented global ceiling larger than the per-client cap** — met at the router/manager level on this branch; transport wiring lands in #92
- `TaskManager.scala:31-42` `TaskScope.bearer(clientKey)` -> owner key `client:<key>`; `:379-382` per-owner cap then per-pool ceiling; `shared/.../core/Tasks.scala` `TaskOwnerContext` / `TaskOwnerKey`; `TaskManager.scala:563` `ownerKeyFor`; `shared/.../router/TaskRouting.scala` modern branch (`TaskOwnerContext(session.clientKey, ...)`); `Session.scala` `clientKey` + `Session.make(..., clientKey)`; `McpServerSettings.scala` `maxConcurrentTotal = 1024 >= maxConcurrentPerSession = 64` guarded by `require`.
- Tests: `TaskManagerSpec` `:627` "bearer tasks should bucket per client key: A at cap, B and anonymous still create", `:655` "pool running ceiling should be distinct from and larger than the per-owner cap", `:680` "not let a legacy-session flood block bearer tasks", `:697` "ownerKeyFor should follow the operator policy" (Transport, Custom, throwing Custom fails the create); `TaskTransportGuardTest` `:96` "modern clients with distinct Session.clientKey get independent task buckets" (`-32602` for A, task for B, no key echoed), `:122` "legacy-session pool at its ceiling does not block bearer tasks".
- On this branch alone the shipped HTTP backends still call `Session.make` without `clientKey`, so every modern request lands in the anonymous bucket (bounded at 64 running / 256 stored inside the bearer pool, but not isolated). #92 adds `clientKey = <peer address>` at the modern `Session.make` sites in `JvmHttpBackend` and `JsTransportBackend` and a two-peer transport test; the independent verifier confirmed the wired behaviour on real sockets on both JVM/netty and Bun (peer A at its cap -> `-32602`, peer B still creates).

**F11.1 — registration all-or-nothing under interruption of the creating fiber; no `Working` entry, no parked fiber, non-terminal count back to zero** — met
- `TaskManager.scala:265-290` `create` under `ZIO.uninterruptibleMask`, gated task fiber (`start: Promise[Nothing, Boolean]`, `false` -> the parked fiber self-interrupts), `registerOrRollback(...).onExit(rollback *> start.succeed(false))` at `:288`; `:308-354` `registerOrRollback` with `failIfInterruptPending` (`:360`) before admission (`:322`) and after registration (`:347`).
- `TaskRouting.scala` legacy branch: finalizer registered before the create, branch `.uninterruptible`; modern branch `.uninterruptible`. `Session.scala` `addFinalizer` late-run + `terminate` latch and in-flight interruption.
- Tests: `TaskManagerSpec` `:717` "create should be atomic under interruption at every checkpoint" (interrupt at `forked` and `registered`; stats empty, perOwner empty, `tasks/list` empty, roots settle, body never started), `:762` "survive a 200-iteration interruption race with no residue"; `TaskTransportGuardTest` `:143` "notifications/cancelled racing a task-augmented legacy call leaves no task behind" (the finding's own repro through `McpRouter.dispatch`: response `None`, stats empty, inflight empty), `:268` "session.terminate racing a task-augmented legacy call leaves no task behind", `:212` "session.terminate releases the session's legacy tasks" (bystander untouched, second terminate no-op), `:253` "a finalizer registered after terminate runs immediately instead of being parked".

**F11.2 — every retained entry has a guaranteed eviction path independent of the creating request; an entry whose create never completed is still swept after its TTL and stops counting** — met
- `TaskManager.scala:332` expiry fixed before insertion; `:339` single `storeRef.modify(admit(...))`; `:344` `startSweeperFiber` inside the mask; `:348-352` a create whose entry was swept while held fails with `TaskNotFoundError` instead of returning a dead handle.
- Tests: `TaskManagerSpec` `:798` "still sweep an entry whose create is held past its TTL and stop counting it" (create parked 400 ms at `registered`, ttl 100 ms, `maxConcurrent = 1`: polled stats reach 0, `sweeperActive` false, next create admitted, held create fails `TaskNotFoundError`); `LifecycleSoakTest` `:114` "expired task TTLs interrupt running work and sweep the entries" (real streamable routes, 10 tasks ttl 300 ms -> `-32602 Unknown task`).

## Tests

- `jvm/test/src/.../server/manager/TaskManagerSpec.scala` (+558 lines, 33 tests): stored-cap eviction x5 incl. self-first and grace-aware pool victims, "nothing evictable" rejections, `-32003` mapping, retention grace, sweeper singleton / drain-restart / shutdown, `releaseScope`, per-client bearer buckets, pool ceiling vs per-owner cap, legacy flood cannot block bearer, `ownerKeyFor` policy, checkpointed interruption atomicity, 200-iteration race, held-create TTL sweep, `TaskSettings` guards.
- `jvm/test/src/.../server/TaskTransportGuardTest.scala` (+295 lines, 8 tests): distinct `clientKey` buckets, legacy pool ceiling vs bearer, `notifications/cancelled` race, `terminate` releases tasks, late finalizer runs immediately, `terminate` racing a create.
- `jvm/test/src/.../server/transport/TaskHttpTransportTest.scala` (+83 lines, 17 tests): `maxStoredPerOwner` loop over real streamable HTTP routes, `-32003` across sessions; POST helpers now send `Content-Type: application/json` and `Accept: application/json, text/event-stream` so the 415/406 gates in #91 need no test edits here.
- `jvm/test/src/.../server/transport/LifecycleSoakTest.scala` (+52 lines, 3 tests): "N terminal tasks leave no sleeping eviction fibers behind"; same header change to the POST helper.
- All interruption tests poll (`awaitStats`) rather than sleep a fixed interval; timing-sensitive suites were re-run 4x consecutively, all green.

## Verification

Run on this branch in isolation (final tree, HEAD `39bcaa3`), from the implementation report; CI results are not claimed here.

- `rm -rf out/fast-mcp-scala && ./mill fast-mcp-scala.compile` — 168/168 SUCCESS (JVM + Scala.js + Scala Native); only pre-existing warnings, none in the touched files.
- `./mill fast-mcp-scala.reformat && ./mill fast-mcp-scala.checkFormat` — 16/16, "Everything is formatted already"; the four owned test files were formatted with the scalafmt 3.8.3 CLI (the mill aggregate does not cover test sources).
- `./mill fast-mcp-scala.jvm.test.testOnly` TaskManagerSpec / TaskTransportGuardTest / TaskHttpTransportTest / LifecycleSoakTest — 33 / 8 / 17 / 3, 0 failed, 4 consecutive runs.
- `./mill fast-mcp-scala.jvm.test.testOnly` Protocol20260728Test / ConformanceGapsTest / McpErrorMappingTest / StdioLoopLifecycleTest — 12 / 12 / 8 / 2, 0 failed (modern tasks path, legacy gates, error-code mapping, stdio lifecycle unchanged).
- `./mill fast-mcp-scala.test` — 532/532 SUCCESS in 66 s (all JVM suites, Bun conformance incl. stateful/stateless tasks cases, Scala Native link + tests).
- `scripts/conformance.sh jvm` and `scripts/conformance.sh js` — 73 passed / 0 failed each across all 42 scenarios; "Baseline check passed" against the EMPTY `conformance/baseline-{jvm,js}.yml`.
- `git diff --name-only` — exactly the 10 files listed above; working tree clean.

## Residual risk / follow-ups

Documented residuals (from the arc report and the independent verifier):

- **F9 out of the box on this branch**: until #92 populates `Session.clientKey` at the two modern `Session.make` sites, `TaskOwnerKey.Transport` yields `None` and all modern clients share the anonymous bucket — bounded, not isolated. Operators can close it today with `TaskOwnerKey.Custom`.
- **Reverse proxies**: with `TaskOwnerKey.Transport` every client arrives from the proxy address and collapses into one bucket; nothing warns at runtime. Configure `TaskOwnerKey.Custom` from an authenticated principal.
- **Multi-address attacker**: ~16 distinct peer addresses (`maxConcurrentTotal / maxConcurrentPerSession`) can hold the bearer pool at its running ceiling, or ~137 fast task calls/s can keep all 4096 stored entries inside the 30 s grace, so other modern clients get `-32003` until traffic stops. Per-client isolation holds; this is the accepted global-ceiling trade-off. The verifier flagged it as undocumented in the scaladoc/CHANGELOG (docs land in #92).
- **Legacy pool**: session minting is unbounded at this layer (the session cap arrives in #91); >= 16 sessions can fill the legacy running ceiling. By design this cannot touch the bearer pool and self-heals when traffic stops.
- **Pool-cap eviction victim**: an owner holding the most stale (> 30 s) uncollected results can have those — and only those — evicted by other owners' admissions. Running tasks and results inside the grace are never affected.
- **F11 window**: an interrupt landing in `McpRouter`'s continuation after the (now uninterruptible) task branch yields an interrupted exit with a fully registered, TTL-scheduled task whose id is never returned. Not a zombie: the sweeper evicts it, legacy ones are listable and released on `Session.terminate`, and it counts only against the attacker's own owner bucket. Rollback also does not undo up to two already-stale cap evictions performed by the same `admit()` in that microsecond window.
- **Sweeper supervision** (verifier, minor): `sweepLoop` has no reachable defect today but is unsupervised; if a future edit made it die, `sweeperActive` would stay true and TTL expiry would stop while size bounds still hold. Follow-up: `catchAllCause` + reset, plus a kill-and-reclaim test.
- **`maxConcurrentTotal >= maxConcurrentPerSession`** (verifier, minor): equal values are accepted, at which point one client fills the pool (as `-32003`). Follow-up: require `>` or reword the scaladoc.
- `TaskSettings.defaultTtlMs` / `maxTtlMs` / `pollIntervalMs` (pre-existing) still have no `require` guards.
- Eviction scans are O(pool entries) but only run when a cap is hit; a per-owner stale index is a follow-up if profiling shows contention.

Deferred to #92 (needs symbols from #91 / #90): `clientKey = <peer address>` at the modern `Session.make` sites and `outbound.shutdown` -> `terminate` for DELETE / idle eviction / cap eviction in `JvmHttpBackend` and `JsTransportBackend`; `McpServer` keeping the `TaskManager` and calling `shutdown` on serve-loop exit; `Builtins.resourcesSubscribe` using `Session.subscriptionCount` for `maxSubscriptionsPerSession`; `TaskRouting`'s three `fields.toMap` lookups switching to `JsonFields.get`; CHANGELOG / README / CLAUDE.md / SECURITY.md / docs/tasks.md updates; a Bun-side two-peer bucket test (verifier: currently only the JVM half exists).

## Stack & merge order

1. #87 `tjc-2299-ci-supply-chain` -> `main` (TJC-2299, CI supply chain: F6, F7)
2. #88 `tjc-2298-macro-overload-binding` -> `tjc-2299-ci-supply-chain` (TJC-2298, macros: F4)
3. **#89 `tjc-2297-tasks-hardening` -> `tjc-2298-macro-overload-binding` (TJC-2297, tasks: F8, F9, F11) — this PR**
4. #90 `tjc-2295-core-input-limits` -> `tjc-2297-tasks-hardening` (TJC-2295, core input limits: F1, F2, F3)
5. #91 `tjc-2296-http-transport-hardening` -> `tjc-2295-core-input-limits` (TJC-2296, HTTP transports: F1, F5, F10, F12)
6. #92 `tjc-2294-security-hardening` -> `tjc-2296-http-transport-hardening` (TJC-2294, cross-arc integration + docs)

Review and merge bottom-up. Merge each PR with a **merge commit, not squash** — squashing the bottom of a stack orphans the PRs above it (see TJC-2114). After each merge, retarget the next PR to `main` (GitHub does this automatically when the base branch is deleted). The stack tip is byte-identical to a fully verified integrated tree: 532/532 Mill test tasks incl. JVM, Bun and Scala Native suites; official MCP conformance 73/73 checks on both JVM and Bun with empty baselines; scalafmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
