### PR TITLE
Bound inbound frames, regex-free URI templates, AST-path argument decoding (TJC-2295)

### DIFF
--- a/fast-mcp-scala/js/src/com/tjclp/fastmcp/server/transport/JsTransportBackend.scala
+++ b/fast-mcp-scala/js/src/com/tjclp/fastmcp/server/transport/JsTransportBackend.scala
@@ -188,7 +188,7 @@ object JsTransportBackend extends TransportBackend with HttpTransportBackend:
     methodOf(req) match
       case "POST" =>
         readBody(req).flatMap { body =>
-          MessageLoop.parseFrame(body) match
+          MessageLoop.parseFrame(body, router.limits) match
             case Left(parseFailure) =>
               ZIO.succeed(jsonResponse(parseFailure.toJson, Map.empty, status = 400))
             case Right(message) =>
@@ -219,7 +219,7 @@ object JsTransportBackend extends TransportBackend with HttpTransportBackend:
         readBody(req).flatMap { body =>
           // Parse BEFORE touching the session store: a malformed or non-initialize body must
           // never mint a durable session (JVM transport does the same).
-          MessageLoop.parseFrame(body) match
+          MessageLoop.parseFrame(body, router.limits) match
             case Left(parseFailure) =>
               ZIO.succeed(jsonResponse(parseFailure.toJson, Map.empty, status = 400))
             case Right(message) =>

--- a/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/codec/FromJsonAstDecodeTest.scala
+++ b/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/codec/FromJsonAstDecodeTest.scala
@@ -1,0 +1,67 @@
+package com.tjclp.fastmcp
+package codec
+
+import org.scalatest.funsuite.AnyFunSuite
+import zio.json.*
+import zio.json.ast.Json
+
+import com.tjclp.fastmcp.core.McpDecoder
+import com.tjclp.fastmcp.server.manager.ResourceTemplatePattern
+
+/** The AST decode path and the embedded-JSON bounds on the JS engine (TJC-2295 / F3), plus a
+  * regex-free spot check of the template matcher on JavaScriptCore (F2).
+  */
+class FromJsonAstDecodeTest extends AnyFunSuite:
+
+  import McpDecoders.given
+
+  case class Add(a: Int, b: Int) derives JsonDecoder
+
+  /** No explicit JsonDecoder: goes through the INLINE `derivedZioJsonDecoder` given, which splices
+    * `DefaultDecodeContext.decodeRaw` into this compilation unit.
+    */
+  case class Point(x: Int, y: Int)
+
+  private val ctx = DefaultDecodeContext.default
+
+  private def now(): Double = scala.scalajs.js.Dynamic.global.performance.now().asInstanceOf[Double]
+
+  test("McpDecoder decodes a Map of wire Json values (the AST path) on JS") {
+    assert(McpDecoder[Add].decode("add", Map("a" -> Json.Num(2), "b" -> Json.Num(3)), ctx) == Add(2, 3))
+    assert(McpDecoder[Point].decode("p", Map("x" -> Json.Num(1), "y" -> Json.Num(-1)), ctx) == Point(1, -1))
+    assert(McpDecoder[Add].decode("add", Json.Obj("a" -> Json.Num(5), "b" -> Json.Num(6)), ctx) == Add(5, 6))
+  }
+
+  test("a 64-deep Json argument decodes or fails with a RuntimeException — never a RangeError") {
+    val deep = (1 to 64).foldLeft(Json.Null: Json)((acc, _) => Json.Arr(acc))
+    val outcome =
+      try Right(McpDecoder[Add].decode("add", Map("a" -> deep, "b" -> Json.Num(1)), ctx))
+      catch case e: RuntimeException => Left(e)
+    assert(outcome.isLeft, "a nested array is not an Int")
+    assert(outcome.swap.toOption.exists(_.getMessage.contains("Failed to decode parameter 'add'")))
+  }
+
+  test("parseJsonArray bounds embedded JSON depth") {
+    val ex = intercept[IllegalArgumentException](ctx.parseJsonArray("blob", "[" * 300 + "]" * 300))
+    assert(ex.getMessage.contains("maxDepth"))
+    assert(ctx.parseJsonArray("blob", "[[1]]") == List(List(1)))
+  }
+
+  test("ResourceTemplatePattern is regex-free and linear on the JS engine") {
+    assert(
+      ResourceTemplatePattern("x://{name}.{ext}").matches("x://archive.tar.gz") ==
+        Some(Map("name" -> "archive.tar", "ext" -> "gz"))
+    )
+    val pattern = ResourceTemplatePattern("x://{a}-{b}")
+    val _ = pattern.matches("x://aaa") // warm-up
+    val uri = "x://" + "a" * 100_000
+    val start = now()
+    val result = pattern.matches(uri)
+    val elapsed = now() - start
+    assert(result.isEmpty)
+    assert(elapsed < 100.0, s"took $elapsed ms")
+    val three = ResourceTemplatePattern("x://{a}.{b}.{c}")
+    val start2 = now()
+    assert(three.matches("x://" + "a" * 99_999 + ".").isEmpty)
+    assert(now() - start2 < 100.0)
+  }

--- a/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerLimitsTest.scala
+++ b/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerLimitsTest.scala
@@ -1,0 +1,183 @@
+package com.tjclp.fastmcp
+package conformance
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.scalajs.js
+
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import zio.*
+import zio.json.*
+
+import com.tjclp.fastmcp.core.*
+import com.tjclp.fastmcp.server.LimitSettings
+import com.tjclp.fastmcp.server.transport.{startStatefulHttp, startStatelessHttp}
+
+/** The inbound input limits over the Bun HTTP listener (TJC-2295 / F1 on the single-threaded
+  * runtime the finding targets). Servers run LOWERED `LimitSettings` with bodies of a few KB, so the
+  * assertions are independent of the transport body cap. Bun is single-threaded, so the wall-clock
+  * round trip of a rejected frame is the meaningful property — measured with `performance.now()`.
+  */
+class JsServerLimitsTest extends AsyncFlatSpec with Matchers:
+
+  override implicit val executionContext: ExecutionContext = ExecutionContext.global
+
+  case class BatchArgs(items: List[Map[String, Int]])
+  given JsonDecoder[BatchArgs] = DeriveJsonDecoder.gen[BatchArgs]
+
+  private val batchSchema = ToolInputSchema.unsafeFromJsonString(
+    """{"type":"object","properties":{"items":{"type":"array","items":{"type":"object","additionalProperties":{"type":"integer"}}}},"required":["items"]}"""
+  )
+
+  private val batchTool = McpTool.withSchema[BatchArgs, Int, Any](
+    name = "batch",
+    description = Some("counts objects"),
+    inputSchema = batchSchema
+  )(args => args.items.size)
+
+  private val limits = LimitSettings(maxObjectFields = 64, maxDepth = 16)
+
+  private def runZio[A](effect: ZIO[Any, Throwable, A]): Future[A] =
+    val promise = Promise[A]()
+    Unsafe.unsafe { implicit unsafe =>
+      Runtime.default.unsafe.runToFuture(effect).onComplete {
+        case scala.util.Success(a) => val _ = promise.trySuccess(a)
+        case scala.util.Failure(e) => val _ = promise.tryFailure(e)
+      }
+    }
+    promise.future
+
+  private def fromJsPromise[A](p: js.Promise[A]): Future[A] =
+    val promise = Promise[A]()
+    val _ = p.`then`[Unit](
+      (value: A) => { val _ = promise.trySuccess(value); () },
+      (err: scala.Any) =>
+        val t = err match
+          case th: Throwable => th
+          case other => new RuntimeException(String.valueOf(other))
+        val _ = promise.tryFailure(t)
+        ()
+    )
+    promise.future
+
+  private def now(): Double = js.Dynamic.global.performance.now().asInstanceOf[Double]
+
+  private def post(port: Int, body: String): Future[js.Dynamic] =
+    val init = js.Dynamic.literal(
+      method = "POST",
+      headers = js.Dictionary(
+        "content-type" -> "application/json",
+        "accept" -> "application/json, text/event-stream"
+      ),
+      body = body
+    )
+    fromJsPromise(
+      js.Dynamic.global.fetch(s"http://127.0.0.1:$port/mcp", init).asInstanceOf[js.Promise[js.Dynamic]]
+    )
+
+  private def textOf(resp: js.Dynamic): Future[String] =
+    fromJsPromise(resp.text().asInstanceOf[js.Promise[String]])
+
+  private def collidingKeys(blocks: Int): IndexedSeq[String] =
+    val parts = Array("Aa", "BB", "C#")
+    (0 until math.pow(3, blocks).toInt).map { k =>
+      val sb = new StringBuilder
+      var rest = k
+      var b = 0
+      while b < blocks do
+        sb.append(parts(rest % 3))
+        rest /= 3
+        b += 1
+      sb.result()
+    }
+
+  private def collidingObject(keys: IndexedSeq[String]): String =
+    keys.map(k => s""""$k":0""").mkString("{", ",", "}")
+
+  private val initBody =
+    """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"1.0"}}}"""
+  private val pingBody = """{"jsonrpc":"2.0","id":2,"method":"ping"}"""
+  private val collidingBody =
+    s"""{"jsonrpc":"2.0","id":3,"method":"ping","params":${collidingObject(collidingKeys(5))}}"""
+  private val deepBody =
+    s"""{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"batch","arguments":{"items":${"[" * 20}1${"]" * 20}}}}"""
+
+  private def withServer(port: Int, stateless: Boolean)(body: Int => Future[Assertion]): Future[Assertion] =
+    val server = com.tjclp.fastmcp.server.McpServer(
+      s"JsLimits$port",
+      "0.1.0",
+      McpServerSettings(host = "127.0.0.1", port = port, httpEndpoint = "/mcp", stateless = stateless, limits = limits)
+    )
+    runZio(server.tool(batchTool).unit).flatMap { _ =>
+      val handle = if stateless then server.startStatelessHttp() else server.startStatefulHttp()
+      body(port).andThen { case _ => handle.stop() }
+    }
+
+  "Bun HTTP limits (stateless)" should "reject a 243-colliding-key body with 400/-32700 in < 200 ms, then serve normally" in {
+    withServer(38931, stateless = true) { port =>
+      for
+        _ <- post(port, pingBody) // warm-up
+        start = now()
+        bad <- post(port, collidingBody)
+        badText <- textOf(bad)
+        elapsed = now() - start
+        deep <- post(port, deepBody)
+        deepText <- textOf(deep)
+        init <- post(port, initBody)
+        initText <- textOf(init)
+        ping <- post(port, pingBody)
+        pingText <- textOf(ping)
+      yield
+        bad.status.asInstanceOf[Int] shouldBe 400
+        badText should include("-32700")
+        badText should include("maxObjectFields")
+        elapsed should be < 200.0
+        deep.status.asInstanceOf[Int] shouldBe 400
+        deepText should include("-32700")
+        deepText should include("maxDepth")
+        deepText should not include "RangeError"
+        init.status.asInstanceOf[Int] shouldBe 200
+        initText should include("serverInfo")
+        ping.status.asInstanceOf[Int] shouldBe 200
+        pingText should include(""""result":{}""")
+    }
+  }
+
+  it should "answer a within-limits worst case (20 × 64 colliding keys) normally in < 500 ms" in {
+    withServer(38933, stateless = true) { port =>
+      val obj = collidingObject(collidingKeys(4).take(64))
+      val body =
+        s"""{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"batch","arguments":{"items":[${List.fill(20)(obj).mkString(",")}]}}}"""
+      for
+        _ <- post(port, pingBody)
+        start = now()
+        resp <- post(port, body)
+        text <- textOf(resp)
+        elapsed = now() - start
+      yield
+        resp.status.asInstanceOf[Int] shouldBe 200
+        text should include("\"20\"")
+        elapsed should be < 500.0
+    }
+  }
+
+  "Bun HTTP limits (stateful)" should "reject a limit-violating POST with 400 and no mcp-session-id" in {
+    withServer(38932, stateless = false) { port =>
+      for
+        bad <- post(port, collidingBody)
+        badText <- textOf(bad)
+        deep <- post(port, deepBody)
+        init <- post(port, initBody)
+      yield
+        bad.status.asInstanceOf[Int] shouldBe 400
+        badText should include("maxObjectFields")
+        Option(bad.headers.get("mcp-session-id").asInstanceOf[String]) shouldBe None
+        deep.status.asInstanceOf[Int] shouldBe 400
+        Option(deep.headers.get("mcp-session-id").asInstanceOf[String]) shouldBe None
+        init.status.asInstanceOf[Int] shouldBe 200
+        Option(init.headers.get("mcp-session-id").asInstanceOf[String]) shouldBe defined
+    }
+  }

--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/transport/JvmHttpBackend.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/transport/JvmHttpBackend.scala
@@ -183,7 +183,7 @@ object JvmHttpBackend extends HttpTransportBackend:
         body <- request.body.asString.mapError(e =>
           Option(e.getMessage).getOrElse("body read error")
         )
-        resp <- MessageLoop.parseFrame(body) match
+        resp <- MessageLoop.parseFrame(body, router.limits) match
           case Left(parseFailure) =>
             ZIO.succeed(Response.json(parseFailure.toJson).status(Status.BadRequest))
           case Right(message) =>
@@ -264,7 +264,7 @@ object JvmHttpBackend extends HttpTransportBackend:
       case Right(body) =>
         // Parse BEFORE touching the session store: a malformed or non-initialize body must never
         // mint a durable session (it used to — an unauthenticated memory leak).
-        MessageLoop.parseFrame(body) match
+        MessageLoop.parseFrame(body, router.limits) match
           case Left(parseFailure) =>
             ZIO.succeed(Response.json(parseFailure.toJson).status(Status.BadRequest))
           case Right(message) =>

--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/transport/JvmTransportBackend.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/transport/JvmTransportBackend.scala
@@ -34,8 +34,7 @@ object JvmTransportBackend extends TransportBackend:
         .fromInputStream(java.lang.System.in)
         .via(ZPipeline.utf8Decode)
         .via(BoundedLines.pipeline(router.limits.maxFrameChars))
-        .map(_.trim)
-        .filter(_.nonEmpty)
+        .filter(MessageLoop.shouldDispatchStdioFrame(_, router.limits))
     )
 
   /** The JVM platform seam, in the impl object so it's exportable (givens can't be wildcard-

--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/transport/JvmTransportBackend.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/transport/JvmTransportBackend.scala
@@ -33,7 +33,7 @@ object JvmTransportBackend extends TransportBackend:
       ZStream
         .fromInputStream(java.lang.System.in)
         .via(ZPipeline.utf8Decode)
-        .via(ZPipeline.splitLines)
+        .via(BoundedLines.pipeline(router.limits.maxFrameChars))
         .map(_.trim)
         .filter(_.nonEmpty)
     )

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/codec/DecodePathTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/codec/DecodePathTest.scala
@@ -126,11 +126,12 @@ class DecodePathTest extends AnyFunSuite with Matchers:
     val ex = intercept[IllegalArgumentException](ctx.parseJsonArray("blob", deep300))
     ex.getMessage should include("maxDepth")
 
-    // Far past what the parser itself can take: zio-json's guarded parser fails first (Left →
-    // RuntimeException). Either way the test JVM is still here — no StackOverflowError escaped.
+    // Far past what the parser itself can take: the linear pre-scan rejects the text before
+    // zio-json's recursive parser ever runs (so this is safe on Scala Native too, where a parser
+    // stack overflow would not be catchable).
     val deep50k = "[" * 50_000 + "]" * 50_000
-    val ex2 = intercept[RuntimeException](ctx.parseJsonArray("blob", deep50k))
-    ex2 should not be a[java.lang.Error]
+    val ex2 = intercept[IllegalArgumentException](ctx.parseJsonArray("blob", deep50k))
+    ex2.getMessage should include("maxDepth")
 
     val wide = (1 to 1100).map(i => s""""k$i":$i""").mkString("{", ",", "}")
     val ex3 = intercept[IllegalArgumentException](ctx.parseJsonObject("blob", wide))

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/codec/DecodePathTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/codec/DecodePathTest.scala
@@ -1,0 +1,181 @@
+package com.tjclp.fastmcp
+package codec
+
+import scala.reflect.ClassTag
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import zio.*
+import zio.json.*
+import zio.json.ast.Json
+
+import com.tjclp.fastmcp.core.{McpDecodeContext, McpDecoder, ResourceArgument}
+import com.tjclp.fastmcp.jsonrpc.McpError
+import com.tjclp.fastmcp.macros.MapToFunctionMacro
+import com.tjclp.fastmcp.server.*
+import com.tjclp.fastmcp.server.router.Session
+import com.tjclp.fastmcp.server.transport.JvmTransportBackend.given
+import com.tjclp.fastmcp.server.transport.MessageLoop
+
+/** The argument decode path after TJC-2295 / F3: wire `Json` nodes decode through zio-json's
+  * guarded `fromJsonAST` (no unguarded recursive re-encode), `writeValueAsString` converts a
+  * StackOverflowError into an IllegalArgumentException, and JSON embedded in string arguments is
+  * depth/width-bounded before any recursive walk. Every deep input here is built programmatically
+  * so the frame-level limits are bypassed — this is the second line of defence under test.
+  */
+class DecodePathTest extends AnyFunSuite with Matchers:
+
+  import McpDecoders.given
+
+  private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
+    Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(effect).getOrThrowFiberFailure())
+
+  case class Add(a: Int, b: Int) derives JsonDecoder
+  case class Profile(name: String, age: Int) derives JsonDecoder
+  case class User(id: String, profile: Profile) derives JsonDecoder
+  case class NoArgs()
+  case class Wrapped(x: Json) derives JsonDecoder
+
+  private val ctx = DefaultDecodeContext.default
+
+  private def deepArray(depth: Int): Json =
+    (1 to depth).foldLeft(Json.Null: Json)((acc, _) => Json.Arr(acc))
+
+  // ---- fromJsonAST path ----
+
+  test("McpDecoder decodes a Map of wire Json nodes straight from the AST") {
+    McpDecoder[Add].decode("add", Map("a" -> Json.Num(2), "b" -> Json.Num(3)), ctx) shouldBe Add(2, 3)
+    McpDecoder[User].decode(
+      "user",
+      Map("id" -> Json.Str("u1"), "profile" -> Json.Obj("name" -> Json.Str("Ada"), "age" -> Json.Num(36))),
+      ctx
+    ) shouldBe User("u1", Profile("Ada", 36))
+    // Mirror-derived fallback (no explicit JsonDecoder) — the inline given.
+    McpDecoder[NoArgs].decode("t", Map.empty[String, Any], ctx) shouldBe NoArgs()
+    // Raw Scala values still work (toJsonAst coerces them).
+    McpDecoder[Add].decode("add", Map("a" -> 2, "b" -> 3), ctx) shouldBe Add(2, 3)
+  }
+
+  test("macro-generated per-parameter decoders handle Option/List/Map from Json-valued maps") {
+    def f(a: Int, b: Option[String], c: List[Int], d: Map[String, Int]): String =
+      s"$a|${b.getOrElse("-")}|${c.sum}|${d.values.sum}"
+    val fn = MapToFunctionMacro.callByMap(f)
+    fn(
+      Map(
+        "a" -> Json.Num(1),
+        "b" -> Json.Str("x"),
+        "c" -> Json.Arr(Json.Num(1), Json.Num(2)),
+        "d" -> Json.Obj("k" -> Json.Num(3), "l" -> Json.Num(4))
+      )
+    ) shouldBe "1|x|3|7"
+    // Absent Option → None; JSON null → None.
+    fn(Map("a" -> Json.Num(1), "c" -> Json.Arr(), "d" -> Json.Obj())) shouldBe "1|-|0|0"
+    fn(Map("a" -> Json.Num(1), "b" -> Json.Null, "c" -> Json.Arr(), "d" -> Json.Obj())) shouldBe "1|-|0|0"
+  }
+
+  test("bad input keeps the documented error prefix and a truncated value preview") {
+    val ex = intercept[RuntimeException](
+      McpDecoder[Add].decode("add", Map("a" -> "not-a-number", "b" -> 3), ctx)
+    )
+    ex.getMessage should include("Failed to decode parameter 'add' from JSON:")
+    ex.getMessage should include("Value:")
+
+    val wide = Json.Obj("a" -> Json.Str("x" * 5000), "b" -> Json.Num(1))
+    val long = intercept[RuntimeException](McpDecoder[Add].decode("add", wide, ctx))
+    long.getMessage.length should be < 1200
+    long.getMessage should include("…")
+  }
+
+  test("a custom McpDecodeContext keeps the legacy writeValueAsString + decodeJson path") {
+    var calls = 0
+    val spy = new McpDecodeContext:
+      def convertValue[T: ClassTag](name: String, rawValue: Any): T = ctx.convertValue(name, rawValue)
+      def parseJsonArray(name: String, rawJson: String): List[Any] = ctx.parseJsonArray(name, rawJson)
+      def parseJsonObject(name: String, rawJson: String): Map[String, Any] =
+        ctx.parseJsonObject(name, rawJson)
+      def writeValueAsString(value: Any): String =
+        calls += 1
+        ctx.writeValueAsString(value)
+    McpDecoder[Add].decode("add", Map("a" -> 1, "b" -> 2), spy) shouldBe Add(1, 2)
+    calls shouldBe 1
+  }
+
+  // ---- StackOverflowError never escapes ----
+
+  test("writeValueAsString on a 200 000-deep value throws IllegalArgumentException, not an Error") {
+    val deep = deepArray(200_000)
+    val ex = intercept[IllegalArgumentException](ctx.writeValueAsString(deep))
+    ex.getMessage should include("nested too deeply")
+  }
+
+  test("decoding a deep raw value through McpDecoder never lets a java.lang.Error out") {
+    val deep = deepArray(200_000)
+    // NoArgs ignores the extra field: no recursion into the value at all.
+    McpDecoder[NoArgs].decode("t", Map("x" -> deep), ctx) shouldBe NoArgs()
+    // Wrapped[x: Json] would re-encode/decode the value on the legacy path; now guarded either way.
+    val outcome =
+      try Right(McpDecoder[Wrapped].decode("t", Map("x" -> deep), ctx))
+      catch case e: RuntimeException => Left(e)
+    outcome.isRight || outcome.isLeft shouldBe true // no java.lang.Error reached this line
+  }
+
+  // ---- embedded JSON strings ----
+
+  test("parseJsonArray / parseJsonObject bound the depth and width of embedded JSON") {
+    val deep300 = "[" * 300 + "]" * 300
+    val ex = intercept[IllegalArgumentException](ctx.parseJsonArray("blob", deep300))
+    ex.getMessage should include("maxDepth")
+
+    // Far past what the parser itself can take: zio-json's guarded parser fails first (Left →
+    // RuntimeException). Either way the test JVM is still here — no StackOverflowError escaped.
+    val deep50k = "[" * 50_000 + "]" * 50_000
+    val ex2 = intercept[RuntimeException](ctx.parseJsonArray("blob", deep50k))
+    ex2 should not be a[java.lang.Error]
+
+    val wide = (1 to 1100).map(i => s""""k$i":$i""").mkString("{", ",", "}")
+    val ex3 = intercept[IllegalArgumentException](ctx.parseJsonObject("blob", wide))
+    ex3.getMessage should include("maxObjectFields")
+
+    val four = new DefaultDecodeContext(maxDepth = 4)
+    four.parseJsonArray("blob", "[[[[1]]]]") shouldBe List(List(List(List(1))))
+    val ex4 = intercept[IllegalArgumentException](four.parseJsonArray("blob", "[[[[[1]]]]]"))
+    ex4.getMessage should include("maxDepth (4)")
+    // A custom decoder reaching the bypass through the public context API gets the same guard.
+    val custom = new McpDecoder[List[Any]]:
+      def decode(name: String, rawValue: Any, context: McpDecodeContext): List[Any] =
+        context.parseJsonArray(name, rawValue.toString)
+    val ex5 = intercept[IllegalArgumentException](custom.decode("blob", deep300, ctx))
+    ex5.getMessage should include("maxDepth")
+    McpError.fromThrowable(new IllegalArgumentException("x")).code shouldBe -32602
+  }
+
+  // ---- end to end ----
+
+  test("tools/call with 60-deep arguments gets a JSON-RPC reply and the JVM stays up") {
+    case class Args(x: Json) derives JsonDecoder
+    val server = McpServer("Deep", "0.1.0")
+    runUnsafe(
+      server.tool(McpTool[Args, String](name = "wrap", description = Some("wraps"))(_ => "ok")) *>
+        server.tool(McpTool[NoArgs, String](name = "noop", description = Some("no args"))(_ => "ok")) *>
+        server.resource(
+          McpTemplateResource[Args](
+            uriPattern = "d://{x}",
+            arguments = List(ResourceArgument("x", None, required = true))
+          )(_ => "r")
+        )
+    )
+    val router = runUnsafe(server.buildRouter)
+    val session = runUnsafe(Session.make("deep"))
+    val init =
+      """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"1.0"}}}"""
+    runUnsafe(MessageLoop.handleFrame(router, session, init)).getOrElse("") should include("serverInfo")
+
+    val deep = "[" * 60 + "1" + "]" * 60
+    List("wrap", "noop").zipWithIndex.foreach { (tool, i) =>
+      val frame =
+        s"""{"jsonrpc":"2.0","id":${10 + i},"method":"tools/call","params":{"name":"$tool","arguments":{"x":$deep}}}"""
+      val reply = runUnsafe(MessageLoop.handleFrame(router, session, frame)).getOrElse(fail("no reply"))
+      reply should include(s""""id":${10 + i}""")
+      (reply.contains("\"result\"") || reply.contains("-32602") || reply.contains("-32603")) shouldBe true
+    }
+  }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/ResourceUriLimitTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/ResourceUriLimitTest.scala
@@ -1,0 +1,124 @@
+package com.tjclp.fastmcp.server
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import zio.*
+import zio.json.*
+import zio.json.ast.Json
+
+import com.tjclp.fastmcp.{given, *}
+import com.tjclp.fastmcp.jsonrpc.{JsonRpcMessage, RequestId}
+import com.tjclp.fastmcp.server.router.{McpRouter, Session}
+import com.tjclp.fastmcp.server.transport.MessageLoop
+
+/** `limits.maxUriChars` (TJC-2295 / F2 criterion 2): over-long client URIs are refused with -32602
+  * on resources/read, subscribe and unsubscribe BEFORE the matcher, the handler or the session's
+  * subscription set is touched, and dropped from subscriptions/listen.
+  */
+class ResourceUriLimitTest extends AnyFunSuite with Matchers:
+
+  private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
+    Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(effect).getOrThrowFiberFailure())
+
+  case class AArgs(a: String)
+
+  private val initFrame =
+    """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"1.0"}}}"""
+
+  /** A router with template `x://{a}` whose handler counts invocations. */
+  private def fixture(limits: LimitSettings = LimitSettings()): (McpRouter[Any], Session, AtomicInteger) =
+    val counter = new AtomicInteger(0)
+    val server = McpServer(
+      "UriLimits",
+      "0.1.0",
+      McpServerSettings(resourcesSubscribe = true, limits = limits)
+    )
+    runUnsafe(
+      server.resource(
+        McpTemplateResource[AArgs](
+          uriPattern = "x://{a}",
+          arguments = List(ResourceArgument("a", None, required = true))
+        ) { args =>
+          counter.incrementAndGet()
+          s"body:${args.a}"
+        }
+      )
+    )
+    val router = runUnsafe(server.buildRouter)
+    val session = runUnsafe(Session.make("uri-limits"))
+    runUnsafe(MessageLoop.handleFrame(router, session, initFrame)).getOrElse("") should include(
+      "\"serverInfo\""
+    )
+    (router, session, counter)
+
+  private def call(router: McpRouter[Any], session: Session, id: Int, method: String, uri: String): String =
+    val frame = s"""{"jsonrpc":"2.0","id":$id,"method":"$method","params":{"uri":${Json.Str(uri).toJson}}}"""
+    runUnsafe(MessageLoop.handleFrame(router, session, frame)).getOrElse(fail("no reply"))
+
+  test("resources/read: a 9 000-char URI is -32602 (maxUriChars) and never reaches the handler") {
+    val (router, session, counter) = fixture()
+    val reply = call(router, session, 2, "resources/read", "x://" + "a" * 8_996)
+    reply should include("-32602")
+    reply should include("maxUriChars")
+    reply should include("resources/read")
+    counter.get() shouldBe 0
+
+    // Exactly at the bound (8 192 chars) the URI is matched and read normally.
+    val ok = call(router, session, 3, "resources/read", "x://" + "a" * 8_188)
+    ok should include("body:")
+    ok should not include "-32602"
+    counter.get() shouldBe 1
+  }
+
+  test("resources/subscribe and unsubscribe refuse over-long URIs before touching the session") {
+    val (router, session, _) = fixture()
+    val long = "x://" + "s" * 9_000
+    val sub = call(router, session, 4, "resources/subscribe", long)
+    sub should include("-32602")
+    sub should include("maxUriChars")
+    runUnsafe(session.isSubscribed(long)) shouldBe false
+
+    val unsub = call(router, session, 5, "resources/unsubscribe", long)
+    unsub should include("-32602")
+    unsub should include("maxUriChars")
+
+    // A normal subscribe still works.
+    call(router, session, 6, "resources/subscribe", "x://fine") should include(""""result":{}""")
+    runUnsafe(session.isSubscribed("x://fine")) shouldBe true
+  }
+
+  test("subscriptions/listen acknowledges without an over-long resourceSubscriptions entry") {
+    val (router, _, _) = fixture()
+    val session = runUnsafe(Session.make("modern-uri-limits"))
+    val long = "x://" + "z" * 9_000
+    val params =
+      s"""{"notifications":{"resourceSubscriptions":[${Json.Str(long).toJson},"x://ok"]},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}"""
+        .fromJson[Json]
+        .fold(error => fail(error), identity)
+    val request = JsonRpcMessage.Request(RequestId.StrId("listen-1"), "subscriptions/listen", Some(params))
+    val ack = runUnsafe(
+      for
+        fiber <- router.dispatch(session, request).fork
+        acknowledgement <- session.outbound.take
+        _ <- fiber.interrupt
+      yield acknowledgement
+    ).toJson
+    ack should include("notifications/subscriptions/acknowledged")
+    ack should not include ("z" * 100)
+  }
+
+  test("a custom maxUriChars is honoured exactly (16 accepted, 17 rejected)") {
+    val (router, session, counter) = fixture(LimitSettings(maxUriChars = 16))
+    val sixteen = "x://" + "a" * 12
+    val seventeen = "x://" + "a" * 13
+    sixteen.length shouldBe 16
+    seventeen.length shouldBe 17
+    call(router, session, 7, "resources/read", sixteen) should include("body:")
+    counter.get() shouldBe 1
+    val rejected = call(router, session, 8, "resources/read", seventeen)
+    rejected should include("-32602")
+    rejected should include("limits.maxUriChars (16 characters)")
+    counter.get() shouldBe 1
+  }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/manager/UriTemplateMatcherTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/manager/UriTemplateMatcherTest.scala
@@ -1,0 +1,256 @@
+package com.tjclp.fastmcp.server.manager
+
+import scala.util.Random
+import scala.util.matching.Regex
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import zio.*
+
+import com.tjclp.fastmcp.core.{ResourceArgument, ResourceDefinition}
+
+/** [[ResourceTemplatePattern]] (TJC-2295 / F2): semantics table, registration errors, the
+  * greedy-regex equivalence property, and the linear-time (ReDoS) guarantee — measured on inputs
+  * that reach the separator-binding loop and fail LATE, not on the segment-count short-circuit.
+  */
+class UriTemplateMatcherTest extends AnyFunSuite with Matchers:
+
+  private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
+    Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(effect).getOrThrowFiberFailure())
+
+  private def m(template: String, uri: String): Option[Map[String, String]] =
+    ResourceTemplatePattern(template).matches(uri)
+
+  private def timed[A](body: => A): (A, Long) =
+    val start = java.lang.System.nanoTime()
+    val result = body
+    (result, (java.lang.System.nanoTime() - start) / 1_000_000L)
+
+  // ---- semantics ----
+
+  test("single-placeholder and per-segment placeholders") {
+    m("users://{id}/profile", "users://123/profile") shouldBe Some(Map("id" -> "123"))
+    m("items://{cat}/{itemId}", "items://books/xyz-987") shouldBe Some(
+      Map("cat" -> "books", "itemId" -> "xyz-987")
+    )
+    m("repos://{owner-name}/{repo_name}", "repos://tjc-lp/fast_mcp") shouldBe Some(
+      Map("owner-name" -> "tjc-lp", "repo_name" -> "fast_mcp")
+    )
+    m("users://{id}/profile", "users://123/profile/extra") shouldBe None
+    m("users://{id}/profile", "users://123") shouldBe None
+  }
+
+  test("several placeholders in one segment bind separators to their last occurrence (greedy)") {
+    m("x://{a}-{b}", "x://1-2-3") shouldBe Some(Map("a" -> "1-2", "b" -> "3"))
+    m("x://{name}.{ext}", "x://archive.tar.gz") shouldBe Some(
+      Map("name" -> "archive.tar", "ext" -> "gz")
+    )
+    m("d://{y}-{m}-{d}", "d://2026-09-04") shouldBe Some(
+      Map("y" -> "2026", "m" -> "09", "d" -> "04")
+    )
+    m("x://v{n}.json", "x://v12.json") shouldBe Some(Map("n" -> "12"))
+    m("x://{a}.{b}.{c}", "x://a.b.c.d") shouldBe Some(Map("a" -> "a.b", "b" -> "c", "c" -> "d"))
+  }
+
+  test("variables must be non-empty") {
+    m("x://{a}-{b}", "x://-2") shouldBe None
+    m("x://{a}-{b}", "x://1-") shouldBe None
+    m("x://{a}-{b}", "x://-") shouldBe None
+    m("x://{a}", "x://") shouldBe None
+    m("x://v{n}.json", "x://v.json") shouldBe None
+  }
+
+  test("literal text is literal (no regex metacharacters)") {
+    m("f://{id}.txt", "f://1Xtxt") shouldBe None
+    m("f://{id}.txt", "f://1.txt") shouldBe Some(Map("id" -> "1"))
+    m("p://{id}(1)", "p://7(1)") shouldBe Some(Map("id" -> "7"))
+    m("p://{id}(1)", "p://71") shouldBe None
+    m("q://{id}$", "q://a$") shouldBe Some(Map("id" -> "a"))
+  }
+
+  test("a zero-placeholder template matches only itself") {
+    val p = ResourceTemplatePattern("static://exact/path")
+    p.isTemplate shouldBe false
+    p.matches("static://exact/path") shouldBe Some(Map.empty)
+    p.matches("static://exact/path2") shouldBe None
+    p.matches("static://exact") shouldBe None
+  }
+
+  test("equality is by pattern text") {
+    ResourceTemplatePattern("a://{x}") shouldBe ResourceTemplatePattern("a://{x}")
+    ResourceTemplatePattern("a://{x}").hashCode shouldBe ResourceTemplatePattern("a://{x}").hashCode
+    ResourceTemplatePattern("a://{x}") should not be ResourceTemplatePattern("a://{y}")
+    ResourceTemplatePattern("a://{x}").toString shouldBe "ResourceTemplatePattern(a://{x})"
+    ResourceTemplatePattern("a://{x}/{y}").paramNames shouldBe List("x", "y")
+  }
+
+  // ---- registration errors ----
+
+  test("invalid templates are rejected at parse time") {
+    ResourceTemplatePattern.parse("x://{a}{b}").isLeft shouldBe true
+    ResourceTemplatePattern.parse("x://{a}/{a}").isLeft shouldBe true
+    ResourceTemplatePattern.parse("x://{a").isLeft shouldBe true
+    ResourceTemplatePattern.parse("x://a}").isLeft shouldBe true
+    ResourceTemplatePattern.parse("x://{a/b}").isLeft shouldBe true
+    ResourceTemplatePattern.parse("x://{{a}}").isLeft shouldBe true
+    ResourceTemplatePattern.parse("x://{}").isLeft shouldBe true
+    ResourceTemplatePattern.parse("x://{a}-{b}").isRight shouldBe true
+    val _ = an[IllegalArgumentException] should be thrownBy ResourceTemplatePattern("x://{a}{b}")
+    ResourceTemplatePattern.parse("x://{a}{b}").left.toOption.get should include("adjacent")
+    ResourceTemplatePattern.parse("x://{a}/{a}").left.toOption.get should include("more than once")
+  }
+
+  test("ResourceManager.addTemplateResource surfaces an invalid template as ResourceRegistrationError") {
+    val rm = new ResourceManager[Any]
+    val ex = runUnsafe(
+      rm.addTemplateResource(
+        "x://{a}{b}",
+        _ => ZIO.succeed("nope"),
+        ResourceDefinition(
+          "x://{a}{b}",
+          None,
+          None,
+          isTemplate = true,
+          arguments = Some(
+            List(ResourceArgument("a", None, required = true), ResourceArgument("b", None, required = true))
+          )
+        )
+      ).either
+    ).swap.getOrElse(fail("registration unexpectedly succeeded"))
+    ex shouldBe a[ResourceRegistrationError]
+    ex.getMessage should include("Failed to register resource template")
+    Option(ex.getCause).map(_.getMessage).getOrElse("") should include("adjacent")
+    rm.listTemplateDefinitions() shouldBe Nil
+  }
+
+  // ---- greedy-regex equivalence ----
+
+  /** The former construction — `{name}` → `([^/]+)`, anchored — but with literals `Regex.quote`d. */
+  private def legacyMatcher(template: String): String => Option[Map[String, String]] =
+    val placeholder = """\{([^{}]+)\}""".r
+    val names = placeholder.findAllMatchIn(template).map(_.group(1)).toList
+    val sb = new StringBuilder("^")
+    var last = 0
+    placeholder.findAllMatchIn(template).foreach { mt =>
+      sb.append(Regex.quote(template.substring(last, mt.start))).append("([^/]+)")
+      last = mt.end
+    }
+    sb.append(Regex.quote(template.substring(last))).append("$")
+    val regex = new Regex(sb.result())
+    uri => regex.findFirstMatchIn(uri).map(mt => names.zipWithIndex.map((n, i) => n -> mt.group(i + 1)).toMap)
+
+  test("matches equals the former greedy regex (with quoted literals) on randomised inputs") {
+    val templates = List(
+      "x://{a}-{b}",
+      "x://{a}-{b}-{c}",
+      "x://{a}.{b}-{c}",
+      "x://{a}--{b}-{c}",
+      "x://v{n}.json",
+      "x://{a}aaab{b}",
+      "x://{a}/{b}.{c}",
+      "x://{a}b{c}"
+    )
+    val alphabet = Array('a', '-', '.', 'b')
+    val rnd = new Random(20260904L)
+    templates.foreach { template =>
+      val compiled = ResourceTemplatePattern(template)
+      val legacy = legacyMatcher(template)
+      var matched = 0
+      (1 to 2000).foreach { _ =>
+        val len = 1 + rnd.nextInt(12)
+        val tail = Array.fill(len)(alphabet(rnd.nextInt(alphabet.length))).mkString
+        val uri = "x://" + (if rnd.nextInt(8) == 0 then tail.replaceFirst("-", "/") else tail)
+        withClue(s"$template on '$uri'") {
+          compiled.matches(uri) shouldBe legacy(uri)
+        }
+        if compiled.matches(uri).isDefined then matched += 1
+      }
+      // Targeted inputs that random text rarely hits.
+      List("x://v1.json", "x://vaaa.json", "x://aaaab", "x://aaaabaaab", "x://aaaaba", "x://a/b.c").foreach { uri =>
+        withClue(s"$template on '$uri'") { compiled.matches(uri) shouldBe legacy(uri) }
+      }
+      withClue(s"$template never matched — property vacuous") {
+        (matched > 0 || template.contains("json") || template.contains("{a}/{b}")) shouldBe true
+      }
+    }
+  }
+
+  // ---- ReDoS / linearity ----
+
+  private def registerAll(rm: ResourceManager[Any], templates: List[String]): Unit =
+    templates.foreach { template =>
+      val names = ResourceTemplatePattern(template).paramNames
+      runUnsafe(
+        rm.addTemplateResource(
+          template,
+          params => ZIO.succeed(params.toString),
+          ResourceDefinition(
+            template,
+            None,
+            None,
+            isTemplate = true,
+            arguments = Some(names.map(n => ResourceArgument(n, None, required = true)))
+          )
+        )
+      )
+    }
+
+  test("100 KB adversarial URIs are matched in milliseconds, directly and through ResourceManager") {
+    val templates = List("x://{a}-{b}", "x://{a}.{b}.{c}", "x://{a}aaab{b}", "x://{id}/profile")
+    val rm = new ResourceManager[Any]
+    registerAll(rm, templates)
+    val aaa = "a" * 100_000
+
+    // Warm-up on a small input.
+    val _ = ResourceTemplatePattern("x://{a}-{b}").matches("x://aaa-b")
+
+    val cases: List[(String, String, Option[Map[String, String]])] = List(
+      // no separator anywhere: one full lastIndexOf scan
+      ("x://{a}-{b}", "x://" + aaa, None),
+      // separator only at index 0: idx < 1 → V1 empty → None
+      ("x://{a}-{b}", "x://-" + aaa, None),
+      // the finding's original input — segment-count short-circuit
+      ("x://{a}-{b}", "x://" + "a-" * 50_000 + "/", None),
+      // one separator, two needed: second lastIndexOf over the whole left window
+      ("x://{a}.{b}.{c}", "x://" + "a" * 99_999 + ".", None),
+      // matches — both windows exercised; last-occurrence binding
+      ("x://{a}.{b}.{c}", "x://" + "a." * 50_000 + "b", Some(Map("a" -> ("a." * 49_998 + "a"), "b" -> "a", "c" -> "b"))),
+      ("x://{a}.{b}.{c}", "x://" + "a." * 50_000 + "/", None),
+      // self-overlapping literal worst case
+      ("x://{a}aaab{b}", "x://" + aaa, None)
+    )
+
+    cases.foreach { (template, uri, expected) =>
+      val (direct, directMs) = timed(ResourceTemplatePattern(template).matches(uri))
+      withClue(s"$template direct") {
+        val _ = direct shouldBe expected
+        directMs should be < 100L
+      }
+    }
+
+    // Through the manager, every registered template is tried against each URI.
+    cases.foreach { (template, uri, expected) =>
+      val (found, ms) = timed(rm.findMatchingTemplate(uri))
+      withClue(s"$template via ResourceManager") {
+        ms should be < 100L
+        expected match
+          case Some(params) =>
+            found.map(_._1.pattern) shouldBe Some(template)
+            found.map(_._4) shouldBe Some(params)
+          case None => found shouldBe None
+      }
+    }
+  }
+
+  test("registered templates are compiled once (findMatchingTemplate uses the stored pattern)") {
+    val rm = new ResourceManager[Any]
+    registerAll(rm, List("x://{a}-{b}"))
+    val Some((pattern, definition, _, params)) = rm.findMatchingTemplate("x://1-2"): @unchecked
+    pattern.pattern shouldBe "x://{a}-{b}"
+    definition.uri shouldBe "x://{a}-{b}"
+    params shouldBe Map("a" -> "1", "b" -> "2")
+    rm.getTemplateResourceHandler("x://{a}-{b}") shouldBe defined
+    rm.listTemplateDefinitions().map(_.uri) shouldBe List("x://{a}-{b}")
+    rm.extractTemplateParams("x://{a}-{b}", "x://1-2") shouldBe Some(Map("a" -> "1", "b" -> "2"))
+    rm.extractTemplateParams("x://{a}{b}", "x://12") shouldBe None // invalid template → no match
+  }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/BoundedLinesTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/BoundedLinesTest.scala
@@ -71,3 +71,39 @@ class BoundedLinesTest extends AnyFunSuite with Matchers:
         err.message should include("maxFrameChars")
       case other => fail(s"unexpected $other")
   }
+
+  test("padded oversized stdio frames are rejected and the following line still parses") {
+    val limits = LimitSettings(maxFrameChars = 128)
+    val ping = """{"jsonrpc":"2.0","id":1,"method":"ping"}"""
+    val invalidLines = List(
+      ping + " " * 200 + "invalid discarded tail",
+      " " * 200 + ping,
+      " " * 200,
+      " " * (limits.maxFrameChars + 1)
+    )
+    invalidLines.foreach { invalid =>
+      // Exercise both a single chunk and a line split across several input chunks.
+      val input = invalid + "\r\n" + ping + "\n"
+      List(List(input), input.grouped(17).toList).foreach { chunks =>
+        val frames = split(limits.maxFrameChars, chunks*)
+          .filter(MessageLoop.shouldDispatchStdioFrame(_, limits))
+        frames.length shouldBe 2
+        MessageLoop.parseFrame(frames.head, limits) match
+          case Left(jsonrpc.JsonRpcMessage.Failure(None, err)) =>
+            err.code shouldBe -32700
+            err.message should include("maxFrameChars")
+          case other => fail(s"oversized stdio frame was accepted: $other")
+        MessageLoop.parseFrame(frames(1), limits).isRight shouldBe true
+      }
+    }
+  }
+
+  test("within-limit stdio padding is preserved and blank lines are ignored") {
+    val limits = LimitSettings(maxFrameChars = 128)
+    val ping = """{"jsonrpc":"2.0","id":1,"method":"ping"}"""
+    val padded = " " + ping + " " * (limits.maxFrameChars - ping.length - 1)
+    val frames = split(limits.maxFrameChars, " \t\r\n" + padded + "\r\n")
+      .filter(MessageLoop.shouldDispatchStdioFrame(_, limits))
+    frames shouldBe Chunk(padded)
+    MessageLoop.parseFrame(frames.head, limits).isRight shouldBe true
+  }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/BoundedLinesTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/BoundedLinesTest.scala
@@ -54,6 +54,14 @@ class BoundedLinesTest extends AnyFunSuite with Matchers:
     out.map(_.length) shouldBe Chunk(11)
   }
 
+  test("pipeline(Int.MaxValue) — the 'unbounded' configuration — passes lines through unchanged") {
+    // maxChars + 1 must not wrap to Int.MinValue (a negative cap threw IndexOutOfBounds on the
+    // first line and killed the stdio stream).
+    split(Int.MaxValue, "abc\ndef\n") shouldBe Chunk("abc", "def")
+    split(Int.MaxValue, "x" * 100_000 + "\r\n", "tail") shouldBe Chunk("x" * 100_000, "tail")
+    LimitSettings(maxFrameChars = Int.MaxValue).maxFrameChars shouldBe Int.MaxValue
+  }
+
   test("the truncated frame is rejected by parseFrame as maxFrameChars") {
     val frame = split(10, "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}\n").head
     frame.length shouldBe 11

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/BoundedLinesTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/BoundedLinesTest.scala
@@ -1,0 +1,65 @@
+package com.tjclp.fastmcp
+package server.transport
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import zio.*
+import zio.stream.*
+
+import com.tjclp.fastmcp.server.LimitSettings
+
+/** [[BoundedLines]] — `splitLines` parity plus the read-buffer cap that keeps a newline-less stdio
+  * peer from growing the accumulator without bound (the frame is truncated to `maxChars + 1` and
+  * `parseFrame` rejects it as FrameTooLong).
+  */
+class BoundedLinesTest extends AnyFunSuite with Matchers:
+
+  private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
+    Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(effect).getOrThrowFiberFailure())
+
+  private def split(maxChars: Int, chunks: String*): Chunk[String] =
+    runUnsafe(ZStream.fromIterable(chunks).via(BoundedLines.pipeline(maxChars)).runCollect)
+
+  test("splitLines parity: LF, CRLF, trailing partial line") {
+    split(100, "a\nbb\r\nccc") shouldBe Chunk("a", "bb", "ccc")
+    split(100, "a\nbb\r\nccc\n") shouldBe Chunk("a", "bb", "ccc")
+    split(100, "one", "\ntwo") shouldBe Chunk("one", "two")
+    split(100, "") shouldBe Chunk.empty
+    split(100, "\n\n") shouldBe Chunk("", "")
+  }
+
+  test("splitLines parity: CRLF split across chunks, lone CR is content") {
+    split(100, "a\r", "\nb") shouldBe Chunk("a", "b")
+    split(100, "a\rb\n") shouldBe Chunk("a\rb")
+    // Same shapes through the stock splitter, to pin parity.
+    def stock(chunks: String*) =
+      runUnsafe(ZStream.fromIterable(chunks).via(ZPipeline.splitLines).runCollect)
+    stock("a\r", "\nb") shouldBe Chunk("a", "b")
+    stock("a\rb\n") shouldBe Chunk("a\rb")
+    stock("a\nbb\r\nccc") shouldBe Chunk("a", "bb", "ccc")
+  }
+
+  test("an over-long line is truncated to maxChars + 1 and the next line arrives intact") {
+    val out = split(10, "x" * 1000 + "\nnext\n")
+    out shouldBe Chunk("x" * 11, "next")
+    // ... also when the long line is spread over many chunks and never terminated
+    val pieces = Seq.fill(50)("y" * 20) :+ "\nafter"
+    split(10, pieces*) shouldBe Chunk("y" * 11, "after")
+  }
+
+  test("50 MB without a newline is bounded to maxChars + 1 and emitted at end of stream") {
+    val chunk = "x" * (64 * 1024)
+    val stream = ZStream.repeatZIO(ZIO.succeed(chunk)).take(800) // 800 × 64 KiB = 50 MiB
+    val out = runUnsafe(stream.via(BoundedLines.pipeline(10)).runCollect)
+    out.map(_.length) shouldBe Chunk(11)
+  }
+
+  test("the truncated frame is rejected by parseFrame as maxFrameChars") {
+    val frame = split(10, "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}\n").head
+    frame.length shouldBe 11
+    MessageLoop.parseFrame(frame, LimitSettings(maxFrameChars = 10)) match
+      case Left(jsonrpc.JsonRpcMessage.Failure(None, err)) =>
+        err.code shouldBe -32700
+        err.message should include("maxFrameChars")
+      case other => fail(s"unexpected $other")
+  }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/JsonLimitsTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/JsonLimitsTest.scala
@@ -129,6 +129,29 @@ class JsonLimitsTest extends AnyFunSuite with Matchers:
     ms should be < 500L
   }
 
+  test("residual per-object cost at the default maxObjectFields is tracked (50 × 1024 colliding keys)") {
+    // Inside the limits nothing is rejected, so every Map sink after the choke point still pays
+    // O(maxObjectFields²) per colliding object. 50 objects × 1024 keys is a ~1 MB frame (the HTTP
+    // body cap); the bound here is loose (measured ≈ 0.2 s on JDK 25) — it pins the ORDER of the
+    // residual so a regression to the pre-fix quadratic-in-frame behaviour is caught.
+    val keys = collidingKeys(7).take(1024) // 2187 available, exactly maxObjectFields used
+    keys.size shouldBe 1024
+    val obj = collidingObject(keys)
+    val list = Seq.fill(50)(obj).mkString("[", ",", "]")
+    val frame =
+      s"""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"t","arguments":{"xs":$list}}}"""
+    val (parsed, parseMs) = timed(MessageLoop.parseFrame(frame))
+    val xs = parsed match
+      case Right(Request(_, _, Some(Json.Obj(params)))) =>
+        JsonFields.get(params, "arguments").flatMap(JsonFields.get(_, "xs")).getOrElse(fail("xs"))
+      case other => fail(s"unexpected $other")
+    parseMs should be < 1000L
+    val (decoded, decodeMs) = timed(JsonDecoder[List[Map[String, Int]]].fromJsonAST(xs))
+    decoded.map(_.size) shouldBe Right(50)
+    decoded.map(_.head.size) shouldBe Right(1024)
+    decodeMs should be < 3000L
+  }
+
   // ---- F3: depth ----
 
   test("100 000 nested arrays are rejected as maxDepth before the parser runs") {
@@ -232,6 +255,28 @@ class JsonLimitsTest extends AnyFunSuite with Matchers:
     JsonFields.get(Json.Str("not an object"), "a") shouldBe None
   }
 
+  test("numeric ids outside Long range are rejected, not silently wrapped") {
+    def idOf(id: String) = MessageLoop.parseFrame(s"""{"jsonrpc":"2.0","id":$id,"method":"ping"}""")
+    idOf("9223372036854775807") shouldBe Right(Request(RequestId.NumId(Long.MaxValue), "ping", None))
+    idOf("-9223372036854775808") shouldBe Right(
+      Request(RequestId.NumId(Long.MinValue), "ping", None)
+    )
+    idOf("1e3") shouldBe Right(Request(RequestId.NumId(1000L), "ping", None))
+    idOf("100e-2") shouldBe Right(Request(RequestId.NumId(1L), "ping", None))
+    idOf("0e99999999") shouldBe Right(Request(RequestId.NumId(0L), "ping", None))
+    // 1e30 used to become NumId(5076944270305263616); 1e999999999 became NumId(0).
+    Seq("9223372036854775808", "1e30", "1e19", "1e999999999", "1e2147483647", "1.5", "1e-2147483647")
+      .foreach { id =>
+        val (result, ms) = timed(idOf(id))
+        withClue(id) {
+          result match
+            case Right(Invalid(None, reason)) => reason should include("64-bit")
+            case other => fail(s"expected Invalid for id $id, got $other")
+          ms should be < 200L
+        }
+      }
+  }
+
   test("unknown top-level fields are tolerated and never materialised") {
     MessageLoop.parseFrame(
       """{"jsonrpc":"2.0","id":1,"method":"ping","extra":{"x":[1,2,3]},"more":true}"""
@@ -304,4 +349,9 @@ class JsonLimitsTest extends AnyFunSuite with Matchers:
     LimitSettings(maxDepth = LimitSettings.MaxSupportedDepth).maxDepth shouldBe 256
     LimitSettings().maxFrameChars shouldBe 4 * 1024 * 1024
     LimitSettings().maxObjectFields shouldBe 1024
+    // LimitSettings' literal defaults and the codec-level constants (DefaultDecodeContext's
+    // embedded-JSON bounds) must not drift apart.
+    LimitSettings().maxDepth shouldBe JsonLimits.DefaultMaxDepth
+    LimitSettings().maxObjectFields shouldBe JsonLimits.DefaultMaxObjectFields
+    LimitSettings.MaxSupportedDepth shouldBe JsonLimits.MaxSupportedDepth
   }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/JsonLimitsTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/JsonLimitsTest.scala
@@ -1,0 +1,307 @@
+package com.tjclp.fastmcp
+package server.transport
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import zio.*
+import zio.json.*
+import zio.json.ast.Json
+
+import com.tjclp.fastmcp.codec.JsonLimits
+import com.tjclp.fastmcp.jsonrpc.*
+import com.tjclp.fastmcp.jsonrpc.JsonRpcMessage.*
+import com.tjclp.fastmcp.server.*
+import com.tjclp.fastmcp.server.router.Session
+import com.tjclp.fastmcp.server.transport.JvmTransportBackend.given
+
+/** The inbound frame limits at the `MessageLoop.parseFrame` choke point (TJC-2295 / F1, F3): the
+  * hash-collision object bound, the depth bound, the frame-length bound, string-awareness of the
+  * pre-scan, exact boundaries, and the no-HashMap envelope decoder (last-wins duplicate keys, no
+  * error-body amplification). Transport-independent — these exercise the shared code every
+  * platform routes through.
+  */
+class JsonLimitsTest extends AnyFunSuite with Matchers:
+
+  private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
+    Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(effect).getOrThrowFiberFailure())
+
+  /** 3^blocks distinct keys of length 2·blocks that all share one `String.hashCode` — "Aa", "BB"
+    * and "C#" hash to 2112, and the polynomial hash is block-compositional.
+    */
+  private def collidingKeys(blocks: Int): IndexedSeq[String] =
+    val parts = Array("Aa", "BB", "C#")
+    val count = math.pow(3, blocks).toInt
+    (0 until count).map { k =>
+      val sb = new StringBuilder(2 * blocks)
+      var rest = k
+      var b = 0
+      while b < blocks do
+        sb.append(parts(rest % 3))
+        rest /= 3
+        b += 1
+      sb.result()
+    }
+
+  /** `{"jsonrpc":"2.0","id":1,"method":"ping",<keys>:0,…}` — the colliding object IS the envelope. */
+  private def collidingEnvelope(keys: IndexedSeq[String]): String =
+    val sb = new StringBuilder(keys.length * (keys.head.length + 6) + 64)
+    sb.append("""{"jsonrpc":"2.0","id":1,"method":"ping"""")
+    keys.foreach(k => sb.append(",\"").append(k).append("\":0"))
+    sb.append('}').result()
+
+  private def collidingObject(keys: IndexedSeq[String]): String =
+    val sb = new StringBuilder(keys.length * (keys.head.length + 6) + 2)
+    sb.append('{')
+    keys.zipWithIndex.foreach { (k, i) =>
+      if i > 0 then sb.append(',')
+      sb.append('"').append(k).append("\":0")
+    }
+    sb.append('}').result()
+
+  private def timed[A](body: => A): (A, Long) =
+    val start = java.lang.System.nanoTime()
+    val result = body
+    (result, (java.lang.System.nanoTime() - start) / 1_000_000L)
+
+  private def parseErrorMessage(result: Either[JsonRpcMessage, JsonRpcMessage]): String =
+    result match
+      case Left(Failure(None, err)) =>
+        err.code shouldBe -32700
+        err.message
+      case other => fail(s"expected a -32700 parse failure, got $other")
+
+  private val big = LimitSettings(maxFrameChars = 8 * 1024 * 1024)
+
+  // ---- F1: colliding keys ----
+
+  test("colliding keys share one hashCode (the attack premise holds on this JVM)") {
+    val keys = collidingKeys(5)
+    keys.map(_.hashCode).distinct.size shouldBe 1
+    keys.distinct.size shouldBe keys.size
+  }
+
+  test("2^15+ and 2^17+ colliding keys are rejected by the pre-scan in well under a second") {
+    val warm = collidingKeys(6)
+    val _ = MessageLoop.parseFrame(collidingEnvelope(warm), big) // warm-up
+
+    val k10 = collidingKeys(10) // 59 049 > 2^15
+    val k11 = collidingKeys(11) // 177 147 > 2^17
+    k10.size should be > (1 << 15)
+    k11.size should be > (1 << 17)
+
+    val (r10, ms10) = timed(MessageLoop.parseFrame(collidingEnvelope(k10), big))
+    parseErrorMessage(r10) should include("maxObjectFields")
+    ms10 should be < 200L
+
+    val (r11, ms11) = timed(MessageLoop.parseFrame(collidingEnvelope(k11), big))
+    parseErrorMessage(r11) should include("maxObjectFields")
+    ms11 should be < 200L
+  }
+
+  test("a colliding object nested under params.arguments is rejected too") {
+    val frame =
+      s"""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"t","arguments":${collidingObject(
+          collidingKeys(10)
+        )}}}"""
+    val (result, ms) = timed(MessageLoop.parseFrame(frame, big))
+    parseErrorMessage(result) should include("maxObjectFields")
+    ms should be < 200L
+  }
+
+  test("a colliding frame does not delay a concurrent ping on the same router") {
+    val server = McpServer("Limits", "0.1.0")
+    val router = runUnsafe(server.buildRouter)
+    val session = runUnsafe(Session.make("limits"))
+    val colliding = collidingEnvelope(collidingKeys(10)) // ~1.5 MB, inside the 4 MiB default
+    val ping = """{"jsonrpc":"2.0","id":7,"method":"ping"}"""
+    val _ = runUnsafe(MessageLoop.handleFrame(router, session, ping)) // warm-up
+
+    val ((bad, good), ms) = timed(
+      runUnsafe(
+        MessageLoop
+          .handleFrame(router, session, colliding)
+          .zipPar(MessageLoop.handleFrame(router, session, ping))
+      )
+    )
+    bad.getOrElse("") should include("-32700")
+    bad.getOrElse("") should include("maxObjectFields")
+    good.getOrElse("") should include(""""result":{}""")
+    ms should be < 500L
+  }
+
+  // ---- F3: depth ----
+
+  test("100 000 nested arrays are rejected as maxDepth before the parser runs") {
+    val frame = "[" * 100_000 + "]" * 100_000
+    val (result, ms) = timed(MessageLoop.parseFrame(frame))
+    parseErrorMessage(result) should include("maxDepth")
+    ms should be < 200L
+  }
+
+  test("300 nested objects are rejected; 60-deep tools/call arguments are accepted") {
+    val deepObj = """{"a":""" * 300 + "1" + "}" * 300
+    parseErrorMessage(MessageLoop.parseFrame(deepObj)) should include("maxDepth")
+
+    // envelope (1) + params (2) + arguments (3) + 60 nested arrays = depth 63 <= 64
+    val args = "[" * 60 + "1" + "]" * 60
+    val frame =
+      s"""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"t","arguments":{"x":$args}}}"""
+    MessageLoop.parseFrame(frame) match
+      case Right(Request(RequestId.NumId(1), "tools/call", Some(_))) => succeed
+      case other => fail(s"expected a Request, got $other")
+  }
+
+  // ---- frame length ----
+
+  test("frames longer than maxFrameChars are rejected without parsing") {
+    val huge = "x" * (LimitSettings().maxFrameChars + 1)
+    parseErrorMessage(MessageLoop.parseFrame(huge)) should include("maxFrameChars")
+
+    val eleven = """{"a":12345}"""
+    eleven.length shouldBe 11
+    parseErrorMessage(MessageLoop.parseFrame(eleven, LimitSettings(maxFrameChars = 10))) should include(
+      "maxFrameChars"
+    )
+    MessageLoop.parseFrame(eleven, LimitSettings(maxFrameChars = 11)) match
+      case Right(Invalid(_, _)) => succeed // parsed (and structurally invalid) — the limit passed
+      case other => fail(s"unexpected $other")
+  }
+
+  // ---- string-awareness ----
+
+  test("brackets, braces and commas inside strings (keys or values) never count") {
+    val tight = LimitSettings(maxObjectFields = 4, maxDepth = 2)
+    val valueFrame =
+      """{"jsonrpc":"2.0","id":1,"method":"ping","params":{"s":"{{{[[[,,,\\\"}"}}"""
+    MessageLoop.parseFrame(valueFrame, tight) match
+      case Right(Request(_, "ping", Some(Json.Obj(fields)))) =>
+        fields.head._2 shouldBe Json.Str("""{{{[[[,,,\"}""")
+      case other => fail(s"unexpected $other")
+
+    val keyFrame = """{"jsonrpc":"2.0","id":1,"method":"ping","params":{"a,{b\"[":1}}"""
+    MessageLoop.parseFrame(keyFrame, tight) match
+      case Right(Request(_, "ping", Some(_))) => succeed
+      case other => fail(s"unexpected $other")
+  }
+
+  // ---- exact boundaries ----
+
+  test("maxObjectFields is inclusive: N members pass, N+1 fail (pre-scan and AST validate)") {
+    val four = LimitSettings(maxObjectFields = 4)
+    val fourMembers = """{"jsonrpc":"2.0","id":1,"method":"ping","params":{}}"""
+    val fiveMembers = """{"jsonrpc":"2.0","id":1,"method":"ping","params":{},"x":1}"""
+    MessageLoop.parseFrame(fourMembers, four).isRight shouldBe true
+    parseErrorMessage(MessageLoop.parseFrame(fiveMembers, four)) should include("maxObjectFields")
+
+    def obj(n: Int): Json = Json.Obj(Chunk.fromIterable((1 to n).map(i => s"k$i" -> Json.Num(i))))
+    JsonLimits.validate(obj(4), 64, 4) shouldBe None
+    JsonLimits.validate(obj(5), 64, 4) shouldBe Some(JsonLimits.Violation.TooManyFields(4))
+    // nested objects are checked too
+    JsonLimits.validate(Json.Obj("inner" -> obj(5)), 64, 4) shouldBe Some(
+      JsonLimits.Violation.TooManyFields(4)
+    )
+    JsonLimits.preScan(obj(5).toJson, Int.MaxValue, 64, 4) shouldBe Some(
+      JsonLimits.Violation.TooManyFields(4)
+    )
+    JsonLimits.preScan(obj(4).toJson, Int.MaxValue, 64, 4) shouldBe None
+  }
+
+  test("maxDepth is inclusive: depth N passes, N+1 fails (pre-scan and AST validate)") {
+    val three = LimitSettings(maxDepth = 3)
+    val depth3 = """{"jsonrpc":"2.0","id":1,"method":"ping","params":{"a":{"b":1}}}"""
+    val depth4 = """{"jsonrpc":"2.0","id":1,"method":"ping","params":{"a":{"b":{"c":1}}}}"""
+    MessageLoop.parseFrame(depth3, three).isRight shouldBe true
+    parseErrorMessage(MessageLoop.parseFrame(depth4, three)) should include("maxDepth")
+
+    val ast3 = depth3.fromJson[Json].toOption.get
+    val ast4 = depth4.fromJson[Json].toOption.get
+    JsonLimits.validate(ast3, 3, 1024) shouldBe None
+    JsonLimits.validate(ast4, 3, 1024) shouldBe Some(JsonLimits.Violation.TooDeep(3))
+    // scalars do not add depth: a string at depth N+1 inside an object at depth N is fine
+    JsonLimits.validate(Json.Arr(Json.Arr(Json.Str("leaf"))), 2, 1024) shouldBe None
+  }
+
+  // ---- envelope decoder semantics ----
+
+  test("duplicate keys keep last-wins semantics (as Chunk.toMap did)") {
+    MessageLoop.parseFrame("""{"jsonrpc":"2.0","id":1,"id":2,"method":"ping"}""") shouldBe Right(
+      Request(RequestId.NumId(2), "ping", None)
+    )
+    JsonFields.get(Json.Obj("a" -> Json.Num(1), "a" -> Json.Num(2)), "a") shouldBe Some(Json.Num(2))
+    JsonFields.get(Json.Obj("a" -> Json.Num(1)), "b") shouldBe None
+    JsonFields.get(Json.Str("not an object"), "a") shouldBe None
+  }
+
+  test("unknown top-level fields are tolerated and never materialised") {
+    MessageLoop.parseFrame(
+      """{"jsonrpc":"2.0","id":1,"method":"ping","extra":{"x":[1,2,3]},"more":true}"""
+    ) shouldBe Right(Request(RequestId.NumId(1), "ping", None))
+  }
+
+  test("router wiring: a server-configured maxDepth floor is applied, defaults stay usable") {
+    val initFrame =
+      """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"1.0"}}}"""
+    // envelope (1) + params (2) + 8 arrays = depth 10
+    val tenDeep = s"""{"jsonrpc":"2.0","id":2,"method":"ping","params":{"a":${"[" * 8}1${"]" * 8}}}"""
+
+    val tight = McpServer("Tight", "0.1.0", McpServerSettings(limits = LimitSettings(maxDepth = 8)))
+    val tightRouter = runUnsafe(tight.buildRouter)
+    tightRouter.limits.maxDepth shouldBe 8
+    val tightSession = runUnsafe(Session.make("tight"))
+    runUnsafe(MessageLoop.handleFrame(tightRouter, tightSession, initFrame)).getOrElse("") should include(
+      "\"serverInfo\""
+    )
+    val rejected = runUnsafe(MessageLoop.handleFrame(tightRouter, tightSession, tenDeep)).getOrElse("")
+    rejected should include("-32700")
+    rejected should include("maxDepth")
+
+    val loose = McpServer("Loose", "0.1.0")
+    val looseRouter = runUnsafe(loose.buildRouter)
+    val looseSession = runUnsafe(Session.make("loose"))
+    runUnsafe(MessageLoop.handleFrame(looseRouter, looseSession, tenDeep)).getOrElse("") should include(
+      """"result":{}"""
+    )
+  }
+
+  // ---- error-body amplification ----
+
+  test("a 1 MiB top-level array yields a small -32700 body naming the type, not echoing it") {
+    val ones = "[" + "1," * 500_000 + "1]"
+    ones.length should be > 1_000_000
+    MessageLoop.parseFrame(ones, big) match
+      case Left(failure) =>
+        val body = failure.toJson
+        body.length should be < 1024
+        body should include("got: array")
+      case other => fail(s"unexpected $other")
+  }
+
+  test("a 1 MiB array `id` yields a small -32600 body naming the type") {
+    val ones = "[" + "1," * 500_000 + "1]"
+    val frame = s"""{"jsonrpc":"2.0","id":$ones,"method":"ping"}"""
+    val message = MessageLoop.parseFrame(frame, big) match
+      case Right(invalid: Invalid) =>
+        invalid.reason should include("got: array")
+        invalid
+      case other => fail(s"unexpected $other")
+    val server = McpServer("Amp", "0.1.0")
+    val router = runUnsafe(server.buildRouter)
+    val session = runUnsafe(Session.make("amp"))
+    val reply = runUnsafe(router.dispatch(session, message)).map(_.toJson).getOrElse("")
+    reply should include("-32600")
+    reply.length should be < 1024
+  }
+
+  // ---- construction guards ----
+
+  test("LimitSettings validates its values at construction") {
+    val _ = an[IllegalArgumentException] should be thrownBy LimitSettings(maxDepth = 0)
+    val _ = an[IllegalArgumentException] should be thrownBy LimitSettings(maxDepth = 257)
+    val _ = an[IllegalArgumentException] should be thrownBy LimitSettings(maxObjectFields = 0)
+    val _ = an[IllegalArgumentException] should be thrownBy LimitSettings(maxFrameChars = 0)
+    val _ = an[IllegalArgumentException] should be thrownBy LimitSettings(maxUriChars = 0)
+    val _ = an[IllegalArgumentException] should be thrownBy LimitSettings(maxSubscriptionsPerSession = 0)
+    LimitSettings(maxDepth = LimitSettings.MaxSupportedDepth).maxDepth shouldBe 256
+    LimitSettings().maxFrameChars shouldBe 4 * 1024 * 1024
+    LimitSettings().maxObjectFields shouldBe 1024
+  }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/JvmHttpLimitsTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/JvmHttpLimitsTest.scala
@@ -154,17 +154,16 @@ class JvmHttpLimitsTest extends AnyFunSuite with Matchers:
     resp.rawHeader(SessionIdHeader) shouldBe None
   }
 
-  test("modern path: a 64-key colliding _meta inside the limits gets a normal reply quickly") {
+  test("modern path: a 64-key colliding _meta inside the limits gets a normal reply") {
     val routes = buildRoutes(stateless = false)
-    // 2 required members + 62 colliding keys = exactly maxObjectFields (64).
+    // 2 required members + 62 colliding keys = exactly maxObjectFields (64). No wall-clock bound
+    // here: this is a cold first request through freshly built routes and flaked under the
+    // three-platform aggregate run; the timing bounds live in JsonLimitsTest (unit level).
     val extra = collidingMembers(collidingKeys(4).take(62))
     val frame =
       s"""{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"add","arguments":{"a":40,"b":2},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},$extra}}}"""
-    val start = java.lang.System.nanoTime()
     val resp = modernPost(routes, frame, "tools/call", Some("add"))
     val body = bodyOf(resp)
-    val ms = (java.lang.System.nanoTime() - start) / 1_000_000L
     resp.status shouldBe Status.Ok
     body should include("42")
-    ms should be < 500L
   }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/JvmHttpLimitsTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/JvmHttpLimitsTest.scala
@@ -1,0 +1,170 @@
+package com.tjclp.fastmcp
+package server.transport
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import zio.*
+import zio.http.*
+
+import com.tjclp.fastmcp.core.*
+import com.tjclp.fastmcp.macros.RegistrationMacro.*
+import com.tjclp.fastmcp.server.*
+import com.tjclp.fastmcp.server.transport.JvmTransportBackend.given
+
+/** The input limits over the JVM HTTP transport (both the streamable and stateless adapters and
+  * the 2026-07-28 modern path), with LOWERED `LimitSettings` and bodies of a few KB — independent
+  * of the transport body cap. A rejected body is HTTP 400 / -32700 and never mints a session.
+  */
+class JvmHttpLimitsTest extends AnyFunSuite with Matchers:
+
+  object TestServer:
+    @Tool(name = Some("add"), description = Some("Add two numbers"))
+    def add(@Param("a") a: Int, @Param("b") b: Int): Int = a + b
+
+    @Tool(name = Some("noop"), description = Some("No parameters"))
+    def noop(): String = "ok"
+
+  private val SessionIdHeader = "mcp-session-id"
+
+  private val initFrame =
+    """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"1.0"}}}"""
+  private val pingFrame = """{"jsonrpc":"2.0","id":2,"method":"ping"}"""
+
+  private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
+    Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(effect).getOrThrowFiberFailure())
+
+  private val limits = LimitSettings(maxObjectFields = 64, maxDepth = 16)
+
+  private def buildRoutes(stateless: Boolean): Routes[Any, Response] =
+    val server = McpServer.typed[Any](
+      "L",
+      "0.1.0",
+      McpServerSettings(stateless = stateless, limits = limits)
+    )
+    val _ = server.scanAnnotations[TestServer.type]
+    runUnsafe(
+      server.buildRouter.flatMap(r =>
+        JvmHttpBackend.httpRoutes(r, server.settings, ZEnvironment.empty)
+      )
+    )
+
+  private def run(routes: Routes[Any, Response], req: Request): Response =
+    runUnsafe(ZIO.scoped(routes.runZIO(req)))
+
+  private def bodyOf(resp: Response): String = runUnsafe(resp.body.asString)
+
+  /** Legacy POST — always carries the JSON content type and the dual Accept header. */
+  private def post(routes: Routes[Any, Response], body: String, sid: Option[String] = None): Response =
+    val base = Request
+      .post(URL(Path.root / "mcp"), Body.fromString(body))
+      .addHeader(Header.Custom("content-type", "application/json"))
+      .addHeader(Header.Custom("accept", "application/json, text/event-stream"))
+    run(routes, sid.fold(base)(s => base.addHeader(Header.Custom(SessionIdHeader, s))))
+
+  private def modernPost(
+      routes: Routes[Any, Response],
+      body: String,
+      method: String,
+      name: Option[String] = None
+  ): Response =
+    val base = Request
+      .post(URL(Path.root / "mcp"), Body.fromString(body))
+      .addHeader(Header.Custom("content-type", "application/json"))
+      .addHeader(Header.Custom("accept", "application/json, text/event-stream"))
+      .addHeader(Header.Custom("mcp-protocol-version", "2026-07-28"))
+      .addHeader(Header.Custom("mcp-method", method))
+    run(routes, name.fold(base)(value => base.addHeader(Header.Custom("mcp-name", value))))
+
+  private def collidingKeys(blocks: Int): IndexedSeq[String] =
+    val parts = Array("Aa", "BB", "C#")
+    (0 until math.pow(3, blocks).toInt).map { k =>
+      val sb = new StringBuilder
+      var rest = k
+      var b = 0
+      while b < blocks do
+        sb.append(parts(rest % 3))
+        rest /= 3
+        b += 1
+      sb.result()
+    }
+
+  private def collidingMembers(keys: IndexedSeq[String]): String =
+    keys.map(k => s""""$k":0""").mkString(",")
+
+  /** An initialize whose params object carries 243 colliding keys (~5 KB). */
+  private val collidingInit =
+    s"""{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"1.0"},${collidingMembers(
+        collidingKeys(5)
+      )}}}"""
+
+  test("streamable: a colliding-key initialize is 400/-32700 and mints no session; a clean one does") {
+    val routes = buildRoutes(stateless = false)
+    val _ = bodyOf(post(routes, pingFrame)) // warm the routes; timing bounds live in JsonLimitsTest
+    val bad = post(routes, collidingInit)
+    bad.status shouldBe Status.BadRequest
+    val body = bodyOf(bad)
+    body should include("-32700")
+    body should include("maxObjectFields")
+    bad.rawHeader(SessionIdHeader) shouldBe None
+
+    val good = post(routes, initFrame)
+    good.status shouldBe Status.Ok
+    val _ = bodyOf(good)
+    good.rawHeader(SessionIdHeader) shouldBe defined
+  }
+
+  test("stateless: the same colliding body is 400/-32700") {
+    val routes = buildRoutes(stateless = true)
+    val resp = post(routes, collidingInit)
+    resp.status shouldBe Status.BadRequest
+    val body = bodyOf(resp)
+    body should include("-32700")
+    body should include("maxObjectFields")
+  }
+
+  test("tools/call nested 20 deep is 400/-32700 (maxDepth); the server then answers a ping") {
+    val routes = buildRoutes(stateless = true)
+    val deep = "[" * 20 + "1" + "]" * 20
+    val frame =
+      s"""{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"noop","arguments":{"x":$deep}}}"""
+    frame.length should be < 200
+    val resp = post(routes, frame)
+    resp.status shouldBe Status.BadRequest
+    val body = bodyOf(resp)
+    body should include("-32700")
+    body should include("maxDepth")
+
+    val ping = post(routes, pingFrame)
+    ping.status shouldBe Status.Ok
+    bodyOf(ping) should include(""""result":{}""")
+  }
+
+  test("modern path: a 20-deep _meta is 400/-32700 — the frame check runs before ModernHttpValidation") {
+    val routes = buildRoutes(stateless = false)
+    val deep = "[" * 20 + "1" + "]" * 20
+    val frame =
+      s"""{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"noop","arguments":{},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"deep":$deep}}}"""
+    val resp = modernPost(routes, frame, "tools/call", Some("noop"))
+    resp.status shouldBe Status.BadRequest
+    val body = bodyOf(resp)
+    body should include("-32700")
+    body should include("maxDepth")
+    body should not include "-32020"
+    body should not include "-32022"
+    resp.rawHeader(SessionIdHeader) shouldBe None
+  }
+
+  test("modern path: a 64-key colliding _meta inside the limits gets a normal reply quickly") {
+    val routes = buildRoutes(stateless = false)
+    // 2 required members + 62 colliding keys = exactly maxObjectFields (64).
+    val extra = collidingMembers(collidingKeys(4).take(62))
+    val frame =
+      s"""{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"add","arguments":{"a":40,"b":2},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},$extra}}}"""
+    val start = java.lang.System.nanoTime()
+    val resp = modernPost(routes, frame, "tools/call", Some("add"))
+    val body = bodyOf(resp)
+    val ms = (java.lang.System.nanoTime() - start) / 1_000_000L
+    resp.status shouldBe Status.Ok
+    body should include("42")
+    ms should be < 500L
+  }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/LimitsWiringTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/LimitsWiringTest.scala
@@ -1,0 +1,62 @@
+package com.tjclp.fastmcp
+package server.transport
+
+import java.nio.file.{Files, Path, Paths}
+
+import scala.jdk.CollectionConverters.*
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** Source-scan guard: every `MessageLoop.parseFrame(` call site outside `MessageLoop.scala` itself
+  * must pass `router.limits`, otherwise a transport silently falls back to the default limits and
+  * ignores the operator's `McpServerSettings.limits`. Protects the cross-arc one-liners across the
+  * transport merges (TJC-2294).
+  */
+class LimitsWiringTest extends AnyFunSuite with Matchers:
+
+  private def repoRoot: Path =
+    Iterator
+      .iterate(Paths.get(System.getProperty("user.dir")).toAbsolutePath)(_.getParent)
+      .takeWhile(_ != null)
+      .find(p => Files.exists(p.resolve("build.mill")) && Files.isDirectory(p.resolve("fast-mcp-scala")))
+      .getOrElse(fail("could not locate the repository root (build.mill) from user.dir"))
+
+  test("every parseFrame call site outside MessageLoop passes router.limits") {
+    val root = repoRoot.resolve("fast-mcp-scala")
+    val platforms = List("jvm", "js", "shared", "native")
+    val offenders = platforms.flatMap { platform =>
+      val src = root.resolve(platform).resolve("src")
+      if !Files.isDirectory(src) then Nil
+      else
+        val files = Files.walk(src).iterator().asScala.filter(_.toString.endsWith(".scala")).toList
+        files.flatMap { file =>
+          if file.getFileName.toString == "MessageLoop.scala" then Nil
+          else
+            Files
+              .readAllLines(file)
+              .asScala
+              .zipWithIndex
+              .collect {
+                case (line, idx) if line.contains("parseFrame(") && !line.contains("router.limits") =>
+                  s"$file:${idx + 1}: $line"
+              }
+        }
+    }
+    withClue(offenders.mkString("\n")) {
+      offenders shouldBe empty
+    }
+  }
+
+  test("the transports actually reference parseFrame (the guard is not vacuous)") {
+    val root = repoRoot.resolve("fast-mcp-scala")
+    val hits = List("jvm", "js").flatMap { platform =>
+      Files
+        .walk(root.resolve(platform).resolve("src"))
+        .iterator()
+        .asScala
+        .filter(_.toString.endsWith(".scala"))
+        .count(f => Files.readString(f).contains("parseFrame(")) :: Nil
+    }
+    hits.sum should be >= 2
+  }

--- a/fast-mcp-scala/native/src/com/tjclp/fastmcp/server/transport/NativeTransportBackend.scala
+++ b/fast-mcp-scala/native/src/com/tjclp/fastmcp/server/transport/NativeTransportBackend.scala
@@ -60,8 +60,7 @@ object NativeTransportBackend extends TransportBackend:
         .chunks
         .map(chunk => new String(chunk.toArray))
         .via(BoundedLines.pipeline(router.limits.maxFrameChars))
-        .map(_.trim)
-        .filter(_.nonEmpty)
+        .filter(MessageLoop.shouldDispatchStdioFrame(_, router.limits))
     )
 
   /** The Scala Native platform seam, in the impl object so it's exportable (givens can't be

--- a/fast-mcp-scala/native/src/com/tjclp/fastmcp/server/transport/NativeTransportBackend.scala
+++ b/fast-mcp-scala/native/src/com/tjclp/fastmcp/server/transport/NativeTransportBackend.scala
@@ -59,7 +59,7 @@ object NativeTransportBackend extends TransportBackend:
         .fromReader(new java.io.InputStreamReader(java.lang.System.in, StandardCharsets.UTF_8))
         .chunks
         .map(chunk => new String(chunk.toArray))
-        .via(ZPipeline.splitLines)
+        .via(BoundedLines.pipeline(router.limits.maxFrameChars))
         .map(_.trim)
         .filter(_.nonEmpty)
     )

--- a/fast-mcp-scala/native/test/src/com/tjclp/fastmcp/server/transport/JsonLimitsNativeTest.scala
+++ b/fast-mcp-scala/native/test/src/com/tjclp/fastmcp/server/transport/JsonLimitsNativeTest.scala
@@ -3,6 +3,8 @@ package server.transport
 
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import zio.*
+import zio.stream.*
 
 import com.tjclp.fastmcp.codec.DefaultDecodeContext
 import com.tjclp.fastmcp.jsonrpc.JsonRpcMessage
@@ -46,7 +48,9 @@ class JsonLimitsNativeTest extends AnyFunSuite with Matchers:
     keys.map(_.hashCode).distinct.size shouldBe 1
     val frame =
       s"""{"jsonrpc":"2.0","id":1,"method":"ping",${keys.map(k => s""""$k":0""").mkString(",")}}"""
-    message(MessageLoop.parseFrame(frame, LimitSettings(maxFrameChars = 8 * 1024 * 1024))) should include(
+    message(
+      MessageLoop.parseFrame(frame, LimitSettings(maxFrameChars = 8 * 1024 * 1024))
+    ) should include(
       "maxObjectFields"
     )
   }
@@ -83,4 +87,25 @@ class JsonLimitsNativeTest extends AnyFunSuite with Matchers:
     ResourceTemplatePattern("x://{name}.{ext}").matches("x://archive.tar.gz") shouldBe Some(
       Map("name" -> "archive.tar", "ext" -> "gz")
     )
+  }
+
+  test("Native stdio preserves padded overflow and recovers on the next line") {
+    val limits = LimitSettings(maxFrameChars = 128)
+    val ping = """{"jsonrpc":"2.0","id":1,"method":"ping"}"""
+    val input = ping + " " * 200 + "discarded junk\n" + " " * 200 + "\n" + ping + "\n"
+    val frames = Unsafe.unsafe { implicit unsafe =>
+      Runtime.default.unsafe
+        .run(
+          ZStream
+            .fromIterable(input.grouped(17).toList)
+            .via(BoundedLines.pipeline(limits.maxFrameChars))
+            .filter(MessageLoop.shouldDispatchStdioFrame(_, limits))
+            .runCollect
+        )
+        .getOrThrowFiberFailure()
+    }
+    frames.length shouldBe 3
+    message(MessageLoop.parseFrame(frames(0), limits)) should include("maxFrameChars")
+    message(MessageLoop.parseFrame(frames(1), limits)) should include("maxFrameChars")
+    MessageLoop.parseFrame(frames(2), limits).isRight shouldBe true
   }

--- a/fast-mcp-scala/native/test/src/com/tjclp/fastmcp/server/transport/JsonLimitsNativeTest.scala
+++ b/fast-mcp-scala/native/test/src/com/tjclp/fastmcp/server/transport/JsonLimitsNativeTest.scala
@@ -1,0 +1,73 @@
+package com.tjclp.fastmcp
+package server.transport
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import com.tjclp.fastmcp.codec.DefaultDecodeContext
+import com.tjclp.fastmcp.jsonrpc.JsonRpcMessage
+import com.tjclp.fastmcp.server.LimitSettings
+import com.tjclp.fastmcp.server.manager.ResourceTemplatePattern
+
+/** Platform canary for the inbound input limits on Scala Native (TJC-2295). Stdio is the only
+  * Native transport, so `MessageLoop.parseFrame` is the whole surface: a deep frame and a
+  * hash-colliding object are rejected with -32700 before the parser allocates, embedded JSON is
+  * bounded, and the template matcher is regex-free (the SN RE2 shim is bypassed). The process
+  * continuing to the end of the suite is the point.
+  */
+class JsonLimitsNativeTest extends AnyFunSuite with Matchers:
+
+  private def message(result: Either[JsonRpcMessage, JsonRpcMessage]): String =
+    result match
+      case Left(JsonRpcMessage.Failure(None, err)) =>
+        err.code shouldBe -32700
+        err.message
+      case other => fail(s"expected a -32700 parse failure, got $other")
+
+  private def collidingKeys(blocks: Int): IndexedSeq[String] =
+    val parts = Array("Aa", "BB", "C#")
+    (0 until math.pow(3, blocks).toInt).map { k =>
+      val sb = new StringBuilder
+      var rest = k
+      var b = 0
+      while b < blocks do
+        sb.append(parts(rest % 3))
+        rest /= 3
+        b += 1
+      sb.result()
+    }
+
+  test("a 100 000-deep frame is rejected as maxDepth without touching the parser") {
+    message(MessageLoop.parseFrame("[" * 100_000 + "]" * 100_000)) should include("maxDepth")
+  }
+
+  test("a 3^9-colliding-key object is rejected as maxObjectFields") {
+    val keys = collidingKeys(9)
+    keys.map(_.hashCode).distinct.size shouldBe 1
+    val frame =
+      s"""{"jsonrpc":"2.0","id":1,"method":"ping",${keys.map(k => s""""$k":0""").mkString(",")}}"""
+    message(MessageLoop.parseFrame(frame, LimitSettings(maxFrameChars = 8 * 1024 * 1024))) should include(
+      "maxObjectFields"
+    )
+  }
+
+  test("a normal frame still parses under the default limits") {
+    MessageLoop.parseFrame("""{"jsonrpc":"2.0","id":1,"method":"ping"}""").isRight shouldBe true
+  }
+
+  test("embedded JSON strings are depth-bounded before any recursive walk") {
+    val ex = intercept[IllegalArgumentException](
+      DefaultDecodeContext.default.parseJsonArray("blob", "[" * 300 + "]" * 300)
+    )
+    ex.getMessage should include("maxDepth")
+  }
+
+  test("the template matcher handles a 100 KB adversarial URI without regex") {
+    val start = java.lang.System.nanoTime()
+    ResourceTemplatePattern("x://{a}.{b}.{c}").matches("x://" + "a" * 99_999 + ".") shouldBe None
+    val ms = (java.lang.System.nanoTime() - start) / 1_000_000L
+    ms should be < 500L
+    ResourceTemplatePattern("x://{name}.{ext}").matches("x://archive.tar.gz") shouldBe Some(
+      Map("name" -> "archive.tar", "ext" -> "gz")
+    )
+  }

--- a/fast-mcp-scala/native/test/src/com/tjclp/fastmcp/server/transport/JsonLimitsNativeTest.scala
+++ b/fast-mcp-scala/native/test/src/com/tjclp/fastmcp/server/transport/JsonLimitsNativeTest.scala
@@ -60,6 +60,19 @@ class JsonLimitsNativeTest extends AnyFunSuite with Matchers:
       DefaultDecodeContext.default.parseJsonArray("blob", "[" * 300 + "]" * 300)
     )
     ex.getMessage should include("maxDepth")
+    // 50 000 levels would overflow the native stack inside zio-json's recursive parser (not
+    // catchable on Scala Native) — the linear pre-scan rejects the text before the parser runs.
+    val ex2 = intercept[IllegalArgumentException](
+      DefaultDecodeContext.default.parseJsonArray("blob", "[" * 50_000 + "]" * 50_000)
+    )
+    ex2.getMessage should include("maxDepth")
+    val ex3 = intercept[IllegalArgumentException](
+      DefaultDecodeContext.default.parseJsonObject(
+        "blob",
+        (1 to 1100).map(i => s""""k$i":$i""").mkString("{", ",", "}")
+      )
+    )
+    ex3.getMessage should include("maxObjectFields")
   }
 
   test("the template matcher handles a 100 KB adversarial URI without regex") {

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/codec/DefaultDecodeContext.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/codec/DefaultDecodeContext.scala
@@ -7,7 +7,6 @@ import zio.json.*
 import zio.json.ast.Json
 
 import com.tjclp.fastmcp.core.McpDecodeContext
-import com.tjclp.fastmcp.server.LimitSettings
 
 /** The single, platform-neutral [[McpDecodeContext]] for the native core.
   *
@@ -17,10 +16,11 @@ import com.tjclp.fastmcp.server.LimitSettings
   *
   * Design: argument values flow as zio-json [[Json]] AST nodes (never Scala `null`). The default
   * decoders ([[McpDecoders]] and the macro-generated per-parameter decoders) go through
-  * [[DefaultDecodeContext.decodeRaw]], which feeds the node straight into zio-json's guarded
-  * `fromJsonAST` — no intermediate string, no unguarded recursive re-encode of client input.
-  * `writeValueAsString` remains for custom contexts/decoders and converts a `StackOverflowError`
-  * into an `IllegalArgumentException` (-32602) instead of letting a fatal error reach the fiber.
+  * [[DefaultDecodeContext.decodeRaw]], which feeds the node into zio-json's guarded `fromJsonAST`
+  * (a `StackOverflowError` inside it is caught by zio-json and surfaces as a decode `Left`; the
+  * frame-level depth bound keeps the node small anyway). `writeValueAsString` remains for custom
+  * contexts/decoders and, on the JVM, converts a `StackOverflowError` into an
+  * `IllegalArgumentException` (-32602) instead of letting a fatal error reach the fiber.
   *
   * @param maxDepth
   *   nesting bound for JSON embedded in STRING arguments parsed via [[parseJsonObject]] /
@@ -29,8 +29,8 @@ import com.tjclp.fastmcp.server.LimitSettings
   *   per-object member bound for the same embedded JSON
   */
 final class DefaultDecodeContext(
-    val maxDepth: Int = LimitSettings.DefaultMaxDepth,
-    val maxObjectFields: Int = LimitSettings.DefaultMaxObjectFields
+    val maxDepth: Int = JsonLimits.DefaultMaxDepth,
+    val maxObjectFields: Int = JsonLimits.DefaultMaxObjectFields
 ) extends McpDecodeContext:
 
   /** Best-effort cast — callers are almost always other decoders, not user code. */
@@ -59,18 +59,20 @@ final class DefaultDecodeContext(
           s"Expected JSON object for '$name', got: ${JsonLimits.typeName(other)}"
         )
 
-  /** Parse (zio-json's guarded parser) and bound the AST BEFORE any recursive walk over it —
-    * `fromJsonAst` recurses per level. A violation is bad input: `IllegalArgumentException` maps to
-    * -32602 via `McpError.fromThrowable`.
+  /** Bound the raw text BEFORE zio-json's recursive parser sees it (`JsonLimits.preScan`, linear,
+    * never recurses — the same guard the transport choke point uses, so a multi-MB `[[[[…` string
+    * argument cannot drive the parser into a stack overflow, which Scala Native does not deliver as
+    * a catchable error), then parse and re-check the AST iteratively before any recursive walk over
+    * it — `fromJsonAst` recurses per level. A violation is bad input: `IllegalArgumentException`
+    * maps to -32602 via `McpError.fromThrowable`.
     */
   private def parseBounded(name: String, rawJson: String, kind: String): Json =
+    def reject(violation: JsonLimits.Violation): Nothing =
+      throw new IllegalArgumentException(s"JSON $kind for '$name' rejected: ${violation.message}")
+    JsonLimits.preScan(rawJson, Int.MaxValue, maxDepth, maxObjectFields).foreach(reject)
     rawJson.fromJson[Json] match
       case Right(json) =>
-        JsonLimits.validate(json, maxDepth, maxObjectFields).foreach { violation =>
-          throw new IllegalArgumentException(
-            s"JSON $kind for '$name' rejected: ${violation.message}"
-          )
-        }
+        JsonLimits.validate(json, maxDepth, maxObjectFields).foreach(reject)
         json
       case Left(err) =>
         throw new RuntimeException(s"Failed to parse JSON $kind for '$name': $err")
@@ -82,11 +84,12 @@ object DefaultDecodeContext:
 
   lazy val default: DefaultDecodeContext = new DefaultDecodeContext()
 
-  /** JVM / Scala Native: convert a `StackOverflowError` from a recursive walk over an argument
-    * value into -32602 material instead of letting it reach `ZIO.attempt` (where a
-    * `VirtualMachineError` is fatal and terminates the process). Scala.js throws a `RangeError`
-    * (`js.JavaScriptException`) that this clause never matches — there the depth bounds (frame and
-    * embedded) are the protection and this catch is inert.
+  /** JVM: convert a `StackOverflowError` from a recursive walk over an argument value into -32602
+    * material instead of letting it reach `ZIO.attempt` (where a `VirtualMachineError` is fatal and
+    * terminates the process). This catch is a JVM-only backstop: Scala.js throws a `RangeError`
+    * (`js.JavaScriptException`) that this clause never matches, and Scala Native does not reliably
+    * deliver a stack overflow as a catchable error at all — on both, the depth bounds (frame-level
+    * `limits.maxDepth` and the embedded-JSON `maxDepth` here) are the protection.
     */
   private[fastmcp] inline def guardDepth[A](inline body: A): A =
     try body
@@ -94,10 +97,13 @@ object DefaultDecodeContext:
       case _: StackOverflowError =>
         throw new IllegalArgumentException("argument value is nested too deeply to encode")
 
-  /** Decode a raw argument through zio-json's AST path: no intermediate string, inside zio-json's
-    * guarded `fromJsonAST`. `toJsonAst` is the identity for wire `Json` nodes and a shallow
-    * `Json.Obj` for the typed-contract `Map[String, Any]`. Custom [[McpDecodeContext]]
-    * implementations keep the legacy `writeValueAsString` + `decodeJson` path.
+  /** Decode a raw argument through zio-json's guarded `fromJsonAST`. Decoders that override
+    * `unsafeFromJsonAST` (derived case classes, primitives, `Option`, `Json`, collections) decode
+    * straight from the node with no intermediate string; a decoder that keeps zio-json's default
+    * re-encodes the node INSIDE `fromJsonAST`, which catches a `StackOverflowError` (JVM) and whose
+    * input is already bounded by the frame-level `limits.maxDepth`. `toJsonAst` is the identity for
+    * wire `Json` nodes and a shallow `Json.Obj` for the typed-contract `Map[String, Any]`. Custom
+    * [[McpDecodeContext]] implementations keep the legacy `writeValueAsString` + `decodeJson` path.
     *
     * PUBLIC and stable: it is the target of the inline `derivedZioJsonDecoder` given and of the
     * macro-generated per-parameter decoders, so it is spliced into user compilation units.

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/codec/DefaultDecodeContext.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/codec/DefaultDecodeContext.scala
@@ -7,6 +7,7 @@ import zio.json.*
 import zio.json.ast.Json
 
 import com.tjclp.fastmcp.core.McpDecodeContext
+import com.tjclp.fastmcp.server.LimitSettings
 
 /** The single, platform-neutral [[McpDecodeContext]] for the native core.
   *
@@ -14,12 +15,23 @@ import com.tjclp.fastmcp.core.McpDecodeContext
   * one zio-json implementation that compiles on JVM and Scala.js alike — the convergence the native
   * rewrite is after ("the SDK is identical regardless of platform").
   *
-  * Design: argument values flow as zio-json [[Json]] AST nodes (never Scala `null`), so
-  * `writeValueAsString` is just `.toJson` and parsing is just `fromJson`. Decoders re-serialize a
-  * shallow `Map[String, Json]` and let zio-json's derived `JsonDecoder` produce the typed value —
-  * no bespoke per-field reflection.
+  * Design: argument values flow as zio-json [[Json]] AST nodes (never Scala `null`). The default
+  * decoders ([[McpDecoders]] and the macro-generated per-parameter decoders) go through
+  * [[DefaultDecodeContext.decodeRaw]], which feeds the node straight into zio-json's guarded
+  * `fromJsonAST` — no intermediate string, no unguarded recursive re-encode of client input.
+  * `writeValueAsString` remains for custom contexts/decoders and converts a `StackOverflowError`
+  * into an `IllegalArgumentException` (-32602) instead of letting a fatal error reach the fiber.
+  *
+  * @param maxDepth
+  *   nesting bound for JSON embedded in STRING arguments parsed via [[parseJsonObject]] /
+  *   [[parseJsonArray]] — invisible to the frame-level limits, so bounded here
+  * @param maxObjectFields
+  *   per-object member bound for the same embedded JSON
   */
-final class DefaultDecodeContext extends McpDecodeContext:
+final class DefaultDecodeContext(
+    val maxDepth: Int = LimitSettings.DefaultMaxDepth,
+    val maxObjectFields: Int = LimitSettings.DefaultMaxObjectFields
+) extends McpDecodeContext:
 
   /** Best-effort cast — callers are almost always other decoders, not user code. */
   override def convertValue[T: ClassTag](name: String, rawValue: Any): T =
@@ -31,28 +43,97 @@ final class DefaultDecodeContext extends McpDecodeContext:
         )
 
   override def parseJsonArray(name: String, rawJson: String): List[Any] =
-    rawJson.fromJson[Json] match
-      case Right(Json.Arr(elems)) => elems.toList.map(DefaultDecodeContext.fromJsonAst)
-      case Right(other) =>
-        throw new RuntimeException(s"Expected JSON array for '$name', got: $other")
-      case Left(err) =>
-        throw new RuntimeException(s"Failed to parse JSON array for '$name': $err")
+    parseBounded(name, rawJson, "array") match
+      case Json.Arr(elems) => elems.toList.map(DefaultDecodeContext.fromJsonAst)
+      case other =>
+        throw new RuntimeException(
+          s"Expected JSON array for '$name', got: ${JsonLimits.typeName(other)}"
+        )
 
   override def parseJsonObject(name: String, rawJson: String): Map[String, Any] =
-    rawJson.fromJson[Json] match
-      case Right(Json.Obj(fields)) =>
+    parseBounded(name, rawJson, "object") match
+      case Json.Obj(fields) =>
         fields.iterator.map((k, v) => k -> DefaultDecodeContext.fromJsonAst(v)).toMap
-      case Right(other) =>
-        throw new RuntimeException(s"Expected JSON object for '$name', got: $other")
+      case other =>
+        throw new RuntimeException(
+          s"Expected JSON object for '$name', got: ${JsonLimits.typeName(other)}"
+        )
+
+  /** Parse (zio-json's guarded parser) and bound the AST BEFORE any recursive walk over it —
+    * `fromJsonAst` recurses per level. A violation is bad input: `IllegalArgumentException` maps to
+    * -32602 via `McpError.fromThrowable`.
+    */
+  private def parseBounded(name: String, rawJson: String, kind: String): Json =
+    rawJson.fromJson[Json] match
+      case Right(json) =>
+        JsonLimits.validate(json, maxDepth, maxObjectFields).foreach { violation =>
+          throw new IllegalArgumentException(
+            s"JSON $kind for '$name' rejected: ${violation.message}"
+          )
+        }
+        json
       case Left(err) =>
-        throw new RuntimeException(s"Failed to parse JSON object for '$name': $err")
+        throw new RuntimeException(s"Failed to parse JSON $kind for '$name': $err")
 
   override def writeValueAsString(value: Any): String =
-    DefaultDecodeContext.toJsonAst(value).toJson
+    DefaultDecodeContext.guardDepth(DefaultDecodeContext.toJsonAst(value).toJson)
 
 object DefaultDecodeContext:
 
-  lazy val default: DefaultDecodeContext = new DefaultDecodeContext
+  lazy val default: DefaultDecodeContext = new DefaultDecodeContext()
+
+  /** JVM / Scala Native: convert a `StackOverflowError` from a recursive walk over an argument
+    * value into -32602 material instead of letting it reach `ZIO.attempt` (where a
+    * `VirtualMachineError` is fatal and terminates the process). Scala.js throws a `RangeError`
+    * (`js.JavaScriptException`) that this clause never matches — there the depth bounds (frame and
+    * embedded) are the protection and this catch is inert.
+    */
+  private[fastmcp] inline def guardDepth[A](inline body: A): A =
+    try body
+    catch
+      case _: StackOverflowError =>
+        throw new IllegalArgumentException("argument value is nested too deeply to encode")
+
+  /** Decode a raw argument through zio-json's AST path: no intermediate string, inside zio-json's
+    * guarded `fromJsonAST`. `toJsonAst` is the identity for wire `Json` nodes and a shallow
+    * `Json.Obj` for the typed-contract `Map[String, Any]`. Custom [[McpDecodeContext]]
+    * implementations keep the legacy `writeValueAsString` + `decodeJson` path.
+    *
+    * PUBLIC and stable: it is the target of the inline `derivedZioJsonDecoder` given and of the
+    * macro-generated per-parameter decoders, so it is spliced into user compilation units.
+    */
+  def decodeRaw[T](
+      name: String,
+      rawValue: Any,
+      context: McpDecodeContext,
+      decoder: JsonDecoder[T]
+  ): T =
+    context match
+      case _: DefaultDecodeContext =>
+        val ast = guardDepth(toJsonAst(rawValue))
+        decoder.fromJsonAST(ast) match
+          case Right(value) => value
+          case Left(err) =>
+            throw new RuntimeException(
+              s"Failed to decode parameter '$name' from JSON: $err. Value: ${preview(ast)}"
+            )
+      case other =>
+        val json = other.writeValueAsString(rawValue)
+        decoder.decodeJson(json) match
+          case Right(value) => value
+          case Left(err) =>
+            throw new RuntimeException(
+              s"Failed to decode parameter '$name' from JSON: $err. Value: $json"
+            )
+
+  /** Render a failing value for the error message — guarded and truncated, so an error body never
+    * amplifies the offending input.
+    */
+  private def preview(ast: Json): String =
+    try
+      val s = ast.toJson
+      if s.length > 512 then s.take(512) + "…" else s
+    catch case _: StackOverflowError => "<too deep>"
 
   /** Coerce an arbitrary argument value into a [[Json]] AST. Handles the shapes that reach the
     * decode path: `Json` nodes (passthrough), shallow `Map`/`Iterable` structures produced by

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/codec/JsonLimits.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/codec/JsonLimits.scala
@@ -1,0 +1,111 @@
+package com.tjclp.fastmcp
+package codec
+
+import scala.collection.mutable
+
+import zio.json.ast.Json
+
+/** Structural bounds on client-supplied JSON: frame length, nesting depth and per-object member
+  * count. Pure and platform-neutral (JVM, Scala.js, Scala Native) — depends only on zio-json's
+  * [[Json]] AST. Lives in `codec/` so both [[DefaultDecodeContext]] (embedded JSON strings) and the
+  * transport choke point (`MessageLoop.parseFrame`) can use it.
+  *
+  * Two layers: [[preScan]] is a linear, near-allocation-free pass over the raw text that rejects a
+  * violating frame BEFORE the parser allocates a single node (so a 100 000-deep `[[[[…` or a
+  * 2^17-key object costs one character scan); [[validate]] is the authoritative, iterative re-check
+  * on the parsed AST. Neither recurses, so neither can overflow the stack on any input.
+  */
+private[fastmcp] object JsonLimits:
+
+  enum Violation:
+    case FrameTooLong(length: Int, max: Int)
+    case TooDeep(max: Int)
+    case TooManyFields(max: Int)
+
+    def message: String = this match
+      case FrameTooLong(n, max) => s"frame is $n characters; limits.maxFrameChars is $max"
+      case TooDeep(max) => s"JSON nesting exceeds limits.maxDepth ($max)"
+      case TooManyFields(max) => s"a JSON object exceeds limits.maxObjectFields ($max)"
+
+  /** Linear pass over raw JSON text. Exact for valid JSON; conservative (may under-count) for
+    * invalid JSON, which the parser rejects anyway. Brackets, braces and commas inside string
+    * literals (keys or values) are never interpreted; `\` escapes are honoured so an escaped quote
+    * cannot end a string early. Depth 1 = the outermost container; an object with exactly
+    * `maxObjectFields` members (`maxObjectFields - 1` commas) passes.
+    */
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.Return"))
+  def preScan(
+      text: String,
+      maxFrameChars: Int,
+      maxDepth: Int,
+      maxObjectFields: Int
+  ): Option[Violation] =
+    if text.length > maxFrameChars then
+      return Some(Violation.FrameTooLong(text.length, maxFrameChars))
+    // maxDepth is capped by LimitSettings (<= 256) so the scratch arrays stay tiny; the +2 leaves
+    // room for the depth that triggers TooDeep before we index into them.
+    val isObject = new Array[Boolean](maxDepth + 2)
+    val members = new Array[Int](maxDepth + 2)
+    var depth = 0
+    var inString = false
+    var escaped = false
+    var i = 0
+    val n = text.length
+    while i < n do
+      val c = text.charAt(i)
+      if inString then
+        if escaped then escaped = false
+        else if c == '\\' then escaped = true
+        else if c == '"' then inString = false
+      else
+        c match
+          case '"' => inString = true
+          case '{' | '[' =>
+            depth += 1
+            if depth > maxDepth then return Some(Violation.TooDeep(maxDepth))
+            isObject(depth) = c == '{'
+            members(depth) = 0
+          case '}' | ']' =>
+            if depth > 0 then depth -= 1
+          case ',' =>
+            if depth > 0 && isObject(depth) then
+              members(depth) += 1
+              if members(depth) >= maxObjectFields then
+                return Some(Violation.TooManyFields(maxObjectFields))
+          case _ => ()
+      i += 1
+    None
+
+  /** Exact re-check on a parsed AST — iterative with an explicit worklist, never recurses. Only
+    * containers count toward depth (the outermost container is depth 1), matching [[preScan]].
+    */
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.Return"))
+  def validate(json: Json, maxDepth: Int, maxObjectFields: Int): Option[Violation] =
+    val work = mutable.ArrayDeque.empty[(Json, Int)]
+    def push(j: Json, depth: Int): Unit = j match
+      case _: Json.Obj | _: Json.Arr => work.append((j, depth))
+      case _ => ()
+    push(json, 1)
+    while work.nonEmpty do
+      val (node, depth) = work.removeLast()
+      if depth > maxDepth then return Some(Violation.TooDeep(maxDepth))
+      node match
+        case Json.Obj(fields) =>
+          if fields.length > maxObjectFields then
+            return Some(Violation.TooManyFields(maxObjectFields))
+          fields.foreach((_, v) => push(v, depth + 1))
+        case Json.Arr(elems) =>
+          elems.foreach(push(_, depth + 1))
+        case _ => ()
+    None
+
+  /** Human-readable JSON type name for error messages — used instead of rendering the offending
+    * value, so a multi-megabyte frame cannot amplify into a multi-megabyte error body.
+    */
+  def typeName(json: Json): String = json match
+    case _: Json.Obj => "object"
+    case _: Json.Arr => "array"
+    case _: Json.Str => "string"
+    case _: Json.Num => "number"
+    case _: Json.Bool => "boolean"
+    case Json.Null => "null"

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/codec/JsonLimits.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/codec/JsonLimits.scala
@@ -17,6 +17,19 @@ import zio.json.ast.Json
   */
 private[fastmcp] object JsonLimits:
 
+  /** Hard ceiling for any configured depth bound: the stack safety of every later recursive walk
+    * over client JSON (zio-json encode, `equals`, `toString`, AST unwrapping) depends on it.
+    * `server.LimitSettings.MaxSupportedDepth` re-exports it; it lives here so `codec` never depends
+    * on `server`.
+    */
+  val MaxSupportedDepth: Int = 256
+
+  /** Defaults shared by `server.LimitSettings` (frame level) and [[DefaultDecodeContext]] (JSON
+    * embedded in string arguments).
+    */
+  val DefaultMaxDepth: Int = 64
+  val DefaultMaxObjectFields: Int = 1024
+
   enum Violation:
     case FrameTooLong(length: Int, max: Int)
     case TooDeep(max: Int)

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/codec/McpDecoders.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/codec/McpDecoders.scala
@@ -16,8 +16,9 @@ import com.tjclp.fastmcp.server.McpContext
   * no JS specifics) to `shared/`, so JVM and Scala.js share one decode surface. Pairs with
   * [[DefaultDecodeContext]]. This replaces the deleted JVM `JacksonConverter` derivation.
   *
-  *   - `given [T: JsonDecoder]: McpDecoder[T]` — re-serialize `rawValue` via the context and decode
-  *     with zio-json. Equivalent to Jackson's old automatic `convertValue` on the JVM.
+  *   - `given [T: JsonDecoder]: McpDecoder[T]` — decode `rawValue` with zio-json through
+  *     [[DefaultDecodeContext.decodeRaw]] (the AST path; no re-serialisation of client input).
+  *     Equivalent to Jackson's old automatic `convertValue` on the JVM.
   *   - low-priority `Mirror`-based fallback for case classes without an explicit `JsonDecoder`.
   *   - `given McpDecoder[McpContext]` — identity, for context-threading in the contract layer.
   *   - `given McpEncoder[Array[Byte]]` — binary → `ImageContent("application/octet-stream")`.
@@ -41,26 +42,14 @@ trait McpDecodersLowPriority:
     val jsonDecoder = macros.ZioJsonEnumDerivation.deriveDecoder[T](using m)
     new McpDecoder[T]:
       def decode(name: String, rawValue: Any, context: McpDecodeContext): T =
-        val json = context.writeValueAsString(rawValue)
-        jsonDecoder.decodeJson(json) match
-          case Right(value) => value
-          case Left(err) =>
-            throw new RuntimeException(
-              s"Failed to decode parameter '$name' from JSON: $err. Value: $json"
-            )
+        DefaultDecodeContext.decodeRaw[T](name, rawValue, context, jsonDecoder)
 
 object McpDecoders extends McpDecodersLowPriority:
 
   given zioJsonDecoder[T](using decoder: JsonDecoder[T]): McpDecoder[T] with
 
     def decode(name: String, rawValue: Any, context: McpDecodeContext): T =
-      val json = context.writeValueAsString(rawValue)
-      decoder.decodeJson(json) match
-        case Right(value) => value
-        case Left(err) =>
-          throw new RuntimeException(
-            s"Failed to decode parameter '$name' from JSON: $err. Value: $json"
-          )
+      DefaultDecodeContext.decodeRaw[T](name, rawValue, context, decoder)
 
   /** Identity decoder so the contract layer can thread the runtime context uniformly. */
   given McpDecoder[McpContext] with

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/jsonrpc/JsonRpc.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/jsonrpc/JsonRpc.scala
@@ -38,12 +38,27 @@ object RequestId:
     },
     JsonDecoder[Json].mapOrFail {
       case Json.Str(s) => Right(StrId(s))
-      // Json.Num wraps java.math.BigDecimal — wrap in scala BigDecimal for isWhole/toLong.
-      case Json.Num(n) if BigDecimal(n).isWhole => Right(NumId(BigDecimal(n).toLong))
+      case Json.Num(n) =>
+        longId(n)
+          .map(NumId(_))
+          .toRight("JSON-RPC id must be a string or a whole number in 64-bit range")
       case other =>
         Left(s"JSON-RPC id must be a string or whole number, got: ${JsonLimits.typeName(other)}")
     }
   )
+
+  /** A numeric id is accepted only if it is whole and fits a `Long` — an out-of-range id would
+    * otherwise be wrapped by `toLong` and the reply would echo a different id than the client sent.
+    * Cheap on any exponent: a negative scale below -19 means |n| >= 10^20 (past `Long`), so
+    * `longValueExact`'s `setScale(0)` (which would materialise 10^|scale|) is never reached for a
+    * huge exponent; for the remaining scales it is O(digits), and zio-json caps the mantissa.
+    */
+  private def longId(n: java.math.BigDecimal): Option[Long] =
+    if n.signum == 0 then Some(0L)
+    else if n.scale < -19 then None
+    else
+      try Some(n.longValueExact)
+      catch case _: ArithmeticException => None
 
 /** A JSON-RPC 2.0 error object (the `error` member of an error response). */
 case class JsonRpcErrorObject(code: Int, message: String, data: Option[Json] = None)

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/jsonrpc/JsonRpc.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/jsonrpc/JsonRpc.scala
@@ -1,9 +1,25 @@
 package com.tjclp.fastmcp.jsonrpc
 
+import zio.Chunk
 import zio.json.*
 import zio.json.ast.Json
 
+import com.tjclp.fastmcp.codec.JsonLimits
 import com.tjclp.fastmcp.core.Protocol
+
+/** Linear field lookup over a decoded JSON object. Last occurrence wins — the semantics
+  * `Chunk.toMap` gave duplicate keys — so behaviour is unchanged while no HashMap is ever built
+  * from client-chosen keys (N hash-colliding keys used to cost O(N²) comparisons per `toMap`).
+  */
+private[fastmcp] object JsonFields:
+
+  def get(fields: Chunk[(String, Json)], key: String): Option[Json] =
+    val idx = fields.lastIndexWhere(_._1 == key)
+    if idx < 0 then None else Some(fields(idx)._2)
+
+  def get(json: Json, key: String): Option[Json] = json match
+    case Json.Obj(fields) => get(fields, key)
+    case _ => None
 
 /** A JSON-RPC 2.0 request/response id. The spec allows `string | number`; we keep numbers as `Long`
   * (the spec discourages fractional ids) and preserve the original kind so responses echo the
@@ -24,7 +40,8 @@ object RequestId:
       case Json.Str(s) => Right(StrId(s))
       // Json.Num wraps java.math.BigDecimal — wrap in scala BigDecimal for isWhole/toLong.
       case Json.Num(n) if BigDecimal(n).isWhole => Right(NumId(BigDecimal(n).toLong))
-      case other => Left(s"JSON-RPC id must be a string or whole number, got: $other")
+      case other =>
+        Left(s"JSON-RPC id must be a string or whole number, got: ${JsonLimits.typeName(other)}")
     }
   )
 
@@ -42,6 +59,9 @@ object JsonRpcErrorObject:
   * `params`/`data` precisely).
   *
   * Batching was dropped from the spec at 2025-06-18, so there is no array case.
+  *
+  * The decoder looks the envelope members up by linear scan ([[JsonFields]]); unknown top-level
+  * fields are tolerated and never materialised into a map.
   */
 sealed trait JsonRpcMessage
 
@@ -94,17 +114,17 @@ object JsonRpcMessage:
 
   given JsonDecoder[JsonRpcMessage] = JsonDecoder[Json].mapOrFail {
     case Json.Obj(fields) =>
-      val m = fields.toMap
-      val idField = m.get("id")
+      def field(key: String): Option[Json] = JsonFields.get(fields, key)
+      val idField = field("id")
       // Best-effort id for echoing back on -32600 (null / fractional ids echo as null).
       val idOpt = idField.filter(_ != Json.Null).flatMap(_.as[RequestId].toOption)
       def invalid(reason: String): Right[String, JsonRpcMessage] = Right(Invalid(idOpt, reason))
-      if !m.get("jsonrpc").contains(Json.Str(V)) then
+      if !field("jsonrpc").contains(Json.Str(V)) then
         invalid(s"""missing or invalid `jsonrpc` version (expected "$V")""")
       else
-        (m.get("method"), m.get("result"), m.get("error")) match
+        (field("method"), field("result"), field("error")) match
           case (Some(Json.Str(method)), _, _) =>
-            val params = m.get("params")
+            val params = field("params")
             idField match
               case None => Right(Notification(method, params))
               case Some(Json.Null) => invalid("request `id` must not be null")
@@ -115,7 +135,7 @@ object JsonRpcMessage:
           case (Some(_), _, _) =>
             invalid("`method` must be a string")
           case (_, Some(result), _) =>
-            m.get("id")
+            idField
               .toRight("JSON-RPC success response missing `id`")
               .flatMap(_.as[RequestId])
               .map(Success(_, result))
@@ -123,7 +143,8 @@ object JsonRpcMessage:
             err.as[JsonRpcErrorObject].map(Failure(idOpt, _))
           case _ =>
             invalid("missing `method`, `result`, and `error`")
-    case other => Left(s"JSON-RPC message must be a JSON object, got: $other")
+    case other =>
+      Left(s"JSON-RPC message must be a JSON object, got: ${JsonLimits.typeName(other)}")
   }
 
   given JsonCodec[JsonRpcMessage] =

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/MapToFunctionMacro.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/MapToFunctionMacro.scala
@@ -81,15 +81,10 @@ object MapToFunctionMacro:
     def jsonDecoderToMcpDecoder[T: Type](jsonDecoderExpr: Expr[JsonDecoder[T]])(using
         Quotes
     ): Expr[McpDecoder[T]] =
+      // AST path (no re-serialisation of client input): see DefaultDecodeContext.decodeRaw.
       '{
         McpDecoder.instance[T] { (name, rawValue, context) =>
-          val json = context.writeValueAsString(rawValue)
-          $jsonDecoderExpr.decodeJson(json) match
-            case Right(value) => value
-            case Left(err) =>
-              throw new RuntimeException(
-                s"Failed to decode parameter '$name' from JSON: $err. Value: $json"
-              )
+          DefaultDecodeContext.decodeRaw[T](name, rawValue, context, $jsonDecoderExpr)
         }
       }
 

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServerSettings.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServerSettings.scala
@@ -85,7 +85,8 @@ case class TaskSettings(
   require(sweepIntervalMs >= 1L, "TaskSettings.sweepIntervalMs must be >= 1")
 
 /** Settings for an MCP server. HTTP-specific fields (`stateless`, `keepAliveInterval`,
-  * `disallowDelete`, `httpEndpoint`) are ignored under stdio transports.
+  * `disallowDelete`, `httpEndpoint`) are ignored under stdio transports. `limits` applies on every
+  * transport.
   */
 case class McpServerSettings(
     debug: Boolean = false,
@@ -123,5 +124,62 @@ case class McpServerSettings(
     // `None` (default) disables host checking, preserving prior behavior.
     allowedHosts: Option[Set[String]] = None,
     // Optional io.modelcontextprotocol/tasks extension. Off by default.
-    tasks: TaskSettings = TaskSettings()
+    tasks: TaskSettings = TaskSettings(),
+    // Inbound input limits (frame size, JSON depth, object width, URI length, subscriptions).
+    // Enforced on every transport before any dispatch work; see [[LimitSettings]].
+    limits: LimitSettings = LimitSettings()
 )
+
+/** Input limits applied to every inbound JSON-RPC frame on every transport (stdio and HTTP; JVM,
+  * Scala.js, Scala Native), plus the resource-URI and per-session subscription bounds.
+  *
+  * Frame-limit violations (`maxFrameChars`, `maxDepth`, `maxObjectFields`) answer JSON-RPC `-32700`
+  * (HTTP 400) before any dispatch work and never mint a session; the URI and subscription bounds
+  * answer `-32602`. Limits cannot be disabled, only moved inside the documented bounds — the
+  * constructor `require`s make a misconfiguration fail fast at construction.
+  *
+  * @param maxFrameChars
+  *   Max length of ONE decoded frame (one stdio line / one HTTP body) in UTF-16 chars. On HTTP the
+  *   transport body cap (`McpServerSettings.maxRequestBodyBytes`) should be <= this so oversized
+  *   bodies get 413 first; this is the transport-independent backstop. Note: sampling/createMessage
+  *   results carrying base64 images must fit — raise for image-heavy stdio deployments, e.g.
+  *   `LimitSettings(maxFrameChars = 16 * 1024 * 1024)`.
+  * @param maxDepth
+  *   Max JSON nesting depth. Depth 1 = the envelope object; every nested `{` / `[` adds one. A
+  *   legacy `initialize` is depth 4, a `tools/call` with one nested argument object is depth 4-5;
+  *   values below 8 break normal clients. The hard ceiling [[LimitSettings.MaxSupportedDepth]]
+  *   keeps every recursive walk (encode / equals / toString) far inside the smallest supported
+  *   stack, so no configuration can re-open the stack-overflow window.
+  * @param maxObjectFields
+  *   Max members of any single JSON object anywhere in a frame. Bounds the worst case of building a
+  *   Scala `Map` from attacker-chosen hash-colliding keys (cost grows quadratically per object).
+  * @param maxUriChars
+  *   Max length (chars) of a client-supplied resource URI: `resources/read`, `resources/subscribe`,
+  *   `resources/unsubscribe`, and `subscriptions/listen` entries.
+  * @param maxSubscriptionsPerSession
+  *   Max distinct URIs one legacy session may hold via `resources/subscribe`; further distinct
+  *   subscriptions are refused with `-32602`.
+  */
+case class LimitSettings(
+    maxFrameChars: Int = 4 * 1024 * 1024,
+    maxDepth: Int = 64,
+    maxObjectFields: Int = 1024,
+    maxUriChars: Int = 8192,
+    maxSubscriptionsPerSession: Int = 1024
+):
+  require(maxFrameChars >= 1, "limits.maxFrameChars must be >= 1")
+  require(
+    maxDepth >= 1 && maxDepth <= LimitSettings.MaxSupportedDepth,
+    s"limits.maxDepth must be in 1..${LimitSettings.MaxSupportedDepth}"
+  )
+  require(maxObjectFields >= 1, "limits.maxObjectFields must be >= 1")
+  require(maxUriChars >= 1, "limits.maxUriChars must be >= 1")
+  require(maxSubscriptionsPerSession >= 1, "limits.maxSubscriptionsPerSession must be >= 1")
+
+object LimitSettings:
+  /** Hard ceiling for `maxDepth`: the stack safety of every later recursive walk over client JSON
+    * (zio-json encode, `equals`, `toString`, AST unwrapping) depends on it.
+    */
+  val MaxSupportedDepth: Int = 256
+  val DefaultMaxDepth: Int = 64
+  val DefaultMaxObjectFields: Int = 1024

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServerSettings.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServerSettings.scala
@@ -152,7 +152,14 @@ case class McpServerSettings(
   *   stack, so no configuration can re-open the stack-overflow window.
   * @param maxObjectFields
   *   Max members of any single JSON object anywhere in a frame. Bounds the worst case of building a
-  *   Scala `Map` from attacker-chosen hash-colliding keys (cost grows quadratically per object).
+  *   Scala `Map` from attacker-chosen hash-colliding keys: every `Map` sink after the frame check
+  *   (zio-json `Map` decoders, `_meta` lookups, tool-argument maps) costs up to `maxObjectFields² /
+  *   2` string comparisons per colliding object, so a frame can cost roughly `maxFrameChars / 20 /
+  *   maxObjectFields` objects × `maxObjectFields² / 2` comparisons — linear in the frame but with a
+  *   constant that grows quadratically in this knob (at the defaults about 0.4 s per 4 MiB frame on
+  *   the JVM, several times that on single-threaded Bun). Operators exposing a Bun server to
+  *   untrusted networks should lower it (e.g. 256); the 2025-11-25 wire shapes never need more than
+  *   a few dozen members per object.
   * @param maxUriChars
   *   Max length (chars) of a client-supplied resource URI: `resources/read`, `resources/subscribe`,
   *   `resources/unsubscribe`, and `subscriptions/listen` entries.
@@ -162,8 +169,8 @@ case class McpServerSettings(
   */
 case class LimitSettings(
     maxFrameChars: Int = 4 * 1024 * 1024,
-    maxDepth: Int = 64,
-    maxObjectFields: Int = 1024,
+    maxDepth: Int = 64, // = codec.JsonLimits.DefaultMaxDepth (pinned by JsonLimitsTest)
+    maxObjectFields: Int = 1024, // = codec.JsonLimits.DefaultMaxObjectFields
     maxUriChars: Int = 8192,
     maxSubscriptionsPerSession: Int = 1024
 ):
@@ -178,8 +185,8 @@ case class LimitSettings(
 
 object LimitSettings:
   /** Hard ceiling for `maxDepth`: the stack safety of every later recursive walk over client JSON
-    * (zio-json encode, `equals`, `toString`, AST unwrapping) depends on it.
+    * (zio-json encode, `equals`, `toString`, AST unwrapping) depends on it. Defined in
+    * `codec.JsonLimits` (shared with `DefaultDecodeContext`'s embedded-JSON bounds) and re-exported
+    * here.
     */
-  val MaxSupportedDepth: Int = 256
-  val DefaultMaxDepth: Int = 64
-  val DefaultMaxObjectFields: Int = 1024
+  val MaxSupportedDepth: Int = com.tjclp.fastmcp.codec.JsonLimits.MaxSupportedDepth

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/ResourceManager.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/ResourceManager.scala
@@ -3,7 +3,6 @@ package com.tjclp.fastmcp.server.manager
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.jdk.CollectionConverters.*
-import scala.util.matching.Regex
 
 import zio.*
 
@@ -23,8 +22,11 @@ type ResourceTemplateHandler[R] = Map[String, String] => ZIO[R, Throwable, Strin
 
 /** Manager for MCP resources.
   *
-  * Since we assume scheme-based URIs such as `users://{id}/profile`, template match patterns are
-  * anchored with `^` and `$` so only exact matches pass.
+  * Templates such as `users://{id}/profile` are compiled ONCE at registration into a
+  * [[ResourceTemplatePattern]] — a regex-free, linear-time matcher where literal text is matched
+  * verbatim and each placeholder matches one non-empty path segment (no `/`); a URI matches only as
+  * a whole. Client URIs are bounded upstream (`limits.maxUriChars`, enforced in the built-in
+  * handlers) before they reach [[findMatchingTemplate]].
   *
   * @tparam R
   *   the ZIO environment all stored handlers may require; supplied by the server at `runHttp[R]()`
@@ -36,7 +38,10 @@ class ResourceManager[R] extends Manager[ResourceDefinition]:
     new ConcurrentHashMap[String, (ResourceDefinition, ResourceHandler[R])]()
 
   private val templateResources =
-    new ConcurrentHashMap[String, (ResourceDefinition, ResourceTemplateHandler[R])]()
+    new ConcurrentHashMap[
+      String,
+      (ResourceTemplatePattern, ResourceDefinition, ResourceTemplateHandler[R])
+    ]()
 
   def addStaticResource(
       uri: String,
@@ -86,7 +91,21 @@ class ResourceManager[R] extends Manager[ResourceDefinition]:
           java.lang.System.err.println(
             s"[ResourceManager] Warning: Resource template with pattern '$uriPattern' already exists. Overwriting."
           )
-        templateResources.put(uriPattern, (templateDefinition, handler))
+        else
+          // Same shape under different placeholder names (`users://{id}` vs `users://{userId}`)
+          // matches the same URIs; whichever the map iterates first wins at read time.
+          val shape = ResourceManager.placeholderShape(uriPattern)
+          templateResources
+            .keySet()
+            .asScala
+            .find(ResourceManager.placeholderShape(_) == shape)
+            .foreach { existing =>
+              java.lang.System.err.println(
+                s"[ResourceManager] Warning: Resource template '$uriPattern' matches the same URIs as " +
+                  s"already-registered '$existing'."
+              )
+            }
+        templateResources.put(uriPattern, (pattern, templateDefinition, handler))
         ()
       }
       .mapError(e =>
@@ -106,13 +125,13 @@ class ResourceManager[R] extends Manager[ResourceDefinition]:
 
   override def listDefinitions(): List[ResourceDefinition] =
     (staticResources.values().asScala.map(_._1) ++
-      templateResources.values().asScala.map(_._1)).toList
+      templateResources.values().asScala.map(_._2)).toList
 
   def listStaticResources(): List[ResourceDefinition] =
     staticResources.values().asScala.map(_._1).toList
 
   def listTemplateResources(): List[ResourceDefinition] =
-    templateResources.values().asScala.map(_._1).toList
+    templateResources.values().asScala.map(_._2).toList
 
   def getStaticResourceHandler(uri: String): Option[ResourceHandler[R]] =
     Option(staticResources.get(uri)).map(_._2)
@@ -121,35 +140,32 @@ class ResourceManager[R] extends Manager[ResourceDefinition]:
   def getResourceHandler(uri: String): Option[ResourceHandler[R]] = getStaticResourceHandler(uri)
 
   def getTemplateResourceHandler(uriPattern: String): Option[ResourceTemplateHandler[R]] =
-    Option(templateResources.get(uriPattern)).map(_._2)
+    Option(templateResources.get(uriPattern)).map(_._3)
 
   def getResourceDefinition(uri: String): Option[ResourceDefinition] =
     Option(staticResources.get(uri)).map(_._1)
 
   def listTemplateDefinitions(): List[ResourceDefinition] = listTemplateResources()
 
-  /** Extract parameters from a URI matching a template pattern */
+  /** Extract parameters from a URI matching a template pattern (convenience / test API — compiles
+    * the template on every call; registered templates are compiled once and stored).
+    */
   def extractTemplateParams(
       template: String,
       uri: String
   ): Option[Map[String, String]] =
-    val pattern = ResourceTemplatePattern(template)
-    pattern.matches(uri).map(pattern.extractParams(uri, _))
+    ResourceTemplatePattern.parse(template).toOption.flatMap(_.matches(uri))
 
+  /** Find the registered template matching `uri`, using the patterns compiled at registration. */
   def findMatchingTemplate(uri: String): Option[
     (ResourceTemplatePattern, ResourceDefinition, ResourceTemplateHandler[R], Map[String, String])
   ] =
     templateResources
-      .entrySet()
+      .values()
       .asScala
       .iterator
-      .map { entry =>
-        val patternString = entry.getKey
-        val pattern = ResourceTemplatePattern(patternString)
-        val (definition, handler) = entry.getValue
-        pattern
-          .matches(uri)
-          .map(regexMatch => (pattern, definition, handler, pattern.extractParams(uri, regexMatch)))
+      .map { case (pattern, definition, handler) =>
+        pattern.matches(uri).map(params => (pattern, definition, handler, params))
       }
       .collectFirst { case Some(result) => result }
 
@@ -179,27 +195,19 @@ class ResourceManager[R] extends Manager[ResourceDefinition]:
 
 end ResourceManager
 
-/** Represents a URI pattern with placeholders. */
-case class ResourceTemplatePattern(pattern: String):
-  private val paramRegex = """\{([^{}]+)\}""".r
-  val paramNames = paramRegex.findAllMatchIn(pattern).map(_.group(1)).toList
+object ResourceManager:
 
-  private val matchRegex = {
-    val regexString = paramRegex.replaceAllIn(pattern, _ => "([^/]+)")
-    new Regex("^" + regexString + "$")
-  }
-
-  @scala.annotation.nowarn("msg=unused explicit parameter")
-  def extractParams(
-      uri: String,
-      regexMatch: Regex.Match
-  ): Map[String, String] =
-    paramNames.zipWithIndex.map { case (name, idx) =>
-      name -> regexMatch.group(idx + 1)
-    }.toMap
-
-  def matches(uri: String): Option[Regex.Match] =
-    matchRegex.findFirstMatchIn(uri)
+  /** `users://{userId}/x` → `users://{}/x`: the URI shape independent of placeholder names. */
+  private[fastmcp] def placeholderShape(pattern: String): String =
+    ResourceTemplatePattern.parse(pattern) match
+      case Right(compiled) =>
+        compiled.segments
+          .map(_.map {
+            case ResourceTemplatePattern.Part.Literal(t) => t
+            case ResourceTemplatePattern.Part.Variable(_) => "{}"
+          }.mkString)
+          .mkString("/")
+      case Left(_) => pattern
 
 @SuppressWarnings(Array("org.wartremover.warts.Null"))
 class ResourceError(message: String, cause: Option[Throwable] = None)

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/ResourceTemplatePattern.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/ResourceTemplatePattern.scala
@@ -1,0 +1,190 @@
+package com.tjclp.fastmcp.server.manager
+
+import scala.collection.mutable.ArrayBuffer
+
+/** A compiled resource URI template such as `users://{id}/profile` or `files://{name}.{ext}`.
+  *
+  * Regex-free: literal text is matched verbatim (a `.` is a dot, not a wildcard) and every
+  * `{placeholder}` matches one non-empty run of non-`/` characters, in time linear in the URI
+  * length (`O(|uri| × longest literal)`, where the literal length is registration-time,
+  * server-controlled input) — no backtracking on any engine (JVM `java.util.regex`, the Scala.js
+  * `RegExp` shim, Scala Native's RE2 shim are all bypassed). Results are identical to the former
+  * greedy-regex implementation for every template whose literal text contained no regex
+  * metacharacters: within a segment each separator binds to its LAST admissible occurrence, so
+  * `{name}.{ext}` on `archive.tar.gz` yields `name = archive.tar`, `ext = gz` — exactly the
+  * leftmost-longest solution the old `([^/]+)\\.([^/]+)` produced.
+  *
+  * Registration-time validation (see [[ResourceTemplatePattern.parse]]): placeholders in the same
+  * segment must be separated by literal text (`{a}{b}` is ambiguous), placeholder names must be
+  * unique and must not contain `/`, braces must balance and not nest. Percent-encoding is not
+  * decoded (unchanged).
+  */
+final class ResourceTemplatePattern private (
+    val pattern: String,
+    private[fastmcp] val segments: Vector[Vector[ResourceTemplatePattern.Part]],
+    val paramNames: List[String]
+):
+  import ResourceTemplatePattern.Part
+
+  def isTemplate: Boolean = paramNames.nonEmpty
+
+  /** Match a client URI against this template; `Some(placeholder -> value)` on success. Linear in
+    * the URI length and free of backtracking (see the class doc).
+    */
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.Return"))
+  def matches(uri: String): Option[Map[String, String]] =
+    val pieces = ResourceTemplatePattern.splitSlashes(uri)
+    if pieces.length != segments.length then return None
+    val bindings = Map.newBuilder[String, String]
+    var i = 0
+    while i < segments.length do
+      if !matchSegment(segments(i), pieces(i), bindings) then return None
+      i += 1
+    Some(bindings.result())
+
+  /** Match one `/`-delimited segment `[L0] V1 L1 V2 L2 … Vk [Lk]` against `seg`: anchor L0 / Lk
+    * with `startsWith` / `endsWith`, then bind the separators L(k-1) … L1 right-to-left with
+    * `lastIndexOf` over disjoint leftward windows (each variable non-empty). Each `lastIndexOf`
+    * scans a window no other iteration revisits, so the whole segment costs O(|seg| × |L_i|max).
+    */
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.Return"))
+  private def matchSegment(
+      parts: Vector[Part],
+      seg: String,
+      out: scala.collection.mutable.Builder[(String, String), Map[String, String]]
+  ): Boolean =
+    parts match
+      case Vector() => seg.isEmpty
+      case Vector(Part.Literal(text)) => seg == text
+      case _ =>
+        val l0 = parts.head match
+          case Part.Literal(t) => t
+          case _ => ""
+        val lk = parts.last match
+          case Part.Literal(t) if parts.length > 1 => t
+          case _ => ""
+        if !(seg.startsWith(l0) && seg.endsWith(lk) && l0.length + lk.length < seg.length) then
+          return false
+        val inner = seg.substring(l0.length, seg.length - lk.length)
+        // Variables in order; interior literals (never first/last) are exactly the separators:
+        // consecutive literal text is merged at parse time and adjacent placeholders are rejected,
+        // so every interior literal sits between two variables and seps.length == vars.length - 1.
+        // seps(i - 1) is L_i, the separator between V_i and V_{i+1}.
+        val vars = parts.collect { case Part.Variable(name) => name }
+        val seps = ArrayBuffer.empty[String]
+        var p = 1
+        while p < parts.length - 1 do
+          parts(p) match
+            case Part.Literal(t) => seps += t
+            case _ => ()
+          p += 1
+        val values = new Array[String](vars.length)
+        var end = inner.length
+        var i = vars.length - 1
+        while i >= 1 do
+          val sep = seps(i - 1)
+          val idx = inner.lastIndexOf(sep, end - sep.length - 1)
+          if idx < 1 then return false // V_i must be non-empty
+          values(i) = inner.substring(idx + sep.length, end) // V_{i+1}, non-empty by construction
+          end = idx
+          i -= 1
+        values(0) = inner.substring(0, end)
+        if values(0).isEmpty then return false
+        var v = 0
+        while v < vars.length do
+          out += vars(v) -> values(v)
+          v += 1
+        true
+
+  override def equals(o: Any): Boolean = o match
+    case p: ResourceTemplatePattern => p.pattern == pattern
+    case _ => false
+
+  override def hashCode: Int = pattern.hashCode
+
+  override def toString: String = s"ResourceTemplatePattern($pattern)"
+
+object ResourceTemplatePattern:
+
+  private[fastmcp] enum Part:
+    case Literal(text: String)
+    case Variable(name: String)
+
+  /** Compile `pattern`; `Left(reason)` for an invalid template. */
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.Return"))
+  def parse(pattern: String): Either[String, ResourceTemplatePattern] =
+    val segments = ArrayBuffer.empty[Vector[Part]]
+    val parts = ArrayBuffer.empty[Part]
+    val literal = new StringBuilder
+    val names = ArrayBuffer.empty[String]
+
+    def flushLiteral(): Unit =
+      if literal.nonEmpty then
+        parts += Part.Literal(literal.result())
+        literal.clear()
+
+    var i = 0
+    val n = pattern.length
+    while i < n do
+      pattern.charAt(i) match
+        case '{' =>
+          val close = pattern.indexOf('}', i + 1)
+          if close < 0 then return Left(s"template '$pattern' has an unclosed '{'")
+          val name = pattern.substring(i + 1, close)
+          if name.isEmpty then return Left(s"template '$pattern' has an empty placeholder '{}'")
+          if name.contains('{') then
+            return Left(s"template '$pattern' nests a '{' inside placeholder '{$name}'")
+          if name.contains('/') then
+            return Left(s"template '$pattern' has a '/' inside placeholder '{$name}'")
+          if names.contains(name) then
+            return Left(
+              s"template '$pattern' uses placeholder '{$name}' more than once"
+            )
+          val afterVariable = parts.lastOption match
+            case Some(Part.Variable(_)) => true
+            case _ => false
+          if literal.isEmpty && afterVariable then
+            return Left(
+              s"template '$pattern' has adjacent placeholders before '{$name}' — ambiguous; " +
+                "separate placeholders with literal text"
+            )
+          flushLiteral()
+          names += name
+          parts += Part.Variable(name)
+          i = close + 1
+        case '}' =>
+          return Left(s"template '$pattern' has an unmatched '}'")
+        case '/' =>
+          flushLiteral()
+          segments += parts.toVector
+          parts.clear()
+          i += 1
+        case c =>
+          literal += c
+          i += 1
+    flushLiteral()
+    segments += parts.toVector
+    Right(new ResourceTemplatePattern(pattern, segments.toVector, names.toList))
+
+  /** Compile or throw `IllegalArgumentException` (registration time; `ResourceManager` wraps it in
+    * `ResourceRegistrationError`).
+    */
+  def apply(pattern: String): ResourceTemplatePattern =
+    parse(pattern) match
+      case Right(compiled) => compiled
+      case Left(reason) => throw new IllegalArgumentException(reason)
+
+  /** Split on `/` with a manual `indexOf` loop — NOT `String.split`, which routes through the
+    * platform regex shim on Scala.js / Scala Native.
+    */
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  private[fastmcp] def splitSlashes(s: String): ArrayBuffer[String] =
+    val out = ArrayBuffer.empty[String]
+    var from = 0
+    var idx = s.indexOf('/')
+    while idx >= 0 do
+      out += s.substring(from, idx)
+      from = idx + 1
+      idx = s.indexOf('/', from)
+    out += s.substring(from)
+    out

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/Builtins.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/Builtins.scala
@@ -7,7 +7,7 @@ import zio.json.ast.Json
 import com.tjclp.fastmcp.core.{Protocol, SetLevelRequestParams}
 import com.tjclp.fastmcp.core.wire.*
 import com.tjclp.fastmcp.jsonrpc.McpError
-import com.tjclp.fastmcp.server.{CompletionHandler, McpContext}
+import com.tjclp.fastmcp.server.{CompletionHandler, LimitSettings, McpContext}
 import com.tjclp.fastmcp.server.manager.{
   PromptManager,
   ResourceManager,
@@ -37,8 +37,23 @@ final class Builtins[R](
     tasksEnabled: Boolean,
     exposeTemplates: Boolean,
     completionHandler: Option[CompletionHandler[R]] = None,
-    hooks: ServerHooks[R] = ServerHooks.noop[R]
+    hooks: ServerHooks[R] = ServerHooks.noop[R],
+    limits: LimitSettings = LimitSettings()
 ):
+
+  /** Bound a client-supplied resource URI BEFORE it reaches the template matcher, the resource
+    * lookup, or the session's subscription set. `-32602` in both eras: this is malformed input, not
+    * a miss (the legacy `-32002` re-coding stays for real misses).
+    */
+  private def checkUriLength(ctx: String, uri: String): IO[McpError, Unit] =
+    ZIO
+      .fail(
+        McpError.invalidParams(
+          s"$ctx: uri exceeds limits.maxUriChars (${limits.maxUriChars} characters)"
+        )
+      )
+      .when(uri.length > limits.maxUriChars)
+      .unit
 
   /** Helper: decode `params` into `A`, failing with InvalidParams. */
   private def decodeParams[A: JsonDecoder](params: Json, ctx: String): IO[McpError, A] =
@@ -104,6 +119,9 @@ final class Builtins[R](
   val toolsCall: RequestHandler[R] = (session, params) =>
     for
       req <- decodeParams[CallToolRequestParams](params, "tools/call")
+      // `ToolManager.callTool` and the macro-generated `Map[String, Any] => Any` handlers need a
+      // Map; the object is already bounded to `limits.maxObjectFields` members by the transport
+      // choke point (MessageLoop.parseFrame), so this build is O(maxObjectFields²) at worst.
       args <- req.arguments match
         case Some(Json.Obj(fields)) => ZIO.succeed(fields.toMap: Map[String, Any])
         case None => ZIO.succeed(Map.empty[String, Any])
@@ -157,6 +175,7 @@ final class Builtins[R](
   val resourcesRead: RequestHandler[R] = (session, params) =>
     for
       req <- decodeParams[ReadResourceRequestParams](params, "resources/read")
+      _ <- checkUriLength("resources/read", req.uri)
       ctx <- contextFor(session)
       modern <- session.currentRequestContext.map(_.isDefined)
       body <- resourceManager
@@ -179,6 +198,11 @@ final class Builtins[R](
   val resourcesSubscribe: RequestHandler[R] = (session, params) =>
     for
       req <- decodeParams[SubscribeRequestParams](params, "resources/subscribe")
+      _ <- checkUriLength("resources/subscribe", req.uri)
+      // TODO(TJC-2294 merge): once Session exposes `subscriptionCount: UIO[Int]` (Arc C), refuse
+      // new distinct URIs beyond `limits.maxSubscriptionsPerSession` with -32602
+      // ("resources/subscribe: subscription limit reached (limits.maxSubscriptionsPerSession = N)")
+      // before `session.subscribe`; re-subscribing an already-held URI must stay OK.
       _ <- session.subscribe(req.uri)
       json <- ok(EmptyResult())
     yield json
@@ -187,6 +211,7 @@ final class Builtins[R](
   val resourcesUnsubscribe: RequestHandler[R] = (session, params) =>
     for
       req <- decodeParams[UnsubscribeRequestParams](params, "resources/unsubscribe")
+      _ <- checkUriLength("resources/unsubscribe", req.uri)
       _ <- session.unsubscribe(req.uri)
       json <- ok(EmptyResult())
     yield json
@@ -217,9 +242,11 @@ final class Builtins[R](
         resourceSubscriptions = requested.resourceSubscriptions
           .filter(_ => supportsResourceSubscriptions)
           .map(
+            // Over-long URIs are silently not acknowledged — the matcher never sees them.
             _.filter(uri =>
-              resourceManager.getResourceDefinition(uri).isDefined ||
-                resourceManager.findMatchingTemplate(uri).isDefined
+              uri.length <= limits.maxUriChars &&
+                (resourceManager.getResourceDefinition(uri).isDefined ||
+                  resourceManager.findMatchingTemplate(uri).isDefined)
             )
           )
           .filter(_.nonEmpty)

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/McpRouter.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/McpRouter.scala
@@ -8,6 +8,7 @@ import com.tjclp.fastmcp.core.*
 import com.tjclp.fastmcp.core.wire.*
 import com.tjclp.fastmcp.jsonrpc.*
 import com.tjclp.fastmcp.jsonrpc.JsonRpcMessage.*
+import com.tjclp.fastmcp.server.LimitSettings
 import com.tjclp.fastmcp.server.transport.HttpHeaderValidation
 
 /** Canonical MCP request method names. */
@@ -54,6 +55,9 @@ object Methods:
   *   advertise legacy `resources.subscribe`
   * @param listChanged
   *   advertise `listChanged` on tools/resources/prompts
+  * @param limits
+  *   inbound input limits; transports read `router.limits` and hand it to `MessageLoop.parseFrame`
+  *   so every frame on every transport is bounded by the server's settings
   */
 final class McpRouter[R](
     serverInfo: Implementation,
@@ -64,7 +68,8 @@ final class McpRouter[R](
     toolInputSchemas: Map[String, Json],
     tasksEnabled: Boolean,
     resourcesSubscribe: Boolean,
-    listChanged: Boolean
+    listChanged: Boolean,
+    val limits: LimitSettings = LimitSettings()
 ):
 
   /** Capabilities derived from the registered handler set. Issue #56 dies here: a capability is
@@ -186,26 +191,54 @@ final class McpRouter[R](
   ): URIO[R, Option[JsonRpcMessage]] =
     RequestContext.decode(params) match
       case Left(err) => ZIO.some(Failure(Some(id), err.toErrorObject))
-      case Right(context) if context.protocolVersion != Protocol.LatestProtocolVersion =>
-        ZIO.some(
-          Failure(
-            Some(id),
-            McpError
-              .unsupportedProtocolVersion(
-                context.protocolVersion,
-                List(Protocol.LatestProtocolVersion)
-              )
-              .toErrorObject
-          )
+      case Right(context) => dispatchModern(session, id, method, params, context)
+
+  /** Dispatch a 2026-07-28 request whose [[RequestContext]] the transport has ALREADY decoded (via
+    * `ModernHttpValidation.validateRequestContext`), skipping the second `RequestContext.decode`
+    * that [[dispatch]] would otherwise perform. Same checks and semantics as the modern arm of
+    * [[dispatch]]: version gate, methods removed from the stateless path, then the fiber-local
+    * request context around the handler.
+    */
+  def dispatchModern(
+      session: Session,
+      request: JsonRpcMessage.Request,
+      context: RequestContext
+  ): URIO[R, Option[JsonRpcMessage]] =
+    dispatchModern(
+      session,
+      request.id,
+      request.method,
+      request.params.getOrElse(Json.Null),
+      context
+    )
+
+  private def dispatchModern(
+      session: Session,
+      id: RequestId,
+      method: String,
+      params: Json,
+      context: RequestContext
+  ): URIO[R, Option[JsonRpcMessage]] =
+    if context.protocolVersion != Protocol.LatestProtocolVersion then
+      ZIO.some(
+        Failure(
+          Some(id),
+          McpError
+            .unsupportedProtocolVersion(
+              context.protocolVersion,
+              List(Protocol.LatestProtocolVersion)
+            )
+            .toErrorObject
         )
-      case Right(_) if removedFromStateless.contains(method) =>
-        ZIO.some(Failure(Some(id), McpError.methodNotFound(method).toErrorObject))
-      case Right(context) =>
-        val effectiveContext =
-          if modernCapabilities.logging.isDefined then context else context.copy(logLevel = None)
-        session.runWithRequest(id, effectiveContext)(
-          dispatchInitialized(session, id, method, params, modern = true)
-        )
+      )
+    else if removedFromStateless.contains(method) then
+      ZIO.some(Failure(Some(id), McpError.methodNotFound(method).toErrorObject))
+    else
+      val effectiveContext =
+        if modernCapabilities.logging.isDefined then context else context.copy(logLevel = None)
+      session.runWithRequest(id, effectiveContext)(
+        dispatchInitialized(session, id, method, params, modern = true)
+      )
 
   private def dispatchInitialized(
       session: Session,

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/RequestContext.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/RequestContext.scala
@@ -5,7 +5,7 @@ import zio.json.ast.Json
 
 import com.tjclp.fastmcp.core.LoggingLevel
 import com.tjclp.fastmcp.core.wire.{ClientCapabilities, Implementation}
-import com.tjclp.fastmcp.jsonrpc.McpError
+import com.tjclp.fastmcp.jsonrpc.{JsonFields, McpError}
 
 /** The 2026-07-28 metadata and retry payload bound to one request fiber. It is deliberately
   * fiber-local: the protocol is stateless and concurrent calls from one stdio connection must never
@@ -27,21 +27,25 @@ object RequestContext:
   val ClientInfoKey = "io.modelcontextprotocol/clientInfo"
   val LogLevelKey = "io.modelcontextprotocol/logLevel"
 
+  /** Linear lookups ([[JsonFields]]) — this runs on every request before dispatch, so it must never
+    * build a map from client-chosen keys.
+    */
   def declaredProtocolVersion(params: Json): Option[String] =
-    params match
-      case Json.Obj(fields) =>
-        fields.toMap.get("_meta") match
-          case Some(Json.Obj(meta)) =>
-            meta.toMap.get(ProtocolVersionKey).collect { case Json.Str(value) => value }
-          case _ => None
-      case _ => None
+    JsonFields
+      .get(params, "_meta")
+      .flatMap(JsonFields.get(_, ProtocolVersionKey))
+      .collect { case Json.Str(value) => value }
 
+  /** Top-level lookups are linear; the `meta` / `inputResponses` maps (public fields) are built
+    * with `toMap` over objects already bounded by `limits.maxObjectFields` at the transport choke
+    * point (`MessageLoop.parseFrame`).
+    */
   def decode(params: Json): Either[McpError, RequestContext] =
     for
       fields <- params match
-        case Json.Obj(value) => Right(value.toMap)
+        case Json.Obj(value) => Right(value)
         case _ => Left(McpError.invalidParams("request params must be an object"))
-      meta <- fields.get("_meta") match
+      meta <- JsonFields.get(fields, "_meta") match
         case Some(Json.Obj(value)) => Right(value.toMap)
         case _ => Left(McpError.invalidParams("request params must include an object `_meta`"))
       version <- meta.get(ProtocolVersionKey) match
@@ -51,11 +55,11 @@ object RequestContext:
       capabilities <- decodeRequired[ClientCapabilities](meta, ClientCapabilitiesKey)
       clientInfo <- decodeOptional[Implementation](meta, ClientInfoKey)
       logLevel <- decodeOptional[LoggingLevel](meta, LogLevelKey)
-      inputResponses <- fields.get("inputResponses") match
+      inputResponses <- JsonFields.get(fields, "inputResponses") match
         case None => Right(Map.empty[String, Json])
         case Some(Json.Obj(values)) => Right(values.toMap)
         case Some(_) => Left(McpError.invalidParams("`inputResponses` must be an object"))
-      requestState <- fields.get("requestState") match
+      requestState <- JsonFields.get(fields, "requestState") match
         case None => Right(None)
         case Some(Json.Str(value)) => Right(Some(value))
         case Some(_) => Left(McpError.invalidParams("`requestState` must be a string"))

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/RouterBuilder.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/RouterBuilder.scala
@@ -82,7 +82,8 @@ object RouterBuilder:
       tasksEnabled = tasksOn,
       exposeTemplates = exposeTemplates,
       completionHandler = completionHandler,
-      hooks = hooks
+      hooks = hooks,
+      limits = settings.limits
     )
 
     val taskHandlers = taskManager.map(tm => new TaskHandlers[R](tm))
@@ -154,5 +155,6 @@ object RouterBuilder:
         toolManager.listDefinitions().map(d => d.name -> d.inputSchema.toAst).toMap,
       tasksEnabled = tasksOn,
       resourcesSubscribe = resourcesSubscribe,
-      listChanged = listChanged
+      listChanged = listChanged,
+      limits = settings.limits
     )

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/Validation.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/router/Validation.scala
@@ -4,7 +4,7 @@ import zio.*
 import zio.json.ast.Json
 
 import com.tjclp.fastmcp.core.ToolInputSchema
-import com.tjclp.fastmcp.jsonrpc.McpError
+import com.tjclp.fastmcp.jsonrpc.{JsonFields, McpError}
 import com.tjclp.fastmcp.server.manager.ToolManager
 
 /** Pluggable JSON Schema validator for `tools/call` arguments.
@@ -39,7 +39,7 @@ final class ValidationMiddleware[R](
           for
             name <- params match
               case Json.Obj(fields) =>
-                fields.toMap.get("name") match
+                JsonFields.get(fields, "name") match
                   case Some(Json.Str(n)) => Right(n)
                   case _ => Left(McpError.invalidParams("tools/call: missing `name`"))
               case _ => Left(McpError.invalidParams("tools/call: params must be an object"))
@@ -47,9 +47,7 @@ final class ValidationMiddleware[R](
               .getToolDefinition(name)
               .map(_.inputSchema)
               .toRight(McpError.invalidParams(s"Unknown tool: $name"))
-            args = params match
-              case Json.Obj(fields) => fields.toMap.getOrElse("arguments", Json.Obj())
-              case _ => Json.Obj()
+            args = JsonFields.get(params, "arguments").getOrElse(Json.Obj())
             _ <- validator.validate(schema, args).left.map(McpError.invalidParams)
           yield ()
         ZIO.fromEither(check) *> next(session, params)

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/BoundedLines.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/BoundedLines.scala
@@ -1,0 +1,85 @@
+package com.tjclp.fastmcp.server.transport
+
+import zio.*
+import zio.stream.*
+
+/** `ZPipeline.splitLines` with a cap on the buffered line.
+  *
+  * The stock splitter accumulates a whole line in memory before emitting it, so on stdio a peer
+  * that never sends a newline grows the read buffer without bound — `MessageLoop.parseFrame`'s
+  * `maxFrameChars` check runs only after the line is complete. This pipeline keeps the first
+  * `maxChars + 1` characters of an over-long line, DISCARDS the rest of that line as it streams in
+  * (the buffer never grows past the cap), and emits the truncated prefix as the frame at the next
+  * newline (or end of stream). `parseFrame` then rejects it as `FrameTooLong` (-32700), so the peer
+  * still gets a reply for every line it sent.
+  *
+  * Line semantics match `splitLines`: `\\n` and `\\r\\n` terminate a line (a `\\r\\n` split across
+  * chunks is handled), a lone `\\r` is content, and a trailing partial line is flushed at end of
+  * stream.
+  */
+object BoundedLines:
+
+  def pipeline(maxChars: Int)(implicit trace: Trace): ZPipeline[Any, Nothing, String, String] =
+    ZPipeline.suspend {
+      val state = new State(maxChars)
+
+      lazy val loop: ZChannel[Any, ZNothing, Chunk[String], Any, Nothing, Chunk[String], Any] =
+        ZChannel.readWithCause(
+          in =>
+            val out = state.feed(in)
+            if out.isEmpty then loop else ZChannel.write(out) *> loop
+          ,
+          err =>
+            state.flush.fold(ZChannel.refailCause(err))(
+              ZChannel.write(_) *> ZChannel.refailCause(err)
+            ),
+          done =>
+            state.flush.fold(ZChannel.succeed(done))(ZChannel.write(_) *> ZChannel.succeed(done))
+        )
+
+      ZPipeline.fromChannel(loop)
+    }
+
+  /** Mutable splitter state — one per pipeline instance (`ZPipeline.suspend` allocates it per
+    * stream), never shared across fibers.
+    */
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  private final class State(maxChars: Int):
+    private val cap = maxChars + 1
+    private val line = new java.lang.StringBuilder
+    private var discarding = false
+
+    /** Append `s(from until until)` to the current line, keeping at most `cap` chars. */
+    private def append(s: String, from: Int, until: Int): Unit =
+      if !discarding && until > from then
+        val room = cap - line.length
+        if until - from <= room then line.append(s, from, until)
+        else
+          line.append(s, from, from + room)
+          discarding = true
+
+    /** Emit the current line (with one trailing `\\r` stripped — CRLF), reset. */
+    private def emit(): String =
+      if !discarding && line.length > 0 && line.charAt(line.length - 1) == '\r' then
+        line.setLength(line.length - 1)
+      val out = line.toString
+      line.setLength(0)
+      discarding = false
+      out
+
+    def feed(chunk: Chunk[String]): Chunk[String] =
+      val builder = ChunkBuilder.make[String]()
+      chunk.foreach { s =>
+        var from = 0
+        var nl = s.indexOf('\n')
+        while nl >= 0 do
+          append(s, from, nl)
+          builder += emit()
+          from = nl + 1
+          nl = s.indexOf('\n', from)
+        append(s, from, s.length)
+      }
+      builder.result()
+
+    def flush: Option[Chunk[String]] =
+      if line.length == 0 && !discarding then None else Some(Chunk.single(emit()))

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/BoundedLines.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/BoundedLines.scala
@@ -45,7 +45,9 @@ object BoundedLines:
     */
   @SuppressWarnings(Array("org.wartremover.warts.Var"))
   private final class State(maxChars: Int):
-    private val cap = maxChars + 1
+    // `maxChars + 1` would wrap for LimitSettings(maxFrameChars = Int.MaxValue) — a legal
+    // "unbounded" configuration — so saturate instead of overflowing into a negative cap.
+    private val cap = if maxChars == Int.MaxValue then Int.MaxValue else maxChars + 1
     private val line = new java.lang.StringBuilder
     private var discarding = false
 
@@ -53,10 +55,9 @@ object BoundedLines:
     private def append(s: String, from: Int, until: Int): Unit =
       if !discarding && until > from then
         val room = cap - line.length
-        if until - from <= room then line.append(s, from, until)
-        else
-          line.append(s, from, from + room)
-          discarding = true
+        val take = if until - from <= room then until else from + room
+        line.append(s, from, take)
+        if take < until then discarding = true
 
     /** Emit the current line (with one trailing `\\r` stripped — CRLF), reset. */
     private def emit(): String =

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/MessageLoop.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/MessageLoop.scala
@@ -2,9 +2,12 @@ package com.tjclp.fastmcp.server.transport
 
 import zio.*
 import zio.json.*
+import zio.json.ast.Json
 
+import com.tjclp.fastmcp.codec.JsonLimits
 import com.tjclp.fastmcp.jsonrpc.*
 import com.tjclp.fastmcp.jsonrpc.JsonRpcMessage.*
+import com.tjclp.fastmcp.server.LimitSettings
 import com.tjclp.fastmcp.server.router.{McpRouter, Methods, Session}
 
 /** Platform-neutral wire ↔ dispatch bridge. Every transport — JVM, Scala.js, Scala Native — reduces
@@ -25,23 +28,45 @@ object MessageLoop:
       session: Session,
       frame: String
   ): URIO[R, Option[String]] =
-    parseFrame(frame) match
+    parseFrame(frame, router.limits) match
       case Right(message) =>
         router.dispatch(session, message).map(_.map(_.toJson))
       case Left(parseFailure) =>
         ZIO.some(parseFailure.toJson)
 
-  /** Parse one frame. `Left` carries the ready-to-send JSON-RPC parse-error response (null id, per
-    * JSON-RPC). HTTP transports parse *before* touching session state so a malformed body can never
-    * mint a session; stdio just feeds both arms to the writer.
+  /** Parse one frame under `limits`. `Left` carries the ready-to-send JSON-RPC parse-error response
+    * (null id, per JSON-RPC).
+    *
+    * This is the single choke point for the inbound input limits on every transport: frame length,
+    * nesting depth and per-object member count are checked on the raw text ([[JsonLimits.preScan]])
+    * BEFORE zio-json allocates a node, and re-checked iteratively on the AST
+    * ([[JsonLimits.validate]]) before the envelope is decoded. Limit violations are parser
+    * constraints and answer `-32700` like any other unparseable frame (JSON-RPC 2.0 §5.1 — the same
+    * mapping Jackson's `StreamReadConstraints` get in the MCP Java SDK); we deliberately do not
+    * echo an id taken from a frame we refused to parse.
+    *
+    * HTTP transports parse — and therefore enforce limits — *before* touching session state, so a
+    * malformed or oversized body can never mint a session; stdio just feeds both arms to the
+    * writer. The 1-arg form keeps default limits for callers without a router; transports pass
+    * `router.limits`.
     */
-  def parseFrame(frame: String): Either[JsonRpcMessage, JsonRpcMessage] =
-    frame
-      .fromJson[JsonRpcMessage]
-      .left
-      .map(parseError =>
-        Failure(None, McpError.parseError(s"Parse error: $parseError").toErrorObject)
-      )
+  def parseFrame(
+      frame: String,
+      limits: LimitSettings = LimitSettings()
+  ): Either[JsonRpcMessage, JsonRpcMessage] =
+    JsonLimits.preScan(frame, limits.maxFrameChars, limits.maxDepth, limits.maxObjectFields) match
+      case Some(violation) => Left(parseFailure(violation.message))
+      case None =>
+        frame.fromJson[Json].left.map(parseFailure).flatMap { json =>
+          JsonLimits.validate(json, limits.maxDepth, limits.maxObjectFields) match
+            case Some(violation) => Left(parseFailure(violation.message))
+            // AST path: the envelope decoder is `mapOrFail`, whose `unsafeFromJsonAST` override
+            // applies straight to the node — no re-encode.
+            case None => json.as[JsonRpcMessage].left.map(parseFailure)
+        }
+
+  private def parseFailure(detail: String): JsonRpcMessage =
+    Failure(None, McpError.parseError(s"Parse error: $detail").toErrorObject)
 
   /** True for the legacy `initialize` request — the only compatibility frame allowed to mint an
     * initialization-era Streamable HTTP session.

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/MessageLoop.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/MessageLoop.scala
@@ -17,6 +17,13 @@ import com.tjclp.fastmcp.server.router.{McpRouter, Methods, Session}
   */
 object MessageLoop:
 
+  /** Ignore blank stdio lines only when they fit the frame limit. An oversized prefix retained by
+    * the line splitter must reach `parseFrame` unchanged, even if it is entirely whitespace;
+    * trimming it could erase the overflow or turn a truncated invalid line into a valid request.
+    */
+  private[fastmcp] def shouldDispatchStdioFrame(frame: String, limits: LimitSettings): Boolean =
+    frame.length > limits.maxFrameChars || frame.trim.nonEmpty
+
   /** Process one inbound JSON-RPC frame (a single message — batching was dropped from the spec).
     *
     * Returns the serialized response frame, or `None` for notifications / cancelled requests /

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/ModernHttpValidation.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/ModernHttpValidation.scala
@@ -109,11 +109,15 @@ private[fastmcp] object ModernHttpValidation:
       _ <- router.validateHttpMethod(notification.method, header).left.map(400 -> _)
     yield ()
 
-  def validateRequest[R](
+  /** Same checks as [[validateRequest]], returning the decoded [[RequestContext]] so the transport
+    * can hand it to `McpRouter.dispatchModern` and skip the second `RequestContext.decode`. Frames
+    * reaching this point have already passed the input limits in `MessageLoop.parseFrame`.
+    */
+  def validateRequestContext[R](
       router: McpRouter[R],
       rpc: JsonRpcMessage.Request,
       header: String => Option[String]
-  ): Either[(Int, McpError), Unit] =
+  ): Either[(Int, McpError), RequestContext] =
     for
       _ <- Either.cond(
         contentTypeOk(header),
@@ -156,4 +160,14 @@ private[fastmcp] object ModernHttpValidation:
         (),
         404 -> McpError.methodNotFound(rpc.method)
       )
-    yield ()
+    yield context
+
+  /** Signature-stable form of [[validateRequestContext]] (both platform backends declare
+    * `Either[(Int, McpError), Unit]` return types around it).
+    */
+  def validateRequest[R](
+      router: McpRouter[R],
+      rpc: JsonRpcMessage.Request,
+      header: String => Option[String]
+  ): Either[(Int, McpError), Unit] =
+    validateRequestContext(router, rpc, header).map(_ => ())


### PR DESCRIPTION
## Summary

Three availability findings from the 2026-09-04 security scan share one root cause: client-supplied input reached recursive or super-linear code paths with no bound. Hash-colliding JSON object keys made `Chunk.toMap` quadratic on Bun's single thread (F1, CWE-407); resource URI templates such as `{name}.{ext}` compiled to a backtracking regex that a 100 KB URI could pin for seconds to hours (F2, CWE-1333); and deeply nested `tools/call` arguments were re-serialised by an unguarded recursive encoder whose `StackOverflowError` is fatal to ZIO and exits the JVM/Native process (F3, CWE-674). This PR adds `McpServerSettings.limits: LimitSettings`, enforced at the single `MessageLoop.parseFrame` choke point on every transport and platform before any dispatch or session work, replaces the regex matcher with a linear `ResourceTemplatePattern` compiled once at registration, and moves tool/prompt/resource argument decoding onto zio-json's guarded `fromJsonAST` path.

Part 4/6 of the TJC-2294 security stack; base: `tjc-2297-tasks-hardening`. Linear: TJC-2295 (umbrella TJC-2294).

## Findings addressed

| Finding | Severity | CWE | Title | Status |
|---|---|---|---|---|
| F1 | HIGH | CWE-407 | Bun HTTP: hash-colliding JSON object keys make Scala HashMap construction quadratic | Criterion 1 fixed in this PR; criterion 2 (operator-configurable HTTP body cap, 413 before parsing) lands in #91, with the `maxRequestBodyBytes <= limits.maxFrameChars` cross-check wired in #92 |
| F2 | HIGH | CWE-1333 | Resource template matching backtracks polynomially on attacker-length client URIs (ReDoS) | Fixed |
| F3 | MEDIUM | CWE-674 | Deeply nested `tools/call` arguments re-encoded by an unguarded recursive encoder; `StackOverflowError` fatal to ZIO | Fixed |

## What changed

**Input limits (F1, F3)**
- `shared/src/com/tjclp/fastmcp/server/McpServerSettings.scala` — new last field `limits: LimitSettings = LimitSettings()` and `case class LimitSettings(maxFrameChars = 4 * 1024 * 1024, maxDepth = 64, maxObjectFields = 1024, maxUriChars = 8192, maxSubscriptionsPerSession = 1024)`. Every value is `require`d at construction (`IllegalArgumentException`); `maxDepth` is capped at `LimitSettings.MaxSupportedDepth = 256`. Frame-limit violations answer `-32700` (HTTP 400, `id: null`); URI/subscription bounds answer `-32602`.
- `shared/src/com/tjclp/fastmcp/codec/JsonLimits.scala` (new, `private[fastmcp]`) — `preScan` is a linear, string/escape-aware pass over the raw text that counts frame length, bracket depth and per-object commas before zio-json allocates a node; `validate` is an iterative worklist re-check on the AST; `typeName` names a JSON type so error bodies never echo the value. Also home of `MaxSupportedDepth` / `DefaultMaxDepth` / `DefaultMaxObjectFields`.
- `shared/src/com/tjclp/fastmcp/server/transport/MessageLoop.scala` — `parseFrame(frame, limits)` runs `preScan` -> `fromJson[Json]` -> `validate` -> `json.as[JsonRpcMessage]` (AST path, no re-encode). `handleFrame` passes `router.limits`.
- `shared/src/com/tjclp/fastmcp/jsonrpc/JsonRpc.scala` — new `private[fastmcp] object JsonFields` (linear last-wins lookup, the semantics `Chunk.toMap` had for duplicate keys); the envelope decoder no longer calls `fields.toMap`. Numeric `RequestId`s are accepted only if whole and within `Long` range (`longValueExact` behind a `scale < -19` short-circuit); otherwise `-32600` with `id: null`. Parse/invalid errors report `JsonLimits.typeName` instead of the offending value.
- `shared/src/com/tjclp/fastmcp/server/router/{RequestContext,Validation}.scala` — `_meta`, `protocolVersion`, `name`, `arguments` lookups go through `JsonFields`; the remaining `toMap`s run only on objects already bounded by `maxObjectFields`.
- `shared/src/com/tjclp/fastmcp/server/router/{McpRouter,RouterBuilder}.scala` — `McpRouter.limits: LimitSettings` threaded from `settings.limits`; new `dispatchModern(session, rpc, ctx)` so a transport can reuse an already-decoded `RequestContext`.
- `shared/src/com/tjclp/fastmcp/server/transport/ModernHttpValidation.scala` — new `validateRequestContext` (returns the decoded context); `validateRequest` keeps its exact signature.
- `shared/src/com/tjclp/fastmcp/server/transport/BoundedLines.scala` (new) — a `ZPipeline.splitLines` replacement that caps the line buffer at `maxChars + 1` (saturating at `Int.MaxValue`): an over-long line is truncated, answered `-32700 maxFrameChars`, and the rest discarded until the next newline. Wired into `jvm/.../JvmTransportBackend.scala:36` and `native/.../NativeTransportBackend.scala:62`.
- `jvm/.../JvmHttpBackend.scala:186,267` and `js/.../JsTransportBackend.scala:191,222` — `MessageLoop.parseFrame(body, router.limits)` (the only edits to those files in this PR).

**Resource URI templates (F2)**
- `shared/src/com/tjclp/fastmcp/server/manager/ResourceTemplatePattern.scala` (new) — `final class` with `parse(pattern): Either[String, ResourceTemplatePattern]` and `matches(uri): Option[Map[String, String]]`. Manual `/` split, `startsWith`/`endsWith` anchoring, right-to-left `lastIndexOf` separator binding over disjoint windows; no `java.util.regex`, no `String.split`. `parse` rejects adjacent placeholders `{a}{b}`, duplicate names, unbalanced/nested braces, `{}` and `/` inside a name.
- `shared/src/com/tjclp/fastmcp/server/manager/ResourceManager.scala` — templates compiled once in `addTemplateResource` and stored as `(ResourceTemplatePattern, ResourceDefinition, handler)`; invalid templates surface as `ResourceRegistrationError`; a template with the same placeholder shape as an existing one (`users://{id}` vs `users://{userId}`) logs a warning.
- `shared/src/com/tjclp/fastmcp/server/router/Builtins.scala:48-55` — `checkUriLength` (`-32602`, `"<method>: uri exceeds limits.maxUriChars (N characters)"`) runs first after params decoding in `resources/read`, `resources/subscribe`, `resources/unsubscribe`, and filters `subscriptions/listen` entries.

**Argument decoding (F3)**
- `shared/src/com/tjclp/fastmcp/codec/DefaultDecodeContext.scala` — constructor `(maxDepth, maxObjectFields)` (defaulted; `DefaultDecodeContext.default` unchanged for callers). New `decodeRaw` decodes via `decoder.fromJsonAST` for the shipped context (custom `McpDecodeContext`s keep the legacy `writeValueAsString + decodeJson` path). `writeValueAsString`, `toJsonAst` and the error preview are wrapped in `guardDepth` (JVM `StackOverflowError` -> `IllegalArgumentException` -> `-32602`). `parseJsonArray`/`parseJsonObject` run `JsonLimits.preScan` on the embedded string before the parser, then `validate` on the AST. No longer imports `server.*`.
- `shared/src/com/tjclp/fastmcp/codec/McpDecoders.scala` and `shared/src/com/tjclp/fastmcp/macros/MapToFunctionMacro.scala` — both default `McpDecoder` givens and the macro-generated per-parameter decoders emit `DefaultDecodeContext.decodeRaw`.

## Behaviour changes (pre-1.0)

- Frames longer than 4 MiB (any transport, any platform) are refused with `-32700` unless `limits.maxFrameChars` is raised; `sampling/createMessage` results carrying large base64 images over stdio may need `LimitSettings(maxFrameChars = 16 * 1024 * 1024)`. `Int.MaxValue` is a valid "unbounded" setting.
- JSON nested deeper than 64 levels (envelope = depth 1) or any object with more than 1024 members is `-32700`; error messages intentionally name the configured limit (replacing the previous stack-size oracle) and name the JSON type instead of echoing the value.
- Numeric JSON-RPC ids such as `1e30` or `1.5` are now `-32600` (`id: null`) rather than silently wrapped and echoed as a different id.
- Resource template literal text is matched verbatim: `.` in `file://{name}.txt` is a dot, not a regex wildcard. Placeholders within one segment must be separated by literal text; `{a}{b}`, duplicate names, malformed braces and `/` in a name are rejected at registration (`ResourceRegistrationError`). Otherwise results equal the former greedy regex: `{name}.{ext}` on `archive.tar.gz` yields `name = archive.tar`, `ext = gz`.
- `ResourceTemplatePattern` is a `final class` (no `unapply`/`copy`); `matches` returns `Option[Map[String, String]]`; `extractParams(uri, Regex.Match)` was removed; `findMatchingTemplate` keeps its tuple shape. Registering a same-shape template logs a warning.
- Client resource URIs longer than 8192 chars are `-32602` on `resources/read`, `resources/subscribe`, `resources/unsubscribe` and are dropped from `subscriptions/listen`.
- JVM and Native stdio: an over-long line is truncated, answered `-32700`, and the remainder discarded.
- `LimitSettings` and `DefaultDecodeContext` validate/accept new constructor parameters; a decode failure that used to surface as a JVM `StackOverflowError` is now a `-32602` tool error.
- Not in this PR (later in the stack): 413 on oversized HTTP bodies and 415 on non-JSON POSTs (#91); `maxSubscriptionsPerSession` enforcement and Bun stdin bounding (#92).

## Fix criteria -> evidence

**F1 — criterion 1** (equal-hash keys processed in linear time or rejected early; 2^17 keys answered well under a second without delaying concurrent requests): `MessageLoop.scala:53-66` (`preScan` then `validate` with `router.limits`, before `fromJson`), `JsonLimits.scala:50-113`, `JsonRpc.scala:14-22,130-163` (`JsonFields`, no `toMap`), `RequestContext.scala:34-62`, `Validation.scala:42,50`. Tests: `JsonLimitsTest` ("2^15+ and 2^17+ colliding keys are rejected by the pre-scan in well under a second" — 3^11 = 177 147 keys in < 200 ms; "a colliding frame does not delay a concurrent ping on the same router" — `zipPar`, both < 500 ms; "residual per-object cost at the default maxObjectFields is tracked"), `JvmHttpLimitsTest` (streamable and stateless colliding `initialize` -> 400/-32700, no `mcp-session-id`), `JsServerLimitsTest` (Bun: 243 colliding keys -> 400 in < 200 ms), `JsonLimitsNativeTest` ("a 3^9-colliding-key object is rejected as maxObjectFields"), `LimitsWiringTest` (source scan: every `parseFrame(` outside `MessageLoop` passes `router.limits`).

**F1 — criterion 2** (explicit HTTP body limit, 413 before parsing): deferred to #91 (`McpServerSettings.maxRequestBodyBytes` -> zio-http/Bun `maxRequestBodySize` -> 413). This PR ships the transport-independent backstop `limits.maxFrameChars` at `MessageLoop.scala:57` (`JsonLimitsTest` "frames longer than maxFrameChars are rejected without parsing"); #92 adds the `maxRequestBodyBytes <= limits.maxFrameChars` startup check.

**F2 — criterion 1** (matching linear in URI length regardless of template shape; 100 KB URI vs `x://{a}-{b}` and `x://{a}.{b}.{c}` in milliseconds): `ResourceTemplatePattern.scala:35-97` (`matches`/`matchSegment`, `lastIndexOf` at :86), `:115-167` (`parse` rejections, adjacent placeholders at :147-148), `:181` (`splitSlashes`). Tests: `UriTemplateMatcherTest` ("100 KB adversarial URIs are matched in milliseconds, directly and through ResourceManager" — 7 inputs each < 100 ms; "matches equals the former greedy regex (with quoted literals) on randomised inputs" — 8 templates x 2000 inputs; "invalid templates are rejected at parse time"), `FromJsonAstDecodeTest` ("ResourceTemplatePattern is regex-free and linear on the JS engine"), `JsonLimitsNativeTest` ("the template matcher handles a 100 KB adversarial URI without regex").

**F2 — criterion 2** (`-32602` above a documented max URI length before matching; patterns compiled once): `Builtins.scala:48-55` (`checkUriLength`), `:178,201,214,247` (call sites), `McpServerSettings.scala:174` (`maxUriChars = 8192`, scaladoc), `ResourceManager.scala:43,78,160-161` (stored compiled pattern; `findMatchingTemplate` only calls `matches`). Tests: `ResourceUriLimitTest` ("resources/read: a 9 000-char URI is -32602 (maxUriChars) and never reaches the handler" — handler counter stays 0, 8192 chars accepted; subscribe/unsubscribe; `subscriptions/listen`; "a custom maxUriChars is honoured exactly (16 accepted, 17 rejected)" through `McpServer` -> `buildRouter` -> `handleFrame`), `UriTemplateMatcherTest` ("registered templates are compiled once").

**F3** (depth bounded by a small fixed limit before any recursive processing; argument decoding via `fromJsonAST` or guarded; `tools/call` nested at any depth up to the body limit returns a JSON-RPC error and the process stays up on JVM and Native): `McpServerSettings.scala:172,178-181,192` (`maxDepth = 64`, `require <= MaxSupportedDepth = 256`), `JsonLimits.scala:25,50-113`, `MessageLoop.scala:57-65`, `DefaultDecodeContext.scala:69-72` (`parseBounded` pre-scan), `:80-81` (`writeValueAsString` under `guardDepth`), `:94-98` (`guardDepth`), `:111` (`decodeRaw`), `McpDecoders.scala:45,52`, `MapToFunctionMacro.scala:84-87`, `BoundedLines.scala:22,50`. Tests: `JsonLimitsTest` ("100 000 nested arrays are rejected as maxDepth before the parser runs"; "300 nested objects are rejected; 60-deep tools/call arguments are accepted"; "maxDepth is inclusive"), `DecodePathTest` ("writeValueAsString on a 200 000-deep value throws IllegalArgumentException, not an Error"; "decoding a deep raw value through McpDecoder never lets a java.lang.Error out"; "parseJsonArray / parseJsonObject bound the depth and width of embedded JSON" — 300- and 50 000-deep strings -> `maxDepth`; "tools/call with 60-deep arguments gets a JSON-RPC reply and the JVM stays up"), `JvmHttpLimitsTest` ("tools/call nested 20 deep is 400/-32700 (maxDepth); the server then answers a ping"; "modern path: a 20-deep _meta is 400/-32700"), `JsServerLimitsTest` (20-deep -> 400, no `RangeError`, then `initialize` + `ping` OK), `JsonLimitsNativeTest` ("a 100 000-deep frame is rejected as maxDepth without touching the parser"; "embedded JSON strings are depth-bounded before any recursive walk" — the suite completing is the Native process-survival canary), `BoundedLinesTest` ("50 MB without a newline is bounded to maxChars + 1").

## Tests

- `jvm/test/.../server/transport/JsonLimitsTest.scala` (18) — pre-scan/validate boundaries, colliding keys, depth, frame length, string-awareness, duplicate keys, out-of-range ids, small error bodies, `LimitSettings` guards, router wiring.
- `jvm/test/.../server/transport/BoundedLinesTest.scala` (6) — `splitLines` parity (LF/CRLF/lone CR, chunk boundaries), truncation, 50 MB no-newline, `Int.MaxValue` passthrough, truncated frame -> `-32700`.
- `jvm/test/.../codec/DecodePathTest.scala` (8) — AST decode path for explicit/derived/nested decoders and macro parameters, custom-context legacy path, deep-value guards, embedded-JSON bounds, end-to-end 60-deep `tools/call`.
- `jvm/test/.../server/transport/JvmHttpLimitsTest.scala` (5) — streamable/stateless/modern HTTP: colliding and deep bodies -> 400/-32700, no session minted, server keeps serving.
- `jvm/test/.../server/transport/LimitsWiringTest.scala` (2) — source scan across `jvm/js/shared/native/src` that fails if any `parseFrame(` call site omits `router.limits`.
- `jvm/test/.../server/manager/UriTemplateMatcherTest.scala` (11) — matcher semantics table, parse rejections, `ResourceRegistrationError`, greedy-regex equivalence property, 100 KB adversarial timing, compiled-once.
- `jvm/test/.../server/ResourceUriLimitTest.scala` (4) — `maxUriChars` on read/subscribe/unsubscribe/listen, custom limit through the full server path.
- `js/test/.../conformance/JsServerLimitsTest.scala` (3, Bun; ports 38931-38933) — colliding-key and deep POSTs on stateless and stateful Bun HTTP, within-limits worst case.
- `js/test/.../codec/FromJsonAstDecodeTest.scala` (4, Bun) — AST decode on JS, no `RangeError`, embedded depth bound, matcher linearity on JavaScriptCore.
- `native/test/.../server/transport/JsonLimitsNativeTest.scala` (5, Scala Native) — deep frame, colliding keys, normal frame, embedded-string bounds, matcher on a 100 KB URI.

## Verification

Run on this branch in isolation (results as reported by the implementation report; no CI claims):

- `rm -rf out/fast-mcp-scala && ./mill fast-mcp-scala.compile` — 168/168 SUCCESS (JVM + Scala.js + Scala Native), clean macro rebuild; zero new warnings in touched files.
- `./mill fast-mcp-scala.reformat && ./mill fast-mcp-scala.checkFormat` — "Everything is formatted already" (16/16).
- `./mill fast-mcp-scala.jvm.test.testOnly` on `JsonLimitsTest`, `BoundedLinesTest`, `DecodePathTest`, `JvmHttpLimitsTest`, `JsonRpcEnvelopeTest` — 18 + 6 + 8 + 5 + 9, 0 failed (the pre-existing envelope test incl. `id: 1.5 -> Invalid` passes against the new range check).
- `./mill fast-mcp-scala.test` — 532/532 SUCCESS across JVM, Scala.js/Bun (49 tests) and Scala Native (13 tests); every suite `failed 0`.
- `scripts/conformance.sh jvm` and `scripts/conformance.sh js` — 73 passed / 0 failed each (31 active scenarios), "Baseline check passed" with the EMPTY `conformance/baseline-{jvm,js}.yml`.
- `git diff --name-only`: 30 files, all within the arc's owned set plus the six permitted one-line backend edits.

The independent verifier additionally reproduced the fixes live on the merged stack tip: 177k colliding keys -> 413 in ~2 ms and 19.7k keys -> 400/-32700 in ~7 ms on Bun with a concurrent request unblocked; the finding's ReDoS inputs and 4 MiB URIs vs `{a}-{b}` / `{a}.{b}.{c}.{d}.{e}` in under 4 ms where the original regex took 19.6 s on a 3 KB three-placeholder URI; JVM HTTP depths 65..200 003 all `-32700` in <= 11 ms and a 2 000 000-deep stdio frame answered `-32700` with the process exiting 0 at EOF.

## Residual risk / follow-ups

- **Residual per-object constant (F1)**: at the default `maxObjectFields = 1024` every `Map` sink after the choke point still costs up to ~1024^2/2 string comparisons per colliding object, i.e. roughly 0.4 s per 4 MiB frame on the JVM and several times that on single-threaded Bun. Cost is linear in frame size (criterion 1 holds) but knob-dependent; documented in the `LimitSettings.maxObjectFields` scaladoc with the recommendation to lower it to 256 for untrusted Bun deployments. Lowering the default is a maintainer call.
- `limits.maxSubscriptionsPerSession` is defined and validated but not yet enforced — `Builtins.scala:202-205` carries a `TODO(TJC-2294 merge)` because the check needs `Session.subscriptionCount` from #89; wired in #92. Until then an initialized legacy session can grow its subscription set with distinct URIs of up to 8192 chars each.
- Bun stdio: the `wireStdin` accumulator in `JsTransportBackend.scala` is unbounded until a newline arrives (file owned by #91; the `BoundedLines`-equivalent bound lands in #92). JVM and Native stdio buffers are bounded here.
- `DefaultDecodeContext.default` uses the built-in 64/1024 embedded-JSON bounds, not `settings.limits`; `McpServer.scala` threads `settings.limits` through in #92.
- Modern HTTP requests decode `RequestContext` twice until the transports adopt `validateRequestContext` + `dispatchModern` (provided here; adoption is a follow-up). Cost is bounded by `maxObjectFields`.
- A user-supplied custom `McpDecodeContext` keeps the legacy `writeValueAsString + decodeJson` path and its own `writeValueAsString` is not wrapped in `guardDepth`; the frame-level depth bound still protects it for wire input.
- Native has unit-level (`parseFrame` / `DefaultDecodeContext`) but no end-to-end `tools/call`-over-stdio canary for deep input; the shared code path is the one exercised live on the JVM.
- The `@Resource` macro (`ResourceProcessor.scala`) still extracts placeholders with a regex and defers ambiguous-template rejection (`x://{a}{b}`) to a startup `ResourceRegistrationError` rather than a compile error.
- On Scala.js and Scala Native the depth bounds, not a `StackOverflowError` catch, are the protection (JS throws `RangeError`; Native does not deliver a catchable overflow).
- `NativeTransportBackend.scala:22` doc comment still mentions `ZPipeline.splitLines` (only the one-line wiring edit was permitted here; fixed in #92). `HttpHeaderValidation.scala` (#91) and `TaskRouting.scala` (#89) still build `params.toMap` for single-key lookups — bounded after the choke point, switched to `JsonFields.get` in #92.
- Memory stays linear in frame size (a 4 MiB `[1,1,...]` frame is ~2M `Json.Num` nodes transiently); no `maxNodes` knob by maintainer decision.
- The conformance harness at this checkout reports 31 scenarios / 73 checks rather than the 42/42 figure in the CI docs.

## Stack & merge order

1. #87 `tjc-2299-ci-supply-chain` -> `main` (TJC-2299, CI supply chain: F6, F7)
2. #88 `tjc-2298-macro-overload-binding` -> `tjc-2299-ci-supply-chain` (TJC-2298, macros: F4)
3. #89 `tjc-2297-tasks-hardening` -> `tjc-2298-macro-overload-binding` (TJC-2297, tasks: F8, F9, F11)
4. **#90 `tjc-2295-core-input-limits` -> `tjc-2297-tasks-hardening` (TJC-2295, core input limits: F1, F2, F3) — this PR**
5. #91 `tjc-2296-http-transport-hardening` -> `tjc-2295-core-input-limits` (TJC-2296, HTTP transports: F1, F5, F10, F12)
6. #92 `tjc-2294-security-hardening` -> `tjc-2296-http-transport-hardening` (TJC-2294, cross-arc integration + docs)

Review and merge bottom-up. Merge each PR with a **merge commit**, not squash — squashing the bottom of a stack orphans the PRs above it (see TJC-2114). After each merge, retarget the next PR to `main` (GitHub does this automatically when the base branch is deleted). The stack tip is byte-identical to a fully verified integrated tree: 532/532 Mill test tasks including the JVM, Bun and Scala Native suites; official MCP conformance 73/73 checks on both JVM and Bun with empty baselines; scalafmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
