### PR TITLE
Full-origin HostGuard, 415/413 POST gates, Bun error boundary, session cap (TJC-2296)

### DIFF
--- a/fast-mcp-scala/js/src/com/tjclp/fastmcp/examples/conformance/ConformanceServerJs.scala
+++ b/fast-mcp-scala/js/src/com/tjclp/fastmcp/examples/conformance/ConformanceServerJs.scala
@@ -14,6 +14,10 @@ import com.tjclp.fastmcp.server.transport.*
   * The Bun streamable transport streams server→client messages (sampling / elicitation / progress /
   * logging) on each request's own POST SSE response, so the full active conformance suite passes on
   * JS, matching the JVM transport.
+  *
+  * `startStatefulHttp()` returns a [[BunHttpHandle]]: like `runHttp()`, it runs the idle-session
+  * sweeper (`sessionIdleTimeout`), bounds the legacy store (`maxSessions`) and applies every HTTP
+  * hardening gate for the listener's lifetime.
   */
 object ConformanceServerJs:
 

--- a/fast-mcp-scala/js/src/com/tjclp/fastmcp/facades/runtime/Bun.scala
+++ b/fast-mcp-scala/js/src/com/tjclp/fastmcp/facades/runtime/Bun.scala
@@ -20,22 +20,43 @@ object Bun extends js.Object:
   def serve(options: BunServeOptions): BunServer = js.native
 
 /** Options accepted by `Bun.serve`. The `fetch` handler is the heart of it — it receives a
-  * Web-Standard `Request` and must return a `Response` (or a Promise of one).
+  * Web-Standard `Request` plus the `Server` (Bun calls `fetch(request, server)`) and must return a
+  * `Response` (or a Promise of one).
+  *
+  * Hardening knobs (all set by the transport, never left to Bun's defaults):
+  *   - `maxRequestBodySize` — bytes; Bun's own default is 128 MiB. Over-cap bodies are answered 413
+  *     by Bun itself (declared or streamed) before / while `fetch` runs.
+  *   - `development = false` — Bun otherwise defaults to `NODE_ENV !== "production"` and renders a
+  *     ~100 KB HTML debug page (stack traces, on-disk paths) for a rejected `fetch` promise.
+  *   - `error` — last-resort callback for anything Bun still sees; returns a plain JSON 500.
   */
 trait BunServeOptions extends js.Object:
   val port: js.UndefOr[Int]
   val hostname: js.UndefOr[String]
-  val fetch: js.Function1[js.Dynamic, js.Promise[js.Dynamic]]
+  val fetch: js.Function2[js.Dynamic, js.Dynamic, js.Promise[js.Dynamic]]
+  val maxRequestBodySize: js.UndefOr[Int]
+  val development: js.UndefOr[Boolean]
+  val error: js.UndefOr[js.Function1[js.Dynamic, js.Dynamic]]
 
 object BunServeOptions:
 
   def apply(
       port: Int,
       hostname: String,
-      fetch: js.Function1[js.Dynamic, js.Promise[js.Dynamic]]
+      fetch: js.Function2[js.Dynamic, js.Dynamic, js.Promise[js.Dynamic]],
+      maxRequestBodySize: Int,
+      development: Boolean,
+      error: js.Function1[js.Dynamic, js.Dynamic]
   ): BunServeOptions =
     js.Dynamic
-      .literal(port = port, hostname = hostname, fetch = fetch)
+      .literal(
+        port = port,
+        hostname = hostname,
+        fetch = fetch,
+        maxRequestBodySize = maxRequestBodySize,
+        development = development,
+        error = error
+      )
       .asInstanceOf[BunServeOptions]
 
 /** Handle returned by `Bun.serve`. */
@@ -45,6 +66,11 @@ trait BunServer extends js.Object:
   val hostname: String = js.native
   val url: js.Dynamic = js.native
   def stop(): Unit = js.native
+
+  /** Peer socket address of a request — `{ address, port, family }` — or `null` once the socket is
+    * gone. The transport uses `address` as the default bearer-task owner key.
+    */
+  def requestIP(request: js.Dynamic): js.Dynamic = js.native
 
 /** Facade for the Web-standard `crypto` global — we need `crypto.randomUUID()` for session id
   * generation. `java.util.UUID.randomUUID` would be natural but Scala.js's stub relies on

--- a/fast-mcp-scala/js/src/com/tjclp/fastmcp/server/transport/JsTransportBackend.scala
+++ b/fast-mcp-scala/js/src/com/tjclp/fastmcp/server/transport/JsTransportBackend.scala
@@ -104,21 +104,26 @@ object JsTransportBackend extends TransportBackend with HttpTransportBackend:
       settings: McpServerSettings
   ): ZIO[R, Throwable, Unit] =
     ZIO.runtime[R].flatMap { rt =>
-      val store = js.Dictionary.empty[Session]
-      ZIO.acquireReleaseWith(ZIO.attempt(startBun(router, rt, settings, store)))(server =>
-        ZIO.succeed(server.stop())
-      )(_ =>
-        // Idle-session sweeper scoped to the server's lifetime (test helpers that call startBun
-        // directly get no sweeper — documented there).
-        ZIO.scoped(evictIdleSessions(store, settings).forkScoped *> ZIO.never)
-      )
+      // `startBun` validates the settings (IllegalArgumentException → this effect fails), starts
+      // the listener and forks the idle-session sweeper; the handle's `stop()` tears both down.
+      ZIO.acquireReleaseWith(ZIO.attempt(startBun(router, rt, settings)))(handle =>
+        ZIO.succeed(handle.stop())
+      )(_ => ZIO.never)
     }
 
   /** Periodically drop streamable sessions idle past `settings.sessionIdleTimeout` (JVM twin:
-    * `JvmTransportBackend.evictIdleSessions`). Bun is single-threaded, so mutating the dictionary
-    * in-place is safe.
+    * `JvmHttpBackend.evictIdleSessions`). Bun is single-threaded, so mutating the dictionary
+    * in-place is safe. Runs for the listener's lifetime on EVERY start entry (`serveHttp`,
+    * `startStatefulHttp()`, `startStatelessHttp()`); the store is additionally bounded by
+    * `settings.maxSessions` at mint time.
+    *
+    * The loop is `sweep *> sleep`, NOT `repeat(Schedule.spaced(..))`: a `Schedule` driver reads
+    * `Clock.currentDateTime`, which on Scala.js goes through scala-java-time's
+    * `ZoneId.systemDefault()` and throws `ZoneRulesException` without the tzdb artifact — the fiber
+    * then died silently after its first tick and no idle session was ever evicted. A failed sweep
+    * is logged and the loop continues.
     */
-  private def evictIdleSessions(
+  private[fastmcp] def evictIdleSessions(
       store: js.Dictionary[Session],
       settings: McpServerSettings
   ): UIO[Unit] =
@@ -137,73 +142,147 @@ object JsTransportBackend extends TransportBackend with HttpTransportBackend:
             }
           yield ()
         val interval = Duration.fromMillis(math.max(timeoutMs / 4, 1000L))
-        sweep.repeat(Schedule.spaced(interval)).unit
+        (sweep.catchAllCause(cause => ZIO.logWarningCause("Idle-session sweep failed", cause)) *>
+          ZIO.sleep(interval)).forever
 
-  /** Start the Bun HTTP listener and return its handle. Used by `serveHttp` (wrapped in
-    * acquire/release, with the idle sweeper running alongside) and directly by JS integration tests
-    * that want a `stop()`-able handle (no sweeper — tests manage session lifetimes).
+  /** Last-resort `Bun.serve` `error` callback: whatever Bun still sees (nothing should reach it —
+    * `guarded` catches every Cause) is answered as a fixed JSON-RPC 500, never the debug page.
     */
-  def startBun[R](
+  private val bunErrorHandler: js.Function1[js.Dynamic, js.Dynamic] =
+    (_: js.Dynamic) => jsonRpcErrorResponse(500, HttpRequestGuards.InternalErrorMessage)
+
+  /** The options handed to `Bun.serve` — a seam so tests can assert `development == false`, the
+    * `error` callback and `maxRequestBodySize` without depending on `NODE_ENV`.
+    */
+  private[fastmcp] def serveOptions[R](
+      router: McpRouter[R],
+      runtime: Runtime[R],
+      settings: McpServerSettings,
+      store: js.Dictionary[Session]
+  ): BunServeOptions =
+    BunServeOptions(
+      port = settings.port,
+      hostname = settings.host,
+      fetch = js.Any.fromFunction2((req: js.Dynamic, server: js.Dynamic) =>
+        ZioJsPromise.zioToPromise(runtime)(
+          guarded(settings)(handleFetch(router, settings, store, req, clientKeyOf(server, req)))
+        )
+      ),
+      maxRequestBodySize = settings.maxRequestBodyBytes,
+      development = false,
+      error = bunErrorHandler
+    )
+
+  /** First-party error boundary, independent of `NODE_ENV`. The by-name `effect` is evaluated
+    * inside `suspendSucceed`, so `handleFetch`'s synchronous prefix (`new URL`, header gates) runs
+    * in the fiber and a throw becomes a defect; every Cause is then rendered as a JSON-RPC error
+    * with a fixed message — the full cause goes to the server log only. Nothing interrupts the
+    * fetch fiber, so no interrupt path exists here.
+    */
+  private def guarded[R](settings: McpServerSettings)(
+      effect: => ZIO[R, Throwable, js.Dynamic]
+  ): URIO[R, js.Dynamic] =
+    ZIO.suspendSucceed(effect).catchAllCause { cause =>
+      val response = cause.failureOption match
+        case Some(t) if Option(t.getMessage).exists(_.contains("maxRequestBodySize")) =>
+          // Bun aborted the body read at its own cap; mirror the first-party 413.
+          reject(HttpRequestGuards.bodyTooLargeRejection(settings))
+        case Some(_) => jsonRpcErrorResponse(400, "Body read error")
+        case None => jsonRpcErrorResponse(500, HttpRequestGuards.InternalErrorMessage)
+      ZIO.logWarningCause("HTTP handler failed", cause).as(response)
+    }
+
+  /** Peer address of the request via `server.requestIP(req)` — the default owner key for
+    * bearer-task buckets. `None` when the socket is already gone or the server handle is absent.
+    */
+  private def clientKeyOf(server: js.Dynamic, req: js.Dynamic): Option[String] =
+    scala.util
+      .Try {
+        Option(server)
+          .filterNot(js.isUndefined)
+          .flatMap(s => Option(s.requestIP(req)))
+          .filterNot(js.isUndefined)
+          .flatMap(a => Option(a.address.asInstanceOf[String]))
+      }
+      .toOption
+      .flatten
+
+  /** Start the Bun HTTP listener with the idle-session sweeper forked alongside it, and return a
+    * [[BunHttpHandle]] whose `stop()` tears both down. Every entry — `serveHttp` / `runHttp()`,
+    * `startStatefulHttp()`, `startStatelessHttp()` — goes through here, so `sessionIdleTimeout` and
+    * `maxSessions` are honoured for the listener's whole lifetime. Fails fast with
+    * `IllegalArgumentException` when `HttpRequestGuards.validateSettings` rejects the settings.
+    */
+  private[fastmcp] def startBun[R](
       router: McpRouter[R],
       runtime: Runtime[R],
       settings: McpServerSettings,
       store: js.Dictionary[Session] = js.Dictionary.empty[Session] // Bun is single-threaded
-  ): BunServer =
-    Bun.serve(
-      BunServeOptions(
-        port = settings.port,
-        hostname = settings.host,
-        fetch = js.Any.fromFunction1((req: js.Dynamic) =>
-          ZioJsPromise.zioToPromise(runtime)(handleFetch(router, settings, store, req))
-        )
-      )
+  ): BunHttpHandle =
+    HttpRequestGuards
+      .validateSettings(settings)
+      .left
+      .foreach(msg => throw new IllegalArgumentException(s"Invalid HTTP settings: $msg"))
+    val server = Bun.serve(serveOptions(router, runtime, settings, store))
+    // `unsafe.fork`, never `unsafe.run`: Runtime.unsafe.run throws on Scala.js when the effect
+    // suspends ("Cannot block for result to be set in JavaScript").
+    val sweeper =
+      Unsafe.unsafe(implicit u => runtime.unsafe.fork(evictIdleSessions(store, settings)))
+    new BunHttpHandle(
+      server,
+      () => Unsafe.unsafe(implicit u => { val _ = runtime.unsafe.fork(sweeper.interrupt) })
     )
 
   private def handleFetch[R](
       router: McpRouter[R],
       settings: McpServerSettings,
       store: js.Dictionary[Session],
-      req: js.Dynamic
+      req: js.Dynamic,
+      clientKey: Option[String]
   ): ZIO[R, Throwable, js.Dynamic] =
     if pathOf(req) != settings.httpEndpoint then ZIO.succeed(webResponse(404, "Not Found"))
     else
-      val allowedHosts = settings.allowedHosts.getOrElse(Set.empty)
       val headerErr =
-        hostError(req, allowedHosts)
-          .orElse(
-            if methodOf(req) == "POST" then postHeaderError(req, requireSse = !settings.stateless)
-            else None
-          )
+        if methodOf(req) == "POST" then postHeaderError(req, settings)
+        else hostError(req, settings)
       headerErr match
         case Some(err) => ZIO.succeed(err)
         case None =>
-          if settings.stateless then handleStateless(router, settings, req)
-          else handleStreamable(router, settings, store, req)
+          if settings.stateless then handleStateless(router, settings, req, clientKey)
+          else handleStreamable(router, settings, store, req, clientKey)
+
+  private def reject(r: HttpRequestGuards.Rejection): js.Dynamic =
+    jsonRpcErrorResponse(r.status, r.message)
 
   private def handleStateless[R](
       router: McpRouter[R],
       settings: McpServerSettings,
-      req: js.Dynamic
+      req: js.Dynamic,
+      clientKey: Option[String]
   ): ZIO[R, Throwable, js.Dynamic] =
     methodOf(req) match
       case "POST" =>
         readBody(req).flatMap { body =>
-          MessageLoop.parseFrame(body, router.limits) match
-            case Left(parseFailure) =>
-              ZIO.succeed(jsonResponse(parseFailure.toJson, Map.empty, status = 400))
-            case Right(message) =>
-              if isModernRequest(req, message) then modernPost(router, req, message, settings)
-              else
-                for
-                  session <- Session.make("stateless", supportsTasks = false)
-                  // Legacy stateless compatibility mode starts ready without a handshake.
-                  _ <- session.markInitialized
-                  reply <- router.dispatch(session, message)
-                yield (message, reply) match
-                  case (_: JsonRpcMessage.Invalid, Some(r)) =>
-                    jsonResponse(r.toJson, Map.empty, status = 400)
-                  case (_, Some(r)) => jsonResponse(r.toJson, Map.empty)
-                  case (_, None) => webResponse(202, "")
+          if HttpRequestGuards.bodyTooLarge(body, settings) then
+            ZIO.succeed(reject(HttpRequestGuards.bodyTooLargeRejection(settings)))
+          else
+            MessageLoop.parseFrame(body, router.limits) match
+              case Left(parseFailure) =>
+                ZIO.succeed(jsonResponse(parseFailure.toJson, Map.empty, status = 400))
+              case Right(message) =>
+                if isModernRequest(req, message) then
+                  modernPost(router, req, message, settings, clientKey)
+                else
+                  for
+                    session <- Session.make("stateless", supportsTasks = false)
+                    // Legacy stateless compatibility mode starts ready without a handshake.
+                    _ <- session.markInitialized
+                    reply <- router.dispatch(session, message)
+                  yield (message, reply) match
+                    case (_: JsonRpcMessage.Invalid, Some(r)) =>
+                      jsonResponse(r.toJson, Map.empty, status = 400)
+                    case (_, Some(r)) => jsonResponse(r.toJson, Map.empty)
+                    case (_, None) => webResponse(202, "")
         }
       case _ =>
         ZIO.succeed(jsonRpcErrorResponse(405, "Stateless mode only accepts POST"))
@@ -212,41 +291,41 @@ object JsTransportBackend extends TransportBackend with HttpTransportBackend:
       router: McpRouter[R],
       settings: McpServerSettings,
       store: js.Dictionary[Session],
-      req: js.Dynamic
+      req: js.Dynamic,
+      clientKey: Option[String]
   ): ZIO[R, Throwable, js.Dynamic] =
     methodOf(req) match
       case "POST" =>
         readBody(req).flatMap { body =>
-          // Parse BEFORE touching the session store: a malformed or non-initialize body must
-          // never mint a durable session (JVM transport does the same).
-          MessageLoop.parseFrame(body, router.limits) match
-            case Left(parseFailure) =>
-              ZIO.succeed(jsonResponse(parseFailure.toJson, Map.empty, status = 400))
-            case Right(message) =>
-              if isModernRequest(req, message) then modernPost(router, req, message, settings)
-              else
-                sessionIdHeader(req) match
-                  case Some(sid) =>
-                    store.get(sid) match
-                      case None =>
-                        ZIO.succeed(jsonRpcErrorResponse(404, s"Session not found: $sid"))
-                      case Some(session) =>
-                        session.touch *>
-                          respondStreamable(router, session, message, isNew = false, settings)
-                  case None if MessageLoop.isInitialize(message) =>
-                    for
-                      sid <- randomId()
-                      session <- Session.make(sid)
-                      _ <- ZIO.succeed { store(session.sessionId) = session }
-                      resp <- respondStreamable(router, session, message, isNew = true, settings)
-                    yield resp
-                  case None =>
-                    ZIO.succeed(
-                      jsonRpcErrorResponse(
-                        400,
-                        s"$SessionIdHeader header is required (only initialize may open a session)"
+          if HttpRequestGuards.bodyTooLarge(body, settings) then
+            ZIO.succeed(reject(HttpRequestGuards.bodyTooLargeRejection(settings)))
+          else
+            // Parse BEFORE touching the session store: a malformed or non-initialize body must
+            // never mint a durable session (JVM transport does the same).
+            MessageLoop.parseFrame(body, router.limits) match
+              case Left(parseFailure) =>
+                ZIO.succeed(jsonResponse(parseFailure.toJson, Map.empty, status = 400))
+              case Right(message) =>
+                if isModernRequest(req, message) then
+                  modernPost(router, req, message, settings, clientKey)
+                else
+                  sessionIdHeader(req) match
+                    case Some(sid) =>
+                      store.get(sid) match
+                        case None =>
+                          ZIO.succeed(jsonRpcErrorResponse(404, s"Session not found: $sid"))
+                        case Some(session) =>
+                          session.touch *>
+                            respondStreamable(router, session, message, isNew = false, settings)
+                    case None if MessageLoop.isInitialize(message) =>
+                      mintSession(router, store, message, settings)
+                    case None =>
+                      ZIO.succeed(
+                        jsonRpcErrorResponse(
+                          400,
+                          s"$SessionIdHeader header is required (only initialize may open a session)"
+                        )
                       )
-                    )
         }
 
       case "DELETE" =>
@@ -272,6 +351,53 @@ object JsTransportBackend extends TransportBackend with HttpTransportBackend:
         ZIO.succeed(
           jsonRpcErrorResponse(405, "No standalone GET stream; server→client rides the POST SSE")
         )
+
+  /** Mint a durable session for a header-less legacy `initialize`, bounded by
+    * `settings.maxSessions` (JVM twin: `JvmHttpBackend.mintSession`). Bun is single-threaded, so
+    * the admission decision, the eviction and the insert happen in ONE synchronous `ZIO.succeed`
+    * block and the store never exceeds the cap even with N initializes in flight. At the cap the
+    * longest-idle session WITHOUT a live GET is evicted (queue shut down, WARN logged) and the
+    * newcomer admitted; only when every stored session holds a live GET is the request refused with
+    * 503.
+    */
+  private def mintSession[R](
+      router: McpRouter[R],
+      store: js.Dictionary[Session],
+      message: JsonRpcMessage,
+      settings: McpServerSettings
+  ): ZIO[R, Throwable, js.Dynamic] =
+    for
+      sid <- randomId()
+      snapshot <-
+        if HttpRequestGuards.capReached(store.size, settings) then
+          ZIO.foreach(store.toList) { case (id, s) =>
+            (s.lastSeen zip s.hasActiveGet).map((seen, live) => (id, seen, live))
+          }
+        else ZIO.succeed(Nil)
+      session <- Session.make(sid)
+      outcome <- ZIO.succeed {
+        if !HttpRequestGuards.capReached(store.size, settings) then
+          store(sid) = session
+          Right(None)
+        else
+          HttpRequestGuards.pickEvictable(snapshot).flatMap(store.get) match
+            case Some(victim) =>
+              store -= victim.sessionId
+              store(sid) = session
+              Right(Some(victim))
+            case None => Left(())
+      }
+      resp <- outcome match
+        case Right(None) => respondStreamable(router, session, message, isNew = true, settings)
+        case Right(Some(victim)) =>
+          ZIO.logWarning(
+            s"Legacy session cap ${settings.maxSessions.getOrElse(0)} reached; evicted idle session ${victim.sessionId}"
+          ) *> victim.outbound.shutdown *>
+            respondStreamable(router, session, message, isNew = true, settings)
+        case Left(()) =>
+          session.outbound.shutdown
+            .as(jsonRpcErrorResponse(503, HttpRequestGuards.SessionLimitMessage))
+    yield resp
 
   /** Dispatch one streamable POST frame. A *request* gets a `text/event-stream` response that
     * streams the notifications and sub-requests it emits (progress, sampling, elicitation) followed
@@ -339,18 +465,30 @@ object JsTransportBackend extends TransportBackend with HttpTransportBackend:
     val source = js.Dynamic.literal(
       pull = js.Any.fromFunction1((controller: js.Dynamic) =>
         ZioJsPromise.zioToPromise(
-          takeNext.map {
-            case None =>
-              val _ = controller.enqueue(encoder.encode(": ping\n\n"))
-            case Some(msg) if MessageLoop.isCloseSentinel(msg) =>
-              // Dispatch ended replyless (cancelled): end the stream without emitting a frame.
-              val _ = controller.close()
-            case Some(msg) =>
-              val frame = s"event: message\ndata: ${MessageLoop.encodeOutbound(msg)}\n\n"
-              val _ = controller.enqueue(encoder.encode(frame))
-              if isFinalReply(msg, reqId) then
+          takeNext
+            .map {
+              case None =>
+                val _ = controller.enqueue(encoder.encode(": ping\n\n"))
+              case Some(msg) if MessageLoop.isCloseSentinel(msg) =>
+                // Dispatch ended replyless (cancelled): end the stream without emitting a frame.
                 val _ = controller.close()
-          }
+              case Some(msg) =>
+                val frame = s"event: message\ndata: ${MessageLoop.encodeOutbound(msg)}\n\n"
+                val _ = controller.enqueue(encoder.encode(frame))
+                if isFinalReply(msg, reqId) then
+                  val _ = controller.close()
+            }
+            // A defect mid-stream ends the stream instead of rejecting the pull promise — Bun
+            // would otherwise surface the raw error itself. A pull racing the client's cancel
+            // (interrupted `take`, or the controller already closed) is benign and not logged.
+            .catchAllCause { cause =>
+              val benign = cause.isInterruptedOnly || cause.dieOption.exists {
+                case _: js.JavaScriptException => true
+                case _ => false
+              }
+              (if benign then ZIO.unit else ZIO.logWarningCause("SSE pull failed", cause)) *>
+                ZIO.succeed { val _ = scala.util.Try(controller.error(js.Error("stream failed"))) }
+            }
         )
       ),
       // Client disconnected mid-request: interrupt the dispatch and drop the queue, otherwise the
@@ -380,8 +518,13 @@ object JsTransportBackend extends TransportBackend with HttpTransportBackend:
       router: McpRouter[R],
       req: js.Dynamic,
       message: JsonRpcMessage,
-      settings: McpServerSettings
+      settings: McpServerSettings,
+      clientKey: Option[String]
   ): ZIO[R, Throwable, js.Dynamic] =
+    // Peer address (`server.requestIP`) — the default owner key for bearer-task buckets.
+    // TODO(TJC-2294 merge): pass as `clientKey = clientKey` to `Session.make` once Arc C's
+    // `Session.make(sessionId, supportsTasks, clientKey)` lands.
+    val _ = clientKey
     message match
       case rpc: JsonRpcMessage.Request =>
         validateModernRequest(router, req, rpc) match
@@ -470,38 +613,25 @@ object JsTransportBackend extends TransportBackend with HttpTransportBackend:
 
   private def methodOf(req: js.Dynamic): String = req.method.asInstanceOf[String]
 
-  /** POST guard: `Accept` (if present) must allow application/json; `mcp-protocol-version` (if
-    * present) must be supported. Lenient when headers are absent. Mirrors the JVM transport.
+  /** Reject (403) when DNS-rebinding protection is on and the request's Host/Origin isn't allowed
+    * (full-origin match — the shared [[HostGuard]] via [[HttpRequestGuards.hostGate]]).
     */
-  /** Reject (403) when DNS-rebinding protection is on and the request's Host/Origin isn't allowed.
-    */
-  private def hostError(req: js.Dynamic, allowedHosts: Set[String]): Option[js.Dynamic] =
-    val host = Option(req.headers.get("host").asInstanceOf[String])
-    val origin = Option(req.headers.get("origin").asInstanceOf[String])
-    if HostGuard.isAllowed(host, origin, allowedHosts) then None
-    else Some(webResponse(403, "Host/Origin not allowed (DNS-rebinding protection)"))
+  private def hostError(req: js.Dynamic, settings: McpServerSettings): Option[js.Dynamic] =
+    HttpRequestGuards.hostGate(headerOf(req), settings).map(reject)
 
-  /** POST guard, mirroring the JVM backend: `Accept` (if present) must allow `application/json` —
-    * and on the streamable transport (`requireSse`) `text/event-stream` too, since request replies
-    * stream as SSE.
+  /** POST guard, identical to the JVM backend through the shared [[HttpRequestGuards.postGate]]:
+    * 403 Host/Origin → 415 unless `Content-Type` is `application/json` → 413 when the declared
+    * `Content-Length` exceeds `maxRequestBodyBytes` → 406 unless `Accept` allows `application/json`
+    * (and `text/event-stream` on the streamable transport). Runs BEFORE the body is read or any
+    * session is minted.
     *
     * As on the JVM, `mcp-protocol-version` is deliberately not checked here: on POST the version
     * comes from the initialize payload (legacy) or from the modern validation path (`-32022`).
     */
-  private def postHeaderError(req: js.Dynamic, requireSse: Boolean): Option[js.Dynamic] =
-    val accept = Option(req.headers.get("accept").asInstanceOf[String]).map(_.toLowerCase)
-    val acceptsJson =
-      accept.forall(a =>
-        a.contains("*/*") || a.contains("application/json") || a.contains("application/*")
-      )
-    val acceptsSse =
-      accept.forall(a =>
-        a.contains("*/*") || a.contains("text/event-stream") || a.contains("text/*")
-      )
-    if !acceptsJson then Some(jsonRpcErrorResponse(406, "Accept must allow application/json"))
-    else if requireSse && !acceptsSse then
-      Some(jsonRpcErrorResponse(406, "Accept must allow text/event-stream"))
-    else None
+  private def postHeaderError(req: js.Dynamic, settings: McpServerSettings): Option[js.Dynamic] =
+    HttpRequestGuards
+      .postGate(headerOf(req), settings, requireSse = !settings.stateless)
+      .map(reject)
 
   private def pathOf(req: js.Dynamic): String =
     // `new URL(req.url).pathname` is the Web-Standard way to pull the path from a Request.
@@ -544,16 +674,32 @@ object JsTransportBackend extends TransportBackend with HttpTransportBackend:
 
 import com.tjclp.fastmcp.server.McpServer
 
-/** JS-only convenience entry points used by integration tests that want a synchronous,
-  * `stop()`-able Bun handle instead of forking `runHttp()` (a `ZIO.never`). They build the router
-  * eagerly on the default runtime, so they apply to `McpServer[Any]`.
+/** Stop-able Bun listener: the `Bun.serve` handle plus the idle-session sweeper that runs for its
+  * lifetime. Returned by EVERY start entry (`startStatelessHttp()` / `startStatefulHttp()`; used
+  * internally by `runHttp()`), so `sessionIdleTimeout` and `maxSessions` are honoured everywhere.
+  * `stop()` interrupts the sweeper and stops the listener. The raw Bun server is `server`.
+  */
+final class BunHttpHandle private[transport] (val server: BunServer, release: () => Unit):
+  def port: Int = server.port
+  def hostname: String = server.hostname
+  def url: js.Dynamic = server.url
+
+  def stop(): Unit =
+    release()
+    server.stop()
+
+/** JS-only convenience entry points for callers that want a synchronous, `stop()`-able handle
+  * instead of forking `runHttp()` (a `ZIO.never`) — integration tests and the shipped
+  * `ConformanceServerJs`. They build the router eagerly on the default runtime, so they apply to
+  * `McpServer[Any]`. Both run the idle-session sweeper and honour every HTTP hardening setting
+  * exactly like `runHttp()`; call `stop()` on the returned [[BunHttpHandle]] to tear down.
   */
 extension (server: McpServer[Any])
 
-  def startStatelessHttp(): BunServer = startHttpHandle(server)
-  def startStatefulHttp(): BunServer = startHttpHandle(server)
+  def startStatelessHttp(): BunHttpHandle = startHttpHandle(server)
+  def startStatefulHttp(): BunHttpHandle = startHttpHandle(server)
 
-private def startHttpHandle(server: McpServer[Any]): BunServer =
+private def startHttpHandle(server: McpServer[Any]): BunHttpHandle =
   val router = Unsafe.unsafe(implicit u =>
     Runtime.default.unsafe.run(server.buildRouter).getOrThrowFiberFailure()
   )

--- a/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerHttpTest.scala
+++ b/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerHttpTest.scala
@@ -13,9 +13,14 @@ import zio.*
 import zio.json.*
 
 import com.tjclp.fastmcp.core.*
-import com.tjclp.fastmcp.facades.runtime.BunServer
 import com.tjclp.fastmcp.server.TaskSettings
-import com.tjclp.fastmcp.server.transport.{startStatefulHttp, startStatelessHttp}
+import com.tjclp.fastmcp.server.router.Session
+import com.tjclp.fastmcp.server.transport.{
+  BunHttpHandle,
+  JsTransportBackend,
+  startStatefulHttp,
+  startStatelessHttp
+}
 
 /** Exercises the shared `McpServer` over `JsTransportBackend`'s Bun HTTP listener (stateless +
   * stateful) using the global `fetch` API. No TS SDK client involvement — just a raw HTTP wire
@@ -51,7 +56,7 @@ class JsServerHttpTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAl
   private val port = 38917
 
   @SuppressWarnings(Array("org.wartremover.warts.Null"))
-  private var bunServer: BunServer = scala.compiletime.uninitialized
+  private var bunServer: BunHttpHandle = scala.compiletime.uninitialized
 
   @SuppressWarnings(Array("org.wartremover.warts.Null"))
   private var fiber: Fiber.Runtime[Throwable, Unit] = scala.compiletime.uninitialized
@@ -82,6 +87,50 @@ class JsServerHttpTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAl
   override def afterAll(): Unit =
     if bunServer != null then bunServer.stop()
     super.afterAll()
+
+  private def delay(ms: Int): Future[Unit] =
+    val promise = Promise[Unit]()
+    val _ = js.timers.setTimeout(ms.toDouble)(promise.success(()))
+    promise.future
+
+  private def text(resp: js.Dynamic): Future[String] =
+    fromJsPromise(resp.text().asInstanceOf[js.Promise[String]])
+
+  private def status(resp: js.Dynamic): Int = resp.status.asInstanceOf[Int]
+
+  private def header(resp: js.Dynamic, name: String): Option[String] =
+    Option(resp.headers.get(name).asInstanceOf[String])
+
+  private def fetchAt(port: Int, init: js.Dynamic, path: String = "/mcp"): Future[js.Dynamic] =
+    fromJsPromise(
+      js.Dynamic.global
+        .fetch(s"http://127.0.0.1:$port$path", init)
+        .asInstanceOf[js.Promise[js.Dynamic]]
+    )
+
+  private val legacyInitBody =
+    """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"1.0"}}}"""
+  private val legacyListBody = """{"jsonrpc":"2.0","id":2,"method":"tools/list"}"""
+
+  private def jsonHeaders(extra: (String, String)*): js.Dictionary[String] =
+    val headers = js.Dictionary[String](
+      "content-type" -> "application/json",
+      "accept" -> "application/json, text/event-stream"
+    )
+    extra.foreach { case (k, v) => headers(k) = v }
+    headers
+
+  private def statefulServer(name: String, port: Int, tweak: McpServerSettings => McpServerSettings)
+      : BunHttpHandle =
+    com.tjclp.fastmcp.server
+      .McpServer(
+        name,
+        "0.1.0",
+        tweak(
+          McpServerSettings(host = "127.0.0.1", port = port, httpEndpoint = "/mcp", stateless = false)
+        )
+      )
+      .startStatefulHttp()
 
   private def setupStatelessServer(): Future[Unit] =
     val server = com.tjclp.fastmcp.server.McpServer(
@@ -238,11 +287,284 @@ class JsServerHttpTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAl
         "/mcp",
         js.Dynamic.literal(
           method = "POST",
-          headers = js.Dictionary("accept" -> "text/plain"),
+          headers = js.Dictionary("content-type" -> "application/json", "accept" -> "text/plain"),
           body = "{}"
         )
       ).map(resp => resp.status.asInstanceOf[Int] shouldBe 406)
     }
+  }
+
+  // ---- F5 §2: Content-Type gate, before body read or minting ----
+
+  it should "reject a text/plain legacy POST with 415 and no session header (stateless)" in {
+    serverReady.flatMap { _ =>
+      // A string body with no explicit content-type: Bun's fetch sends text/plain;charset=UTF-8 —
+      // exactly the CORS-simple request a cross-site page can fire without a preflight.
+      val init = js.Dynamic.literal(
+        method = "POST",
+        headers = js.Dictionary("accept" -> "application/json, text/event-stream"),
+        body = legacyInitBody
+      )
+      for
+        resp <- httpFetch("/mcp", init)
+        body <- text(resp)
+      yield
+        status(resp) shouldBe 415
+        header(resp, "mcp-session-id") shouldBe None
+        body should include("-32000")
+        body should include("application/json")
+    }
+  }
+
+  it should "reject a Content-Type-less Blob legacy tools/call with 415 (stateless)" in {
+    serverReady.flatMap { _ =>
+      val callBody =
+        """{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"ping","arguments":{"msg":"csrf"}}}"""
+      val blob = js.Dynamic.newInstance(js.Dynamic.global.Blob)(js.Array(callBody))
+      val init = js.Dynamic.literal(method = "POST", body = blob)
+      for
+        resp <- httpFetch("/mcp", init)
+        body <- text(resp)
+      yield
+        status(resp) shouldBe 415
+        body should not include "csrf"
+    }
+  }
+
+  it should "accept application/json with a charset parameter" in {
+    serverReady.flatMap { _ =>
+      httpFetch(
+        "/mcp",
+        js.Dynamic.literal(
+          method = "POST",
+          headers = js.Dictionary(
+            "content-type" -> "application/json; charset=utf-8",
+            "accept" -> "application/json, text/event-stream"
+          ),
+          body = legacyListBody
+        )
+      ).map(resp => status(resp) shouldBe 200)
+    }
+  }
+
+  // ---- F10: header sentinel + error boundary ----
+
+  it should "answer `Mcp-Name: =?base64?=` with a small JSON -32020, never a trace or a debug page" in {
+    serverReady.flatMap { _ =>
+      val init = js.Dynamic.literal(
+        method = "POST",
+        headers = jsonHeaders(
+          "mcp-protocol-version" -> "2026-07-28",
+          "mcp-method" -> "tools/call",
+          "mcp-name" -> "=?base64?="
+        ),
+        body =
+          """{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"x","arguments":{},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}"""
+      )
+      for
+        resp <- httpFetch("/mcp", init)
+        body <- text(resp)
+      yield
+        status(resp) shouldBe 400
+        header(resp, "content-type").getOrElse("") should include("application/json")
+        body should include("-32020")
+        body should include("Malformed Base64 header sentinel")
+        body should not include "Exception"
+        body should not include "StringIndexOutOfBounds"
+        body should not include "main.js"
+        body should not include "    at "
+        body should not include "<html"
+        body.length should be < 512
+    }
+  }
+
+  it should "answer `Mcp-Name: =?base64??=` (empty payload) with -32020 as well" in {
+    serverReady.flatMap { _ =>
+      val init = js.Dynamic.literal(
+        method = "POST",
+        headers = jsonHeaders(
+          "mcp-protocol-version" -> "2026-07-28",
+          "mcp-method" -> "tools/call",
+          "mcp-name" -> "=?base64??="
+        ),
+        body =
+          """{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"x","arguments":{},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}"""
+      )
+      for
+        resp <- httpFetch("/mcp", init)
+        body <- text(resp)
+      yield
+        status(resp) shouldBe 400
+        body should include("-32020")
+        body should not include "Exception"
+    }
+  }
+
+  "Bun.serve options" should "run with development=false, an error callback and the body cap (NODE_ENV-independent)" in {
+    val settings = McpServerSettings(
+      host = "127.0.0.1",
+      port = 1, // never bound: serveOptions does not call Bun.serve
+      stateless = true,
+      maxRequestBodyBytes = 4096
+    )
+    val server = com.tjclp.fastmcp.server.McpServer("JsHttpOptionsServer", "0.1.0", settings)
+    runZio(server.tool(pingTool) *> server.buildRouter).flatMap { router =>
+      val opts =
+        JsTransportBackend.serveOptions(router, Runtime.default, settings, js.Dictionary.empty[Session])
+      opts.development.getOrElse(true) shouldBe false
+      opts.maxRequestBodySize.getOrElse(0) shouldBe 4096
+      opts.port.getOrElse(0) shouldBe 1
+      opts.error.isDefined shouldBe true
+      // Bun calls fetch(request, server): the closure must take both.
+      opts.fetch.asInstanceOf[js.Dynamic].length.asInstanceOf[Int] shouldBe 2
+
+      val errorResponse = opts.error.map(_(js.Dynamic.literal(message = "kaboom"))).getOrElse(fail())
+      // Fake Web Requests drive handleFetch below Bun's own network layer, so the FIRST-PARTY
+      // gates (postGate 413 on Content-Length, post-read bodyTooLarge 413) are what answers.
+      def fakeRequest(headers: Map[String, String], body: String): js.Dynamic =
+        js.Dynamic.literal(
+          url = "http://127.0.0.1:1/mcp",
+          method = "POST",
+          headers = js.Dynamic.newInstance(js.Dynamic.global.Headers)(js.Dictionary(headers.toSeq*)),
+          text = js.Any.fromFunction0(() => js.Promise.resolve[String](body))
+        )
+      val json = Map("content-type" -> "application/json", "accept" -> "application/json")
+      def call(req: js.Dynamic): Future[(Int, String)] =
+        fromJsPromise(opts.fetch(req, js.undefined.asInstanceOf[js.Dynamic]))
+          .flatMap(resp => text(resp).map(body => (status(resp), body)))
+      for
+        errorBody <- text(errorResponse)
+        // First-party boundary: a request object that makes handleFetch throw synchronously
+        // (`new URL("not a url")`) must resolve — not reject — to a JSON-RPC 500.
+        boundaryResponse <- fromJsPromise(
+          opts.fetch(
+            js.Dynamic.literal(url = "not a url", method = "POST"),
+            js.undefined.asInstanceOf[js.Dynamic]
+          )
+        )
+        boundaryBody <- text(boundaryResponse)
+        declared <- call(fakeRequest(json + ("content-length" -> "9999"), legacyListBody))
+        oversized <- call(fakeRequest(json, "x" * 5000))
+        fine <- call(fakeRequest(json, legacyListBody))
+        // A body read that fails is a controlled 400, never a rejected promise.
+        brokenRead <- call(
+          js.Dynamic.literal(
+            url = "http://127.0.0.1:1/mcp",
+            method = "POST",
+            headers = js.Dynamic.newInstance(js.Dynamic.global.Headers)(js.Dictionary(json.toSeq*)),
+            text = js.Any.fromFunction0(() => js.Promise.reject(js.Error("socket reset")).asInstanceOf[js.Promise[String]])
+          )
+        )
+      yield
+        declared._1 shouldBe 413
+        declared._2 should include("-32000")
+        declared._2 should include("4096 bytes")
+        oversized._1 shouldBe 413
+        oversized._2 should include("-32000")
+        oversized._2 should not include "-32700"
+        fine._1 shouldBe 200
+        fine._2 should include("\"tools\"")
+        brokenRead._1 shouldBe 400
+        brokenRead._2 should include("-32000")
+        brokenRead._2 should not include "socket reset"
+        status(errorResponse) shouldBe 500
+        errorBody should include("-32000")
+        errorBody should include("Internal server error")
+        errorBody should not include "kaboom"
+        status(boundaryResponse) shouldBe 500
+        header(boundaryResponse, "content-type").getOrElse("") should include("application/json")
+        boundaryBody should include("-32000")
+        boundaryBody should include("Internal server error")
+        boundaryBody should not include "Exception"
+        boundaryBody should not include "    at "
+        boundaryBody should not include "not a url"
+    }
+  }
+
+  "a dying tool on Bun" should "be answered in-band as JSON (router boundary), never a raw 500 or HTML" in {
+    val boomPort = 38927
+    val boomTool = McpTool
+      .withSchema[PingArgs, String](
+        name = "boom",
+        inputSchema = pingSchema,
+        description = Some("Dies with a defect")
+      )
+      .contextual((_, _) => ZIO.die(new IllegalStateException("boom: secret handler state")))
+    val server = com.tjclp.fastmcp.server.McpServer(
+      "JsHttpBoomServer",
+      "0.1.0",
+      McpServerSettings(host = "127.0.0.1", port = boomPort, httpEndpoint = "/mcp", stateless = true)
+    )
+    runZio(server.tool(boomTool).unit).flatMap { _ =>
+      val handle = server.startStatelessHttp()
+      val checked = for
+        resp <- fetchAt(
+          boomPort,
+          js.Dynamic.literal(
+            method = "POST",
+            headers = jsonHeaders(),
+            body =
+              """{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"boom","arguments":{"msg":"x"}}}"""
+          )
+        )
+        body <- text(resp)
+      yield
+        status(resp) shouldBe 200
+        header(resp, "content-type").getOrElse("") should include("application/json")
+        body should include("\"jsonrpc\"")
+        body should not include "<html"
+        body should not include "    at "
+      checked.andThen { case _ => handle.stop() }
+    }
+  }
+
+  // ---- F1 §2: body cap ----
+
+  "maxRequestBodyBytes on Bun" should "answer 413 for a declared oversize body and never 200/500 for a streamed one" in {
+    val capPort = 38926
+    val handle = statefulServer(
+      "JsHttpBodyCapServer",
+      capPort,
+      _.copy(stateless = true, maxRequestBodyBytes = 64)
+    )
+    val big = "a" * 200
+    val declared = fetchAt(
+      capPort,
+      js.Dynamic.literal(method = "POST", headers = jsonHeaders(), body = big)
+    ).flatMap(resp => text(resp).map(body => (status(resp), body)))
+
+    val encoder = js.Dynamic.newInstance(js.Dynamic.global.TextEncoder)()
+    val source = js.Dynamic.literal(
+      start = js.Any.fromFunction1((controller: js.Dynamic) =>
+        val _ = controller.enqueue(encoder.encode(big))
+        val _ = controller.close()
+      )
+    )
+    val stream = js.Dynamic.newInstance(js.Dynamic.global.ReadableStream)(source)
+    val streamed: Future[Option[Int]] = fetchAt(
+      capPort,
+      js.Dynamic.literal(method = "POST", headers = jsonHeaders(), body = stream, duplex = "half")
+    ).map(resp => Some(status(resp))).recover { case _: Throwable => None }
+
+    val small = fetchAt(
+      capPort,
+      js.Dynamic.literal(method = "POST", headers = jsonHeaders(), body = legacyListBody)
+    ).map(status)
+
+    val checked = for
+      (declaredStatus, declaredBody) <- declared
+      streamedStatus <- streamed
+      smallStatus <- small
+    yield
+      // Bun enforces `maxRequestBodySize` itself first (an empty 413 for a declared oversize body,
+      // an errored body read for a streamed one — which `guarded` maps to a JSON 413); the
+      // first-party gates behind it are proven on fake requests in the "Bun.serve options" test.
+      // Never 200 (parsed) and never 500 (escaped as a defect).
+      declaredStatus shouldBe 413
+      if declaredBody.nonEmpty then declaredBody should include("-32000")
+      streamedStatus.foreach(st => st shouldBe 413)
+      smallStatus shouldBe 200
+    checked.andThen { case _ => handle.stop() }
   }
 
   it should "return 404 for unknown paths" in {
@@ -273,7 +595,99 @@ class JsServerHttpTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAl
     }
   }
 
-  "HostGuard on Bun" should "reject a foreign Origin with 403 when allowedHosts is set" in {
+  "HostGuard on Bun" should "match Origin as a full origin: cross-port/scheme/null are 403, same authority 200" in {
+    val originPort = 38924
+    val handle = statefulServer(
+      "JsHttpOriginServer",
+      originPort,
+      _.copy(stateless = true, allowedHosts = Some(Set("127.0.0.1", "localhost")))
+    )
+    def withOrigin(origin: String): Future[(String, Int, Option[String])] =
+      fetchAt(
+        originPort,
+        js.Dynamic.literal(
+          method = "POST",
+          headers = jsonHeaders("origin" -> origin),
+          body = legacyListBody
+        )
+      ).map(resp => (origin, status(resp), header(resp, "mcp-session-id")))
+
+    val refused = List(
+      "http://localhost:3000",
+      "https://localhost",
+      "http://127.0.0.1:1",
+      "null",
+      "http://localhost:99999",
+      "http://evil.example.com",
+      s"http://localhost:$originPort" // listed hostname, right port, but not this request's Host
+    )
+    val checked = for
+      refusedResults <- Future.sequence(refused.map(withOrigin))
+      same <- withOrigin(s"http://127.0.0.1:$originPort")
+      sameUpper <- withOrigin(s"HTTP://127.0.0.1:$originPort")
+      none <- fetchAt(
+        originPort,
+        js.Dynamic.literal(method = "POST", headers = jsonHeaders(), body = legacyListBody)
+      ).map(status)
+    yield
+      refusedResults.foreach { case (origin, st, sid) =>
+        withClue(s"Origin: $origin") {
+          st shouldBe 403
+          sid shouldBe None
+        }
+      }
+      same._2 shouldBe 200
+      sameUpper._2 shouldBe 200
+      none shouldBe 200
+    checked.andThen { case _ => handle.stop() }
+  }
+
+  it should "admit an explicitly listed allowedOrigins entry" in {
+    val listedPort = 38930
+    val handle = statefulServer(
+      "JsHttpAllowedOriginsServer",
+      listedPort,
+      _.copy(
+        stateless = true,
+        allowedHosts = Some(Set("127.0.0.1", "localhost")),
+        allowedOrigins = Some(Set("http://localhost:3000"))
+      )
+    )
+    def withOrigin(origin: String): Future[Int] =
+      fetchAt(
+        listedPort,
+        js.Dynamic.literal(
+          method = "POST",
+          headers = jsonHeaders("origin" -> origin),
+          body = legacyListBody
+        )
+      ).map(status)
+    val checked = for
+      listed <- withOrigin("http://localhost:3000")
+      other <- withOrigin("http://localhost:3001")
+    yield
+      listed shouldBe 200
+      other shouldBe 403
+    checked.andThen { case _ => handle.stop() }
+  }
+
+  it should "refuse to start on an unparseable allowedOrigins entry" in {
+    val server = com.tjclp.fastmcp.server.McpServer(
+      "JsHttpBadOriginsServer",
+      "0.1.0",
+      McpServerSettings(
+        host = "127.0.0.1",
+        port = 38931,
+        stateless = true,
+        allowedOrigins = Some(Set("app.example.com"))
+      )
+    )
+    val thrown = intercept[IllegalArgumentException](server.startStatelessHttp())
+    thrown.getMessage should include("allowedOrigins")
+    Future.successful(succeed)
+  }
+
+  it should "reject a foreign Origin with 403 when allowedHosts is set" in {
     val guardPort = 38920
     val guardServer = com.tjclp.fastmcp.server.McpServer(
       "JsHttpGuardServer",
@@ -392,6 +806,150 @@ class JsServerHttpTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAl
       Option(resp.headers.get("mcp-session-id").asInstanceOf[String]) shouldBe None
     }
     done.andThen { case _ => mintBunServer.stop() }
+  }
+
+  "runHttp (streamable gates)" should "415 a text/plain or Blob initialize and mint nothing" in {
+    val gatePort = 38925
+    val handle = statefulServer("JsHttpGateServer", gatePort, identity)
+    val textPlain = fetchAt(
+      gatePort,
+      js.Dynamic.literal(
+        method = "POST",
+        headers = js.Dictionary("accept" -> "application/json, text/event-stream"),
+        body = legacyInitBody
+      )
+    )
+    val blob = js.Dynamic.newInstance(js.Dynamic.global.Blob)(js.Array(legacyInitBody))
+    val blobPost = fetchAt(gatePort, js.Dynamic.literal(method = "POST", body = blob))
+    val checked = for
+      tp <- textPlain
+      tpBody <- text(tp)
+      bl <- blobPost
+      guessed <- fetchAt(
+        gatePort,
+        js.Dynamic.literal(
+          method = "POST",
+          headers = jsonHeaders("mcp-session-id" -> "guessed-session-id"),
+          body = legacyListBody
+        )
+      )
+    yield
+      status(tp) shouldBe 415
+      header(tp, "mcp-session-id") shouldBe None
+      tpBody should include("-32000")
+      status(bl) shouldBe 415
+      header(bl, "mcp-session-id") shouldBe None
+      status(guessed) shouldBe 404 // nothing was minted by the refused POSTs
+    checked.andThen { case _ => handle.stop() }
+  }
+
+  // ---- F12: sweeper on every entry + bounded store ----
+
+  // Regression net: the sweeper used `repeat(Schedule.spaced(..))`, whose driver reads
+  // `Clock.currentDateTime` → scala-java-time `ZoneId.systemDefault()` → `ZoneRulesException` on
+  // Scala.js without tzdb — the fiber died silently after its first tick and never evicted.
+  "evictIdleSessions on Bun" should "drop an idle session from the dictionary when forked via unsafe.fork" in {
+    val settings = McpServerSettings(sessionIdleTimeout = Some(java.time.Duration.ofMillis(100)))
+    runZio(Session.make("idle-unit")).flatMap { session =>
+      val store = js.Dictionary[Session]("idle-unit" -> session)
+      val sweeper = Unsafe.unsafe(implicit u =>
+        Runtime.default.unsafe.fork(JsTransportBackend.evictIdleSessions(store, settings))
+      )
+      def poll(remaining: Int): Future[Boolean] =
+        if store.isEmpty then Future.successful(true)
+        else if remaining <= 0 then Future.successful(false)
+        else delay(200).flatMap(_ => poll(remaining - 1))
+      poll(remaining = 25).map { evicted =>
+        val _ = Unsafe.unsafe(implicit u => Runtime.default.unsafe.fork(sweeper.interrupt))
+        evicted shouldBe true
+      }
+    }
+  }
+
+  "startStatefulHttp" should "run the idle-session sweeper: a session idle past sessionIdleTimeout 404s" in {
+    val idlePort = 38928
+    val handle = statefulServer(
+      "JsHttpIdleServer",
+      idlePort,
+      _.copy(sessionIdleTimeout = Some(java.time.Duration.ofMillis(200)))
+    )
+    def listWith(sid: String): Future[Int] =
+      fetchAt(
+        idlePort,
+        js.Dynamic.literal(
+          method = "POST",
+          headers = jsonHeaders("mcp-session-id" -> sid),
+          body = legacyListBody
+        )
+      ).map(status)
+    // The sweep interval floors at 1 s; each poll `touch`es the session, so wait out the first
+    // sweep untouched, then allow a few more sweeps before giving up (5 s deadline).
+    def pollUntil404(sid: String, remaining: Int): Future[Int] =
+      listWith(sid).flatMap { st =>
+        if st == 404 || remaining <= 0 then Future.successful(st)
+        else delay(1100).flatMap(_ => pollUntil404(sid, remaining - 1))
+      }
+    val checked = for
+      initResp <- fetchAt(
+        idlePort,
+        js.Dynamic.literal(method = "POST", headers = jsonHeaders(), body = legacyInitBody)
+      )
+      _ <- text(initResp)
+      sid = initResp.headers.get("mcp-session-id").asInstanceOf[String]
+      live <- listWith(sid)
+      _ <- delay(1600)
+      afterIdle <- pollUntil404(sid, remaining = 3)
+    yield
+      status(initResp) shouldBe 200
+      live shouldBe 200
+      afterIdle shouldBe 404
+    checked.andThen { case _ => handle.stop() }
+  }
+
+  "maxSessions on Bun" should "evict the longest-idle session at the cap instead of growing the store" in {
+    val capPort = 38929
+    val handle = statefulServer("JsHttpSessionCapServer", capPort, _.copy(maxSessions = Some(2)))
+    def init(): Future[String] =
+      fetchAt(
+        capPort,
+        js.Dynamic.literal(method = "POST", headers = jsonHeaders(), body = legacyInitBody)
+      ).flatMap { resp =>
+        text(resp).map { _ =>
+          status(resp) shouldBe 200
+          resp.headers.get("mcp-session-id").asInstanceOf[String]
+        }
+      }
+    def listWith(sid: String): Future[Int] =
+      fetchAt(
+        capPort,
+        js.Dynamic.literal(
+          method = "POST",
+          headers = jsonHeaders("mcp-session-id" -> sid),
+          body = legacyListBody
+        )
+      ).map(status)
+    val checked = for
+      sid1 <- init()
+      _ <- delay(10)
+      sid2 <- init()
+      _ <- delay(10)
+      touched2 <- listWith(sid2) // sid1 is now unambiguously the longest-idle session
+      sid3 <- init() // at the cap: evicts sid1, admits sid3
+      after1 <- listWith(sid1)
+      after2 <- listWith(sid2)
+      after3 <- listWith(sid3)
+      sid4 <- init() // still capped at 2: evicts the next-oldest idle (sid2)
+      after2b <- listWith(sid2)
+      after4 <- listWith(sid4)
+    yield
+      touched2 shouldBe 200
+      after1 shouldBe 404
+      after2 shouldBe 200
+      after3 shouldBe 200
+      after2b shouldBe 404
+      after4 shouldBe 200
+      Option(sid3) should not be None
+    checked.andThen { case _ => handle.stop() }
   }
 
   "runHttp (stateful tasks)" should "handle tasks/list without params" in {

--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/transport/JvmHttpBackend.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/transport/JvmHttpBackend.scala
@@ -35,24 +35,27 @@ object JvmHttpBackend extends HttpTransportBackend:
     // Capture the environment ZIO-natively and thread it into each handler via provideEnvironment,
     // so Routes stay `Routes[Any]` — Server.serve then needs only `Server`, avoiding the generic-R
     // HasNoScope constraint. No Unsafe, no runtime capture.
-    ZIO.environment[R].flatMap { env =>
-      val ep = settings.httpEndpoint.stripPrefix("/")
-      if settings.stateless then serve(statelessRoutes(router, env, settings), settings)
-      else
-        // The idle-session sweeper is forked here (scoped to the server's lifetime), NOT in
-        // httpRoutes — tests drive httpRoutes directly and must not leak a sweeper fiber each.
-        Ref.make(Map.empty[String, Session]).flatMap { store =>
-          val routes = streamableRoutes(router, ep, env, store, settings)
-          ZIO.scoped {
-            evictIdleSessions(store, settings).forkScoped *> serve(routes, settings)
+    ZIO
+      .fromEither(HttpRequestGuards.validateSettings(settings))
+      .mapError(msg => new IllegalArgumentException(s"Invalid HTTP settings: $msg")) *>
+      ZIO.environment[R].flatMap { env =>
+        val ep = settings.httpEndpoint.stripPrefix("/")
+        if settings.stateless then serve(statelessRoutes(router, env, settings), settings)
+        else
+          // The idle-session sweeper is forked here (scoped to the server's lifetime), NOT in
+          // httpRoutes — tests drive httpRoutes directly and must not leak a sweeper fiber each.
+          Ref.make(Map.empty[String, Session]).flatMap { store =>
+            val routes = streamableRoutes(router, ep, env, store, settings)
+            ZIO.scoped {
+              evictIdleSessions(store, settings).forkScoped *> serve(routes, settings)
+            }
           }
-        }
-    }
+      }
 
   /** Periodically drop streamable sessions idle past `settings.sessionIdleTimeout` — abandoned
     * clients would otherwise grow the store forever. Sessions with a live GET stream are exempt
-    * (push-only consumers may never POST). Eviction shuts the outbound queue down; the session's
-    * tasks stay in the TaskManager until their own TTL.
+    * (push-only consumers may never POST). Eviction shuts the outbound queue down. The store is
+    * additionally bounded by `settings.maxSessions` at mint time (see [[streamablePostDispatch]]).
     */
   private[fastmcp] def evictIdleSessions(
       store: Ref[Map[String, Session]],
@@ -132,7 +135,13 @@ object JvmHttpBackend extends HttpTransportBackend:
     // Server.customized with NettyConfig.default is behavior-identical to Server.defaultWith
     // (Server.live supplies NettyConfig.default internally); going through it is what lets the
     // channel type be pinned.
-    val config = Server.Config.default.binding(settings.host, settings.port)
+    // `disableRequestStreaming(n)` installs netty's HttpObjectAggregator with `n` as its cap: bodies
+    // above `maxRequestBodyBytes` (declared or chunked) are answered 413 on the wire before the
+    // handler runs. The first-party checks in `postGate` / `bodyTooLarge` give the same verdict on
+    // paths with no aggregator in front (in-memory route tests).
+    val config = Server.Config.default
+      .binding(settings.host, settings.port)
+      .disableRequestStreaming(settings.maxRequestBodyBytes)
     val netty = nettyConfigFor(resolveChannelType())
     Server
       .serve(routes)
@@ -151,7 +160,7 @@ object JvmHttpBackend extends HttpTransportBackend:
     val ep = settings.httpEndpoint.stripPrefix("/")
     Routes(
       Method.POST / ep -> handler { (request: Request) =>
-        handleStatelessPost(router, request, settings).provideEnvironment(env)
+        guarded(handleStatelessPost(router, request, settings)).provideEnvironment(env)
       },
       Method.GET / ep -> handler((_: Request) =>
         ZIO.succeed(Response.status(Status.MethodNotAllowed))
@@ -161,6 +170,21 @@ object JvmHttpBackend extends HttpTransportBackend:
       )
     )
 
+  /** First-party error boundary: any non-interrupt Cause (a defect, or a failure no handler mapped)
+    * becomes a JSON-RPC 500 with a fixed message; the full cause is logged server-side only.
+    * Interrupts (client disconnect) keep zio-http's own 408 path.
+    */
+  private[fastmcp] def guarded[R](effect: URIO[R, Response]): URIO[R, Response] =
+    effect.catchSomeCause {
+      case cause if !cause.isInterruptedOnly =>
+        ZIO
+          .logWarningCause("HTTP handler failed", cause)
+          .as(errorResponse(Status.InternalServerError, HttpRequestGuards.InternalErrorMessage))
+    }
+
+  private def reject(r: HttpRequestGuards.Rejection): Response =
+    errorResponse(Status.fromInt(r.status), r.message)
+
   /** One stateless POST: fresh ephemeral session, dispatch a single frame, return the reply (or
     * `202 Accepted` for a notification, which produces no body).
     */
@@ -169,7 +193,7 @@ object JvmHttpBackend extends HttpTransportBackend:
       request: Request,
       settings: McpServerSettings
   ): ZIO[R, Nothing, Response] =
-    postHeaderError(request, settings.allowedHosts.getOrElse(Set.empty), requireSse = false) match
+    postHeaderError(request, settings, requireSse = false) match
       case Some(err) => ZIO.succeed(err)
       case None => statelessDispatch(router, request, settings)
 
@@ -183,22 +207,27 @@ object JvmHttpBackend extends HttpTransportBackend:
         body <- request.body.asString.mapError(e =>
           Option(e.getMessage).getOrElse("body read error")
         )
-        resp <- MessageLoop.parseFrame(body, router.limits) match
-          case Left(parseFailure) =>
-            ZIO.succeed(Response.json(parseFailure.toJson).status(Status.BadRequest))
-          case Right(message) =>
-            if isModernRequest(request, message) then modernPost(router, request, message, settings)
-            else
-              for
-                session <- Session.make("stateless", supportsTasks = false)
-                // Legacy stateless compatibility mode starts ready without a handshake.
-                _ <- session.markInitialized
-                reply <- router.dispatch(session, message)
-              yield (message, reply) match
-                case (_: JsonRpcMessage.Invalid, Some(r)) =>
-                  Response.json(r.toJson).status(Status.BadRequest)
-                case (_, Some(r)) => Response.json(r.toJson)
-                case (_, None) => Response.status(Status.Accepted)
+        resp <-
+          if HttpRequestGuards.bodyTooLarge(body, settings) then
+            ZIO.succeed(reject(HttpRequestGuards.bodyTooLargeRejection(settings)))
+          else
+            MessageLoop.parseFrame(body, router.limits) match
+              case Left(parseFailure) =>
+                ZIO.succeed(Response.json(parseFailure.toJson).status(Status.BadRequest))
+              case Right(message) =>
+                if isModernRequest(request, message) then
+                  modernPost(router, request, message, settings)
+                else
+                  for
+                    session <- Session.make("stateless", supportsTasks = false)
+                    // Legacy stateless compatibility mode starts ready without a handshake.
+                    _ <- session.markInitialized
+                    reply <- router.dispatch(session, message)
+                  yield (message, reply) match
+                    case (_: JsonRpcMessage.Invalid, Some(r)) =>
+                      Response.json(r.toJson).status(Status.BadRequest)
+                    case (_, Some(r)) => Response.json(r.toJson)
+                    case (_, None) => Response.status(Status.Accepted)
       yield resp
     effect.catchAll(msg => ZIO.succeed(errorResponse(Status.BadRequest, msg)))
 
@@ -215,18 +244,13 @@ object JvmHttpBackend extends HttpTransportBackend:
   ): Routes[Any, Response] =
     Routes(
       Method.POST / ep -> handler { (request: Request) =>
-        handleStreamablePost(router, store, request, settings).provideEnvironment(env)
+        guarded(handleStreamablePost(router, store, request, settings)).provideEnvironment(env)
       },
       Method.GET / ep -> handler { (request: Request) =>
-        handleStreamableGet(store, request, settings)
+        guarded(handleStreamableGet(store, request, settings))
       },
       Method.DELETE / ep -> handler { (request: Request) =>
-        handleStreamableDelete(
-          store,
-          request,
-          settings.disallowDelete,
-          settings.allowedHosts.getOrElse(Set.empty)
-        )
+        guarded(handleStreamableDelete(store, request, settings))
       }
     )
 
@@ -246,7 +270,7 @@ object JvmHttpBackend extends HttpTransportBackend:
       request: Request,
       settings: McpServerSettings
   ): ZIO[R, Nothing, Response] =
-    postHeaderError(request, settings.allowedHosts.getOrElse(Set.empty), requireSse = true) match
+    postHeaderError(request, settings, requireSse = true) match
       case Some(err) => ZIO.succeed(err)
       case None => streamablePostDispatch(router, store, request, settings)
 
@@ -261,6 +285,8 @@ object JvmHttpBackend extends HttpTransportBackend:
         ZIO.succeed(
           errorResponse(Status.BadRequest, Option(err.getMessage).getOrElse("body read error"))
         )
+      case Right(body) if HttpRequestGuards.bodyTooLarge(body, settings) =>
+        ZIO.succeed(reject(HttpRequestGuards.bodyTooLargeRejection(settings)))
       case Right(body) =>
         // Parse BEFORE touching the session store: a malformed or non-initialize body must never
         // mint a durable session (it used to — an unauthenticated memory leak).
@@ -280,12 +306,7 @@ object JvmHttpBackend extends HttpTransportBackend:
                         respondStreamable(router, session, message, isNew = false, settings)
                   }
                 case None if MessageLoop.isInitialize(message) =>
-                  for
-                    id <- JvmTransportBackend.randomId()
-                    session <- Session.make(id)
-                    _ <- store.update(_ + (session.sessionId -> session))
-                    resp <- respondStreamable(router, session, message, isNew = true, settings)
-                  yield resp
+                  mintSession(router, store, message, settings)
                 case None =>
                   ZIO.succeed(
                     errorResponse(
@@ -294,6 +315,49 @@ object JvmHttpBackend extends HttpTransportBackend:
                     )
                   )
     }
+
+  /** Mint a durable session for a header-less legacy `initialize`, bounded by
+    * `settings.maxSessions`. The admission decision and the insert are one atomic `store.modify`,
+    * so the store never exceeds the cap even under concurrent initializes. When the store is full
+    * the longest-idle session WITHOUT a live GET (snapshot taken just before the modify) is evicted
+    * — its queue shut down — and the newcomer admitted; only when every stored session holds a live
+    * GET is the request refused with 503. A victim `touch`ed in the tiny snapshot→modify window may
+    * still be evicted: it was the longest-idle session a moment earlier, and the cap is preserved.
+    */
+  private def mintSession[R](
+      router: McpRouter[R],
+      store: Ref[Map[String, Session]],
+      message: JsonRpcMessage,
+      settings: McpServerSettings
+  ): URIO[R, Response] =
+    for
+      id <- JvmTransportBackend.randomId()
+      snapshot <- store.get.flatMap { all =>
+        if HttpRequestGuards.capReached(all.size, settings) then
+          ZIO.foreach(all.values.toList) { s =>
+            (s.lastSeen zip s.hasActiveGet).map((seen, live) => (s.sessionId, seen, live))
+          }
+        else ZIO.succeed(Nil)
+      }
+      session <- Session.make(id)
+      outcome <- store.modify { m =>
+        if !HttpRequestGuards.capReached(m.size, settings) then (Right(None), m + (id -> session))
+        else
+          HttpRequestGuards.pickEvictable(snapshot).filter(m.contains) match
+            case Some(victim) => (Right(Some(m(victim))), (m - victim) + (id -> session))
+            case None => (Left(()), m)
+      }
+      resp <- outcome match
+        case Right(None) => respondStreamable(router, session, message, isNew = true, settings)
+        case Right(Some(victim)) =>
+          ZIO.logWarning(
+            s"Legacy session cap ${settings.maxSessions.getOrElse(0)} reached; evicted idle session ${victim.sessionId}"
+          ) *> victim.outbound.shutdown *>
+            respondStreamable(router, session, message, isNew = true, settings)
+        case Left(()) =>
+          session.outbound.shutdown
+            .as(errorResponse(Status.ServiceUnavailable, HttpRequestGuards.SessionLimitMessage))
+    yield resp
 
   /** Dispatch one streamable POST frame. A *request* gets an SSE response that streams the
     * notifications and sub-requests it emits (progress, sampling, elicitation) followed by its
@@ -423,6 +487,11 @@ object JvmHttpBackend extends HttpTransportBackend:
                 .status(status)
             )
           case Right(_) =>
+            // Peer address of the request — the default owner key for bearer-task buckets.
+            // TODO(TJC-2294 merge): pass as `clientKey = clientKey` to `Session.make` once Arc C's
+            // `Session.make(sessionId, supportsTasks, clientKey)` lands.
+            val clientKey: Option[String] = clientKeyOf(request)
+            val _ = clientKey
             Session.make(s"request-${req.id.toString}").flatMap { session =>
               streamRequest(router, session, req, isNew = false, settings, modern = true)
             }
@@ -478,6 +547,10 @@ object JvmHttpBackend extends HttpTransportBackend:
   private def isModernRequest(request: Request, message: JsonRpcMessage): Boolean =
     ModernHttpValidation.isModern(name => request.rawHeader(name), message)
 
+  /** The TCP peer address as seen by netty (`None` for in-memory `routes.runZIO` requests). */
+  private def clientKeyOf(request: Request): Option[String] =
+    request.remoteAddress.map(_.getHostAddress)
+
   /** Merge a heartbeat into an SSE stream so proxies / idle timeouts don't kill long-quiet
     * connections. The `ping` event type is ignored by conforming clients (the TS SDK only parses
     * `message` events); zio-http 3.4.0 has no comment-frame support. Halts with the data stream.
@@ -513,13 +586,12 @@ object JvmHttpBackend extends HttpTransportBackend:
       request: Request,
       settings: McpServerSettings
   ): ZIO[Any, Nothing, Response] =
-    val allowedHosts = settings.allowedHosts.getOrElse(Set.empty)
-    hostError(request, allowedHosts) match
+    hostError(request, settings) match
       case Some(err) => ZIO.succeed(err)
       case None if request.rawHeader("mcp-protocol-version").exists(Protocol.isStatelessVersion) =>
         ZIO.succeed(Response.status(Status.MethodNotAllowed))
       case None =>
-        getHeaderError(request, allowedHosts) match
+        getHeaderError(request, settings) match
           case Some(err) => ZIO.succeed(err)
           case None => streamableGetDispatch(store, request, settings)
 
@@ -558,14 +630,13 @@ object JvmHttpBackend extends HttpTransportBackend:
   private def handleStreamableDelete(
       store: Ref[Map[String, Session]],
       request: Request,
-      disallowDelete: Boolean,
-      allowedHosts: Set[String]
+      settings: McpServerSettings
   ): ZIO[Any, Nothing, Response] =
-    hostError(request, allowedHosts) match
+    hostError(request, settings) match
       case Some(err) => ZIO.succeed(err)
       case None if request.rawHeader("mcp-protocol-version").exists(Protocol.isStatelessVersion) =>
         ZIO.succeed(Response.status(Status.MethodNotAllowed))
-      case None if disallowDelete => ZIO.succeed(Response.status(Status.MethodNotAllowed))
+      case None if settings.disallowDelete => ZIO.succeed(Response.status(Status.MethodNotAllowed))
       case None =>
         request.rawHeader(SessionIdHeader) match
           case None =>
@@ -576,15 +647,9 @@ object JvmHttpBackend extends HttpTransportBackend:
               case None => ZIO.succeed(errorResponse(Status.NotFound, s"Session not found: $id"))
             }
 
-  // --- Header validation (validate `Accept` + `mcp-protocol-version`; lenient when absent, so
-  // header-less clients still work while clearly-wrong headers are rejected per spec). ---
-
-  private def acceptsAny(req: Request, types: List[String]): Boolean =
-    req.rawHeader("accept") match
-      case None => true // absent Accept is treated as "accepts anything"
-      case Some(a) =>
-        val lower = a.toLowerCase
-        lower.contains("*/*") || types.exists(lower.contains)
+  // --- Header validation. The decisions live in the shared [[HttpRequestGuards]] (one truth for
+  // JVM and Bun); this backend only renders the verdicts. `mcp-protocol-version` stays lenient when
+  // absent so header-less clients still work while clearly-wrong headers are rejected per spec. ---
 
   /** `mcp-protocol-version` header validation. Absent ⇒ assume
     * [[Protocol.DefaultNegotiatedProtocolVersion]] per the spec's backwards-compatibility rule
@@ -596,15 +661,16 @@ object JvmHttpBackend extends HttpTransportBackend:
       .getOrElse(Protocol.DefaultNegotiatedProtocolVersion)
     Protocol.SupportedProtocolVersions.contains(declared)
 
-  /** Reject (403) when DNS-rebinding protection is on and the request's Host/Origin isn't allowed.
+  /** Reject (403) when DNS-rebinding protection is on and the request's Host/Origin isn't allowed
+    * (full-origin match, see [[HostGuard]]).
     */
-  private def hostError(req: Request, allowedHosts: Set[String]): Option[Response] =
-    if HostGuard.isAllowed(req.rawHeader("host"), req.rawHeader("origin"), allowedHosts) then None
-    else Some(errorResponse(Status.Forbidden, "Host/Origin not allowed (DNS-rebinding protection)"))
+  private def hostError(req: Request, settings: McpServerSettings): Option[Response] =
+    HttpRequestGuards.hostGate(req.rawHeader, settings).map(reject)
 
-  /** POST guard: `Accept` (if present) must allow `application/json` — and on the streamable
-    * transport (`requireSse`) `text/event-stream` too, since request replies stream as SSE (spec
-    * requires clients to accept both).
+  /** POST guard, evaluated on headers only and BEFORE the body is read or any session is minted:
+    * 403 Host/Origin → 415 unless `Content-Type` is `application/json` → 413 when the declared
+    * `Content-Length` exceeds `maxRequestBodyBytes` → 406 unless `Accept` allows `application/json`
+    * (and `text/event-stream` too on the streamable transport, `requireSse`).
     *
     * Note this guard does NOT check `mcp-protocol-version`: on POST the version travels in the
     * initialize payload (legacy) or is validated by [[ModernHttpValidation]] (modern, `-32022`).
@@ -612,24 +678,21 @@ object JvmHttpBackend extends HttpTransportBackend:
     */
   private def postHeaderError(
       req: Request,
-      allowedHosts: Set[String],
+      settings: McpServerSettings,
       requireSse: Boolean
   ): Option[Response] =
-    hostError(req, allowedHosts).orElse {
-      if !acceptsAny(req, List("application/json", "application/*")) then
-        Some(errorResponse(Status.NotAcceptable, "Accept must allow application/json"))
-      else if requireSse && !acceptsAny(req, List("text/event-stream", "text/*")) then
-        Some(errorResponse(Status.NotAcceptable, "Accept must allow text/event-stream"))
-      else None
-    }
+    HttpRequestGuards.postGate(req.rawHeader, settings, requireSse).map(reject)
 
   /** GET guard (SSE channel): `Accept` (if present) must allow `text/event-stream`. */
-  private def getHeaderError(req: Request, allowedHosts: Set[String]): Option[Response] =
-    hostError(req, allowedHosts).orElse {
+  private def getHeaderError(req: Request, settings: McpServerSettings): Option[Response] =
+    hostError(req, settings).orElse {
       if !protocolVersionOk(req) then
         Some(errorResponse(Status.BadRequest, "Unsupported mcp-protocol-version header"))
-      else if !acceptsAny(req, List("text/event-stream", "text/*")) then
-        Some(errorResponse(Status.NotAcceptable, "Accept must allow text/event-stream"))
+      else if !HttpRequestGuards.acceptsAny(
+          req.rawHeader("accept"),
+          List("text/event-stream", "text/*")
+        )
+      then Some(errorResponse(Status.NotAcceptable, "Accept must allow text/event-stream"))
       else None
     }
 

--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/transport/JvmHttpBackend.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/transport/JvmHttpBackend.scala
@@ -44,7 +44,7 @@ object JvmHttpBackend extends HttpTransportBackend:
         else
           // The idle-session sweeper is forked here (scoped to the server's lifetime), NOT in
           // httpRoutes — tests drive httpRoutes directly and must not leak a sweeper fiber each.
-          Ref.make(Map.empty[String, Session]).flatMap { store =>
+          Ref.Synchronized.make(Map.empty[String, Session]).flatMap { store =>
             val routes = streamableRoutes(router, ep, env, store, settings)
             ZIO.scoped {
               evictIdleSessions(store, settings).forkScoped *> serve(routes, settings)
@@ -90,7 +90,7 @@ object JvmHttpBackend extends HttpTransportBackend:
     val ep = settings.httpEndpoint.stripPrefix("/")
     if settings.stateless then ZIO.succeed(statelessRoutes(router, env, settings))
     else
-      Ref
+      Ref.Synchronized
         .make(Map.empty[String, Session])
         .map(store => streamableRoutes(router, ep, env, store, settings))
 
@@ -172,10 +172,12 @@ object JvmHttpBackend extends HttpTransportBackend:
 
   /** First-party error boundary: any non-interrupt Cause (a defect, or a failure no handler mapped)
     * becomes a JSON-RPC 500 with a fixed message; the full cause is logged server-side only.
-    * Interrupts (client disconnect) keep zio-http's own 408 path.
+    * Interrupts (client disconnect) keep zio-http's own 408 path. `effect` is by-name and suspended
+    * so a synchronous throw while the handler effect is BUILT (the eager header gates) is caught
+    * too — parity with the Bun boundary.
     */
-  private[fastmcp] def guarded[R](effect: URIO[R, Response]): URIO[R, Response] =
-    effect.catchSomeCause {
+  private[fastmcp] def guarded[R](effect: => URIO[R, Response]): URIO[R, Response] =
+    ZIO.suspendSucceed(effect).catchSomeCause {
       case cause if !cause.isInterruptedOnly =>
         ZIO
           .logWarningCause("HTTP handler failed", cause)
@@ -239,7 +241,7 @@ object JvmHttpBackend extends HttpTransportBackend:
       router: McpRouter[R],
       ep: String,
       env: ZEnvironment[R],
-      store: Ref[Map[String, Session]],
+      store: Ref.Synchronized[Map[String, Session]],
       settings: McpServerSettings
   ): Routes[Any, Response] =
     Routes(
@@ -266,7 +268,7 @@ object JvmHttpBackend extends HttpTransportBackend:
     */
   private def handleStreamablePost[R](
       router: McpRouter[R],
-      store: Ref[Map[String, Session]],
+      store: Ref.Synchronized[Map[String, Session]],
       request: Request,
       settings: McpServerSettings
   ): ZIO[R, Nothing, Response] =
@@ -276,7 +278,7 @@ object JvmHttpBackend extends HttpTransportBackend:
 
   private def streamablePostDispatch[R](
       router: McpRouter[R],
-      store: Ref[Map[String, Session]],
+      store: Ref.Synchronized[Map[String, Session]],
       request: Request,
       settings: McpServerSettings
   ): ZIO[R, Nothing, Response] =
@@ -317,35 +319,35 @@ object JvmHttpBackend extends HttpTransportBackend:
     }
 
   /** Mint a durable session for a header-less legacy `initialize`, bounded by
-    * `settings.maxSessions`. The admission decision and the insert are one atomic `store.modify`,
-    * so the store never exceeds the cap even under concurrent initializes. When the store is full
-    * the longest-idle session WITHOUT a live GET (snapshot taken just before the modify) is evicted
-    * — its queue shut down — and the newcomer admitted; only when every stored session holds a live
-    * GET is the request refused with 503. A victim `touch`ed in the tiny snapshot→modify window may
-    * still be evicted: it was the longest-idle session a moment earlier, and the cap is preserved.
+    * `settings.maxSessions`. The cap check, the idle/live snapshot, the victim choice and the
+    * insert all run inside ONE `store.modifyZIO` on the `Ref.Synchronized` store, so concurrent
+    * initializes are serialised at the cap: the store never exceeds it, and a newcomer is never
+    * refused while an evictable session exists. When the store is full the longest-idle session
+    * WITHOUT a live GET is evicted — its queue shut down — and the newcomer admitted; only when
+    * every stored session holds a live GET is the request refused with 503.
     */
   private def mintSession[R](
       router: McpRouter[R],
-      store: Ref[Map[String, Session]],
+      store: Ref.Synchronized[Map[String, Session]],
       message: JsonRpcMessage,
       settings: McpServerSettings
   ): URIO[R, Response] =
     for
       id <- JvmTransportBackend.randomId()
-      snapshot <- store.get.flatMap { all =>
-        if HttpRequestGuards.capReached(all.size, settings) then
-          ZIO.foreach(all.values.toList) { s =>
-            (s.lastSeen zip s.hasActiveGet).map((seen, live) => (s.sessionId, seen, live))
-          }
-        else ZIO.succeed(Nil)
-      }
       session <- Session.make(id)
-      outcome <- store.modify { m =>
-        if !HttpRequestGuards.capReached(m.size, settings) then (Right(None), m + (id -> session))
+      outcome <- store.modifyZIO { m =>
+        if !HttpRequestGuards.capReached(m.size, settings) then
+          ZIO.succeed((Right(None), m + (id -> session)))
         else
-          HttpRequestGuards.pickEvictable(snapshot).filter(m.contains) match
-            case Some(victim) => (Right(Some(m(victim))), (m - victim) + (id -> session))
-            case None => (Left(()), m)
+          ZIO
+            .foreach(m.values.toList) { s =>
+              (s.lastSeen zip s.hasActiveGet).map((seen, live) => (s.sessionId, seen, live))
+            }
+            .map { snapshot =>
+              HttpRequestGuards.pickEvictable(snapshot) match
+                case Some(victim) => (Right(Some(m(victim))), (m - victim) + (id -> session))
+                case None => (Left(()), m)
+            }
       }
       resp <- outcome match
         case Right(None) => respondStreamable(router, session, message, isNew = true, settings)

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/ConformanceGapsTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/ConformanceGapsTest.scala
@@ -27,15 +27,27 @@ class ConformanceGapsTest extends AnyFunSuite with Matchers:
 
   test("HostGuard allows loopback and rejects foreign Host/Origin when an allowlist is set") {
     val allowed = Set("127.0.0.1", "localhost", "[::1]")
-    HostGuard.isAllowed(Some("127.0.0.1:8077"), None, allowed) shouldBe true
-    HostGuard.isAllowed(Some("localhost:8077"), Some("http://localhost:8077"), allowed) shouldBe true
-    HostGuard.isAllowed(None, None, allowed) shouldBe true // absent Host is not the rebinding threat
-    HostGuard.isAllowed(Some("evil.example.com"), None, allowed) shouldBe false
-    HostGuard.isAllowed(Some("127.0.0.1:8077"), Some("http://evil.example.com"), allowed) shouldBe false
+    HostGuard.isAllowed(Some("127.0.0.1:8077"), None, allowed, Set.empty) shouldBe true
+    HostGuard.isAllowed(Some("localhost:8077"), Some("http://localhost:8077"), allowed, Set.empty) shouldBe true
+    HostGuard.isAllowed(None, None, allowed, Set.empty) shouldBe true // absent Host is not the rebinding threat
+    HostGuard.isAllowed(Some("evil.example.com"), None, allowed, Set.empty) shouldBe false
+    HostGuard.isAllowed(Some("127.0.0.1:8077"), Some("http://evil.example.com"), allowed, Set.empty) shouldBe false
   }
 
-  test("HostGuard is disabled (always allows) when the allowlist is empty") {
-    HostGuard.isAllowed(Some("evil.example.com"), Some("http://evil.example.com"), Set.empty) shouldBe true
+  test("HostGuard matches Origin as a full origin: cross-port / scheme / null / bad-port loopback pages are refused") {
+    val allowed = Set("127.0.0.1", "localhost", "[::1]")
+    val host = Some("localhost:8077")
+    HostGuard.isAllowed(host, Some("http://localhost:3000"), allowed, Set.empty) shouldBe false
+    HostGuard.isAllowed(host, Some("https://localhost"), allowed, Set.empty) shouldBe false
+    HostGuard.isAllowed(host, Some("http://127.0.0.1:1"), allowed, Set.empty) shouldBe false
+    HostGuard.isAllowed(host, Some("null"), allowed, Set.empty) shouldBe false
+    HostGuard.isAllowed(host, Some("http://localhost:99999"), allowed, Set.empty) shouldBe false
+    // An explicit allowedOrigins entry admits a cross-port front-end.
+    HostGuard.isAllowed(host, Some("http://localhost:3000"), allowed, Set("http://localhost:3000")) shouldBe true
+  }
+
+  test("HostGuard is disabled (always allows) when both allowlists are empty") {
+    HostGuard.isAllowed(Some("evil.example.com"), Some("http://evil.example.com"), Set.empty, Set.empty) shouldBe true
   }
 
   // ---- inbound progress token (gap 3) ----

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/HostGuardTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/HostGuardTest.scala
@@ -1,0 +1,231 @@
+package com.tjclp.fastmcp
+package server.transport
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import com.tjclp.fastmcp.server.McpServerSettings
+
+/** The [[HostGuard]] truth table (F5): `Origin` is matched as a full origin against the request's
+  * `Host` authority or the explicit `allowedOrigins` list — never by port-stripped hostname.
+  */
+class HostGuardTest extends AnyFunSuite with Matchers:
+
+  private val hosts = Set("127.0.0.1", "localhost")
+  private val sameHost = Some("localhost:8000")
+
+  private def allowed(host: Option[String], origin: Option[String]): Boolean =
+    HostGuard.isAllowed(host, origin, hosts, Set.empty)
+
+  test("absent Origin is allowed (non-browser client; not the guarded threat)") {
+    allowed(sameHost, None) shouldBe true
+    allowed(Some("127.0.0.1:8000"), None) shouldBe true
+  }
+
+  test("same authority Origin is allowed, case-insensitively") {
+    allowed(sameHost, Some("http://localhost:8000")) shouldBe true
+    allowed(sameHost, Some("HTTP://LocalHost:8000")) shouldBe true
+    allowed(Some("LOCALHOST:8000"), Some("http://localhost:8000")) shouldBe true
+  }
+
+  test("cross-port localhost origins are refused (the F5 bypass)") {
+    allowed(sameHost, Some("http://localhost:3000")) shouldBe false
+    allowed(Some("127.0.0.1:8000"), Some("http://127.0.0.1:1")) shouldBe false
+  }
+
+  test("cross-scheme default port is refused: https://localhost is :443, not :8000") {
+    allowed(sameHost, Some("https://localhost")) shouldBe false
+    allowed(Some("localhost:8000"), Some("http://localhost")) shouldBe false // :80 != 8000
+  }
+
+  test("null and empty origins are refused (opaque origin)") {
+    allowed(sameHost, Some("null")) shouldBe false
+    allowed(sameHost, Some("")) shouldBe false
+    allowed(sameHost, Some("   ")) shouldBe false
+  }
+
+  test("foreign hostname is refused even with a matching port") {
+    allowed(sameHost, Some("http://evil.example.com")) shouldBe false
+    allowed(sameHost, Some("http://evil.example.com:8000")) shouldBe false
+  }
+
+  test("invalid explicit ports are unparseable and refused (fail-closed)") {
+    for bad <- List(
+        "http://localhost:99999",
+        "http://localhost:",
+        "http://localhost:abc",
+        "http://localhost:0",
+        "http://localhost:-1",
+        "http://localhost:8000x",
+        "http://localhost:٨٠٠٠" // Unicode digits are not decimal ASCII digits
+      )
+    do
+      withClue(bad) {
+        allowed(sameHost, Some(bad)) shouldBe false
+        // Even against a port-less Host (where a default port would otherwise be compared).
+        allowed(Some("localhost"), Some(bad)) shouldBe false
+        HostGuard.parseOrigin(bad) shouldBe None
+      }
+  }
+
+  test("malformed origins and non-http schemes are refused") {
+    for bad <- List(
+        "http://localhost:8000/x",
+        "http://user@localhost:8000",
+        "http://localhost:8000?q=1",
+        "http://localhost:8000#f",
+        "http://local host:8000",
+        "ftp://localhost:8000",
+        "ws://localhost:8000",
+        "localhost:8000",
+        "://localhost:8000",
+        "http://",
+        "http://[::1",
+        "http://[]:8000",
+        "http://[::1]junk"
+      )
+    do
+      withClue(bad) {
+        allowed(sameHost, Some(bad)) shouldBe false
+        HostGuard.parseOrigin(bad) shouldBe None
+      }
+  }
+
+  test("a listed hostname on the same port but different from Host is cross-origin → refused") {
+    allowed(Some("localhost:8000"), Some("http://127.0.0.1:8000")) shouldBe false
+  }
+
+  test("an Origin with an absent Host has no authority to compare → refused") {
+    allowed(None, Some("http://localhost:8000")) shouldBe false
+  }
+
+  test("a port-less Host accepts only the scheme-default origin port") {
+    allowed(Some("localhost"), Some("http://localhost")) shouldBe true
+    allowed(Some("localhost"), Some("http://localhost:80")) shouldBe true
+    allowed(Some("localhost"), Some("https://localhost")) shouldBe true // :443 vs port-less Host
+    allowed(Some("localhost"), Some("http://localhost:8000")) shouldBe false
+  }
+
+  test("scheme is not compared in the same-authority rule (TLS-terminating proxy) — documented") {
+    allowed(sameHost, Some("https://localhost:8000")) shouldBe true
+  }
+
+  test("bracketed IPv6 literals are handled on both sides") {
+    val v6 = Set("[::1]")
+    HostGuard.isAllowed(Some("[::1]:8000"), Some("http://[::1]:8000"), v6, Set.empty) shouldBe true
+    HostGuard.isAllowed(Some("[::1]:8000"), Some("http://[::1]:8001"), v6, Set.empty) shouldBe false
+    HostGuard.isAllowed(Some("[::1]"), Some("http://[::1]"), v6, Set.empty) shouldBe true
+  }
+
+  test("a verbatim host:port entry in allowedHosts also admits the Origin hostname") {
+    HostGuard.isAllowed(
+      Some("localhost:8000"),
+      Some("http://localhost:8000"),
+      Set("localhost:8000"),
+      Set.empty
+    ) shouldBe true
+    HostGuard.isAllowed(
+      Some("localhost:8000"),
+      Some("http://localhost:3000"),
+      Set("localhost:8000"),
+      Set.empty
+    ) shouldBe false
+  }
+
+  test("explicit allowedOrigins entries win regardless of Host, after normalisation") {
+    val origins = Set("https://app.example.com:443", "http://localhost:3000")
+    HostGuard.isAllowed(sameHost, Some("https://app.example.com"), hosts, origins) shouldBe true
+    HostGuard.isAllowed(None, Some("https://app.example.com"), hosts, origins) shouldBe true
+    HostGuard.isAllowed(
+      Some("127.0.0.1:8000"),
+      Some("HTTPS://App.Example.com:443"),
+      hosts,
+      origins
+    ) shouldBe true
+    HostGuard.isAllowed(sameHost, Some("http://localhost:3000"), hosts, origins) shouldBe true
+    // Not listed and not same-authority → still refused.
+    HostGuard.isAllowed(sameHost, Some("http://localhost:3001"), hosts, origins) shouldBe false
+    HostGuard.isAllowed(sameHost, Some("http://app.example.com"), hosts, origins) shouldBe false
+    // The Host allow-list still applies alongside allowedOrigins.
+    HostGuard.isAllowed(
+      Some("evil.example.com"),
+      Some("https://app.example.com"),
+      hosts,
+      origins
+    ) shouldBe false
+  }
+
+  test("allowedHosts None + allowedOrigins Some: Host unchecked, Origin must be listed") {
+    val origins = Set("https://app.example.com")
+    HostGuard.isAllowed(Some("anything.example"), None, Set.empty, origins) shouldBe true
+    HostGuard.isAllowed(
+      Some("anything.example"),
+      Some("https://app.example.com"),
+      Set.empty,
+      origins
+    ) shouldBe true
+    HostGuard.isAllowed(
+      Some("anything.example"),
+      Some("http://localhost:3000"),
+      Set.empty,
+      origins
+    ) shouldBe false
+    HostGuard.isAllowed(Some("localhost:8000"), Some("null"), Set.empty, origins) shouldBe false
+  }
+
+  test("both lists empty disables the guard entirely") {
+    HostGuard.isAllowed(
+      Some("evil.example.com"),
+      Some("http://evil.example.com"),
+      Set.empty,
+      Set.empty
+    ) shouldBe true
+    HostGuard.isAllowed(Some("x"), Some("null"), Set.empty, Set.empty) shouldBe true
+  }
+
+  test("Host matching is unchanged: hostname with port stripped, verbatim host:port, absent ok") {
+    allowed(Some("127.0.0.1:65000"), None) shouldBe true
+    allowed(Some("127.0.0.1"), None) shouldBe true
+    allowed(None, None) shouldBe true
+    allowed(Some("evil.example.com"), None) shouldBe false
+    allowed(Some("evil.example.com:8000"), None) shouldBe false
+  }
+
+  test("settings overload wires allowedHosts and allowedOrigins") {
+    val settings = McpServerSettings(
+      allowedHosts = Some(hosts),
+      allowedOrigins = Some(Set("https://app.example.com"))
+    )
+    HostGuard.isAllowed(sameHost, Some("https://app.example.com"), settings) shouldBe true
+    HostGuard.isAllowed(sameHost, Some("http://localhost:8000"), settings) shouldBe true
+    HostGuard.isAllowed(sameHost, Some("http://localhost:3000"), settings) shouldBe false
+    HostGuard.isAllowed(sameHost, Some("http://localhost:3000"), McpServerSettings()) shouldBe true
+  }
+
+  test("deprecated 3-arg overload keeps Host semantics and full-origin matching, no allowedOrigins") {
+    @annotation.nowarn("cat=deprecation")
+    def legacy(host: Option[String], origin: Option[String]): Boolean =
+      HostGuard.isAllowed(host, origin, hosts)
+    legacy(sameHost, Some("http://localhost:8000")) shouldBe true
+    legacy(sameHost, Some("http://localhost:3000")) shouldBe false
+    legacy(Some("evil.example.com"), None) shouldBe false
+  }
+
+  test("parseOrigin normalises scheme/host case and defaults the port per scheme") {
+    HostGuard.parseOrigin("HTTP://LocalHost") shouldBe Some(HostGuard.Origin("http", "localhost", 80))
+    HostGuard.parseOrigin("https://App.Example.com") shouldBe
+      Some(HostGuard.Origin("https", "app.example.com", 443))
+    HostGuard.parseOrigin(" https://app.example.com:8443 ") shouldBe
+      Some(HostGuard.Origin("https", "app.example.com", 8443))
+    HostGuard.parseOrigin("http://[::1]:8000") shouldBe Some(HostGuard.Origin("http", "[::1]", 8000))
+    HostGuard.parseOrigin("http://[::1]") shouldBe Some(HostGuard.Origin("http", "[::1]", 80))
+    HostGuard.parseOrigin("null") shouldBe None
+    HostGuard.parseOrigin("") shouldBe None
+  }
+
+  test("invalidOrigins lists exactly the unparseable allow-list entries") {
+    HostGuard.invalidOrigins(
+      Set("https://app.example.com", "https//app.example.com", "app.example.com", "http://x:0")
+    ) shouldBe Set("https//app.example.com", "app.example.com", "http://x:0")
+    HostGuard.invalidOrigins(Set("http://localhost:3000")) shouldBe Set.empty
+  }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/HostGuardTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/HostGuardTest.scala
@@ -99,11 +99,36 @@ class HostGuardTest extends AnyFunSuite with Matchers:
     allowed(None, Some("http://localhost:8000")) shouldBe false
   }
 
-  test("a port-less Host accepts only the scheme-default origin port") {
+  test("a port-less Host accepts only the origin's scheme-default port (80 for http, 443 for https)") {
     allowed(Some("localhost"), Some("http://localhost")) shouldBe true
     allowed(Some("localhost"), Some("http://localhost:80")) shouldBe true
-    allowed(Some("localhost"), Some("https://localhost")) shouldBe true // :443 vs port-less Host
+    // Documented allow row: a port-less Host admits BOTH scheme defaults (listener on 80 or 443).
+    allowed(Some("localhost"), Some("https://localhost")) shouldBe true
+    allowed(Some("localhost"), Some("https://localhost:443")) shouldBe true
     allowed(Some("localhost"), Some("http://localhost:8000")) shouldBe false
+    allowed(Some("localhost"), Some("http://localhost:443")) shouldBe false
+    allowed(Some("localhost"), Some("https://localhost:80")) shouldBe false
+  }
+
+  test("a Host with a malformed port is fail-closed, never treated as port-less") {
+    for badHost <- List(
+        "localhost:99999",
+        "localhost:abc",
+        "localhost:",
+        "localhost:0",
+        "localhost:-1",
+        "localhost:8000x",
+        "localhost:٨٠٠٠"
+      )
+    do
+      withClue(badHost) {
+        allowed(Some(badHost), Some("http://localhost")) shouldBe false
+        allowed(Some(badHost), Some("https://localhost")) shouldBe false
+        allowed(Some(badHost), Some("http://localhost:8000")) shouldBe false
+        allowed(Some(badHost), Some("http://localhost:99999")) shouldBe false
+        // Host-only matching (no Origin) is unchanged: the hostname is listed.
+        allowed(Some(badHost), None) shouldBe true
+      }
   }
 
   test("scheme is not compared in the same-authority rule (TLS-terminating proxy) — documented") {

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/HttpHeaderValidationTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/HttpHeaderValidationTest.scala
@@ -1,0 +1,56 @@
+package com.tjclp.fastmcp
+package server.transport
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import zio.json.ast.Json
+
+import com.tjclp.fastmcp.jsonrpc.{JsonRpcMessage, McpError, RequestId}
+
+/** F10 §2: a sentinel-shaped `Mcp-Name` value shorter than `=?base64?` + `?=` (or otherwise
+  * malformed) must yield the `Malformed Base64 header sentinel` McpError, never throw. The Bun
+  * end-to-end proof is `JsServerHttpTest`; this pins the shared decoder on the JVM.
+  */
+class HttpHeaderValidationTest extends AnyFunSuite with Matchers:
+
+  private val toolsCall = JsonRpcMessage.Request(
+    RequestId.NumId(1),
+    "tools/call",
+    Some(Json.Obj("name" -> Json.Str("add"), "arguments" -> Json.Obj()))
+  )
+
+  private def validate(mcpName: String): Either[McpError, Unit] =
+    val headers = Map("mcp-method" -> "tools/call", "mcp-name" -> mcpName)
+    HttpHeaderValidation.validate(toolsCall, headers.get, Map.empty)
+
+  test("`=?base64?=` (prefix and suffix overlapping) is a malformed sentinel, not an exception") {
+    val result = validate("=?base64?=")
+    result.isLeft shouldBe true
+    val err = result.left.getOrElse(fail("expected Left"))
+    err.code shouldBe -32020
+    err.message shouldBe "Malformed Base64 header sentinel"
+  }
+
+  test("`=?base64??=` (empty payload) is a malformed sentinel") {
+    val err = validate("=?base64??=").left.getOrElse(fail("expected Left"))
+    err.code shouldBe -32020
+    err.message shouldBe "Malformed Base64 header sentinel"
+  }
+
+  test("`=?base64?!!?=` (invalid Base64 payload) is a malformed sentinel") {
+    val err = validate("=?base64?!!?=").left.getOrElse(fail("expected Left"))
+    err.code shouldBe -32020
+    err.message shouldBe "Malformed Base64 header sentinel"
+  }
+
+  test("a valid Base64 sentinel decodes and matches the body name") {
+    validate("=?base64?YWRk?=") shouldBe Right(()) // "add"
+    val mismatch = validate("=?base64?c3Vi?=").left.getOrElse(fail("expected Left")) // "sub"
+    mismatch.code shouldBe -32020
+    mismatch.message should include("does not match")
+  }
+
+  test("a plain header value still works and mismatches are reported") {
+    validate("add") shouldBe Right(())
+    validate("subtract").isLeft shouldBe true
+  }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/HttpRequestGuardsTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/HttpRequestGuardsTest.scala
@@ -1,0 +1,208 @@
+package com.tjclp.fastmcp
+package server.transport
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import com.tjclp.fastmcp.server.McpServerSettings
+import com.tjclp.fastmcp.server.transport.HttpRequestGuards.Rejection
+
+/** Unit coverage of the shared transport admission decisions (F1 §2, F5, F12): the POST gate order,
+  * the media-type matcher, the body cap and the legacy session-cap policy.
+  */
+class HttpRequestGuardsTest extends AnyFunSuite with Matchers:
+
+  private val guarded = McpServerSettings(
+    allowedHosts = Some(Set("127.0.0.1", "localhost")),
+    maxRequestBodyBytes = 64
+  )
+
+  private def headers(pairs: (String, String)*): String => Option[String] =
+    val m = pairs.toMap
+    name => m.get(name)
+
+  private val jsonOk = headers(
+    "host" -> "localhost:8000",
+    "content-type" -> "application/json",
+    "accept" -> "application/json, text/event-stream"
+  )
+
+  test("postGate: a request violating everything is refused 403 first") {
+    val everythingWrong = headers(
+      "host" -> "localhost:8000",
+      "origin" -> "http://localhost:3000",
+      "content-type" -> "text/plain",
+      "content-length" -> "200",
+      "accept" -> "text/plain"
+    )
+    HttpRequestGuards.postGate(everythingWrong, guarded, requireSse = true).map(_.status) shouldBe
+      Some(403)
+  }
+
+  test("postGate: 415 comes before 413 and 406") {
+    val h = headers(
+      "host" -> "localhost:8000",
+      "content-type" -> "text/plain",
+      "content-length" -> "200",
+      "accept" -> "text/plain"
+    )
+    HttpRequestGuards.postGate(h, guarded, requireSse = true) shouldBe
+      Some(Rejection(415, "Content-Type must be application/json"))
+    // Absent Content-Type is 415 too.
+    HttpRequestGuards
+      .postGate(headers("host" -> "localhost:8000"), guarded, requireSse = false)
+      .map(_.status) shouldBe Some(415)
+  }
+
+  test("postGate: 413 (declared Content-Length) comes before 406") {
+    val h = headers(
+      "host" -> "localhost:8000",
+      "content-type" -> "application/json",
+      "content-length" -> "200",
+      "accept" -> "text/plain"
+    )
+    HttpRequestGuards.postGate(h, guarded, requireSse = true) shouldBe
+      Some(Rejection(413, "Request body exceeds 64 bytes"))
+  }
+
+  test("postGate: 406 for Accept excluding JSON, and for missing SSE only when required") {
+    val noJson = headers(
+      "host" -> "localhost:8000",
+      "content-type" -> "application/json",
+      "accept" -> "text/plain"
+    )
+    HttpRequestGuards.postGate(noJson, guarded, requireSse = false) shouldBe
+      Some(Rejection(406, "Accept must allow application/json"))
+    val jsonOnly = headers(
+      "host" -> "localhost:8000",
+      "content-type" -> "application/json",
+      "accept" -> "application/json"
+    )
+    HttpRequestGuards.postGate(jsonOnly, guarded, requireSse = false) shouldBe None
+    HttpRequestGuards.postGate(jsonOnly, guarded, requireSse = true) shouldBe
+      Some(Rejection(406, "Accept must allow text/event-stream"))
+  }
+
+  test("postGate: a well-formed request passes; absent Accept passes; guard off ignores Origin") {
+    HttpRequestGuards.postGate(jsonOk, guarded, requireSse = true) shouldBe None
+    HttpRequestGuards.postGate(
+      headers("host" -> "localhost:8000", "content-type" -> "application/json"),
+      guarded,
+      requireSse = true
+    ) shouldBe None
+    val crossPort = headers(
+      "host" -> "localhost:8000",
+      "origin" -> "http://localhost:3000",
+      "content-type" -> "application/json"
+    )
+    HttpRequestGuards.postGate(crossPort, McpServerSettings(), requireSse = true) shouldBe None
+    HttpRequestGuards.postGate(crossPort, guarded, requireSse = true).map(_.status) shouldBe Some(403)
+  }
+
+  test("hostGate: 403 with the DNS-rebinding message; None when allowed") {
+    HttpRequestGuards.hostGate(headers("host" -> "evil.example.com"), guarded) shouldBe
+      Some(Rejection(403, "Host/Origin not allowed (DNS-rebinding protection)"))
+    HttpRequestGuards.hostGate(headers("host" -> "127.0.0.1:8000"), guarded) shouldBe None
+    HttpRequestGuards.hostGate(headers("host" -> "evil.example.com"), McpServerSettings()) shouldBe
+      None
+  }
+
+  test("isJsonContentType: application/json with parameters, case-insensitive, utf-8 charsets") {
+    for ok <- List(
+        "application/json",
+        "application/json; charset=utf-8",
+        "application/json;charset=UTF-8",
+        "Application/JSON",
+        "application/json;charset=\"UTF-8\"",
+        "application/json; charset=utf8",
+        " application/json ",
+        "application/json; boundary=x"
+      )
+    do withClue(ok)(HttpRequestGuards.isJsonContentType(Some(ok)) shouldBe true)
+  }
+
+  test("isJsonContentType: other media types, wildcards, non-utf-8 charsets and absent → false") {
+    for bad <- List(
+        "text/plain",
+        "text/plain; charset=utf-8",
+        "application/json-patch+json",
+        "application/*",
+        "*/*",
+        "application/json; charset=utf-16",
+        "application/json; charset=iso-8859-1",
+        "application/jsonx",
+        "application/x-www-form-urlencoded",
+        "multipart/form-data; boundary=----x",
+        ""
+      )
+    do withClue(bad)(HttpRequestGuards.isJsonContentType(Some(bad)) shouldBe false)
+    HttpRequestGuards.isJsonContentType(None) shouldBe false
+  }
+
+  test("acceptsAny: absent passes; wildcard passes; listed types match case-insensitively") {
+    val types = List("application/json", "application/*")
+    HttpRequestGuards.acceptsAny(None, types) shouldBe true
+    HttpRequestGuards.acceptsAny(Some("*/*"), types) shouldBe true
+    HttpRequestGuards.acceptsAny(Some("Application/JSON"), types) shouldBe true
+    HttpRequestGuards.acceptsAny(Some("text/event-stream, application/json"), types) shouldBe true
+    HttpRequestGuards.acceptsAny(Some("text/plain"), types) shouldBe false
+  }
+
+  test("declaredLengthExceeds: only a parseable length above the cap trips") {
+    HttpRequestGuards.declaredLengthExceeds(Some("200"), guarded) shouldBe true
+    HttpRequestGuards.declaredLengthExceeds(Some("65"), guarded) shouldBe true
+    HttpRequestGuards.declaredLengthExceeds(Some("64"), guarded) shouldBe false
+    HttpRequestGuards.declaredLengthExceeds(Some(" 10 "), guarded) shouldBe false
+    HttpRequestGuards.declaredLengthExceeds(Some("garbage"), guarded) shouldBe false
+    HttpRequestGuards.declaredLengthExceeds(None, guarded) shouldBe false
+    HttpRequestGuards.declaredLengthExceeds(Some("99999999999999"), guarded) shouldBe true
+  }
+
+  test("bodyTooLarge: strictly above the cap in UTF-16 code units; rejection message names the cap") {
+    HttpRequestGuards.bodyTooLarge("a" * 64, guarded) shouldBe false
+    HttpRequestGuards.bodyTooLarge("a" * 65, guarded) shouldBe true
+    HttpRequestGuards.bodyTooLargeRejection(guarded) shouldBe
+      Rejection(413, "Request body exceeds 64 bytes")
+  }
+
+  test("capReached: Some(n) caps at n; None disables") {
+    val two = McpServerSettings(maxSessions = Some(2))
+    HttpRequestGuards.capReached(0, two) shouldBe false
+    HttpRequestGuards.capReached(1, two) shouldBe false
+    HttpRequestGuards.capReached(2, two) shouldBe true
+    HttpRequestGuards.capReached(3, two) shouldBe true
+    val off = McpServerSettings(maxSessions = None)
+    HttpRequestGuards.capReached(1_000_000, off) shouldBe false
+    HttpRequestGuards.capReached(1000, McpServerSettings()) shouldBe true // default Some(1000)
+    HttpRequestGuards.capReached(999, McpServerSettings()) shouldBe false
+  }
+
+  test("pickEvictable: longest-idle session without a live GET; None when all hold a GET") {
+    val snapshot = List(("a", 300L, false), ("b", 100L, true), ("c", 200L, false))
+    HttpRequestGuards.pickEvictable(snapshot) shouldBe Some("c") // b is oldest but live
+    HttpRequestGuards.pickEvictable(List(("a", 1L, true), ("b", 2L, true))) shouldBe None
+    HttpRequestGuards.pickEvictable(Nil) shouldBe None
+    HttpRequestGuards.pickEvictable(List(("only", 5L, false))) shouldBe Some("only")
+  }
+
+  test("validateSettings: accepts defaults and parseable origins") {
+    HttpRequestGuards.validateSettings(McpServerSettings()) shouldBe Right(())
+    HttpRequestGuards.validateSettings(
+      McpServerSettings(allowedOrigins = Some(Set("https://app.example.com", "http://localhost:3000")))
+    ) shouldBe Right(())
+    HttpRequestGuards.validateSettings(McpServerSettings(maxSessions = None)) shouldBe Right(())
+  }
+
+  test("validateSettings: rejects unparseable origins, non-positive body cap and non-positive cap") {
+    val badOrigins = HttpRequestGuards.validateSettings(
+      McpServerSettings(allowedOrigins = Some(Set("https//app.example.com", "app.example.com")))
+    )
+    badOrigins.isLeft shouldBe true
+    badOrigins.left.getOrElse("") should include("app.example.com")
+    badOrigins.left.getOrElse("") should include("https//app.example.com")
+    HttpRequestGuards.validateSettings(McpServerSettings(maxRequestBodyBytes = 0)) shouldBe
+      Left("maxRequestBodyBytes must be positive")
+    HttpRequestGuards.validateSettings(McpServerSettings(maxRequestBodyBytes = -1)).isLeft shouldBe
+      true
+    HttpRequestGuards.validateSettings(McpServerSettings(maxSessions = Some(0))).isLeft shouldBe true
+  }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/JvmHttpTransportTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/JvmHttpTransportTest.scala
@@ -38,6 +38,10 @@ class JvmHttpTransportTest extends AnyFunSuite with Matchers:
       ZIO.foreachDiscard(ctx.progressToken)(t => ctx.sendProgress(t, 0.5)) *>
         ZIO.sleep(30.seconds).as("done")
 
+    @Tool(name = Some("boom"), description = Some("Dies with a defect (error-boundary target)"))
+    def boom(): ZIO[Any, Throwable, String] =
+      ZIO.succeed(throw new IllegalStateException("boom: secret handler state"))
+
   private val SessionIdHeader = "mcp-session-id"
 
   private val initFrame =
@@ -58,7 +62,10 @@ class JvmHttpTransportTest extends AnyFunSuite with Matchers:
   private def buildRoutes(
       stateless: Boolean,
       keepAlive: Option[java.time.Duration] = None,
-      allowedHosts: Option[Set[String]] = None
+      allowedHosts: Option[Set[String]] = None,
+      allowedOrigins: Option[Set[String]] = None,
+      maxRequestBodyBytes: Int = 1024 * 1024,
+      maxSessions: Option[Int] = Some(1000)
   ): Routes[Any, Response] =
     val server = McpServer.typed[Any](
       "T",
@@ -66,7 +73,10 @@ class JvmHttpTransportTest extends AnyFunSuite with Matchers:
       McpServerSettings(
         stateless = stateless,
         keepAliveInterval = keepAlive,
-        allowedHosts = allowedHosts
+        allowedHosts = allowedHosts,
+        allowedOrigins = allowedOrigins,
+        maxRequestBodyBytes = maxRequestBodyBytes,
+        maxSessions = maxSessions
       )
     )
     val _ = server.scanAnnotations[TestServer.type]
@@ -82,10 +92,32 @@ class JvmHttpTransportTest extends AnyFunSuite with Matchers:
   private def run(routes: Routes[Any, Response], req: Request): Response =
     runUnsafe(ZIO.scoped(routes.runZIO(req)))
 
+  /** A legacy POST as a compliant client sends it: JSON media type and an Accept covering both the
+    * JSON and SSE reply shapes (every POST needs `Content-Type: application/json` — 415 otherwise).
+    */
   private def post(routes: Routes[Any, Response], body: String, sid: Option[String]): Response =
-    val base = Request.post(URL(Path.root / "mcp"), Body.fromString(body))
+    val base = Request
+      .post(URL(Path.root / "mcp"), Body.fromString(body))
+      .addHeader(Header.Custom("content-type", "application/json"))
+      .addHeader(Header.Custom("accept", "application/json, text/event-stream"))
     val req = sid.fold(base)(s => base.addHeader(Header.Custom(SessionIdHeader, s)))
     run(routes, req)
+
+  /** A raw POST with exactly the given headers — for the transport-gate tests. */
+  private def rawPost(
+      routes: Routes[Any, Response],
+      body: String,
+      headers: (String, String)*
+  ): Response =
+    val req = headers.foldLeft(Request.post(URL(Path.root / "mcp"), Body.fromString(body))) {
+      case (r, (k, v)) => r.addHeader(Header.Custom(k, v))
+    }
+    run(routes, req)
+
+  private val JsonHeaders = List(
+    "content-type" -> "application/json",
+    "accept" -> "application/json, text/event-stream"
+  )
 
   private def bodyOf(resp: Response): String = runUnsafe(resp.body.asString)
 
@@ -232,6 +264,7 @@ class JvmHttpTransportTest extends AnyFunSuite with Matchers:
             routes.runZIO(
               Request
                 .post(URL(Path.root / "mcp"), Body.fromString(slowFrame))
+                .addHeader(Header.Custom("content-type", "application/json"))
                 .addHeader(Header.Custom(SessionIdHeader, sid))
             )
           )
@@ -242,6 +275,7 @@ class JvmHttpTransportTest extends AnyFunSuite with Matchers:
           routes.runZIO(
             Request
               .post(URL(Path.root / "mcp"), Body.fromString(cancelFrame))
+              .addHeader(Header.Custom("content-type", "application/json"))
               .addHeader(Header.Custom(SessionIdHeader, sid))
           )
         )
@@ -274,6 +308,7 @@ class JvmHttpTransportTest extends AnyFunSuite with Matchers:
     val routes = buildRoutes(stateless = false)
     val req = Request
       .post(URL(Path.root / "mcp"), Body.fromString(initFrame))
+      .addHeader(Header.Custom("content-type", "application/json"))
       .addHeader(Header.Custom("accept", "application/json"))
     run(routes, req).status shouldBe Status.NotAcceptable
 
@@ -376,6 +411,7 @@ class JvmHttpTransportTest extends AnyFunSuite with Matchers:
       buildRoutes(stateless = false, allowedHosts = Some(Set("localhost", "127.0.0.1")))
     val evilPost = Request
       .post(URL(Path.root / "mcp"), Body.fromString(initFrame))
+      .addHeader(Header.Custom("content-type", "application/json"))
       .addHeader(Header.Custom("host", "evil.example.com"))
     run(routes, evilPost).status shouldBe Status.Forbidden
 
@@ -385,30 +421,256 @@ class JvmHttpTransportTest extends AnyFunSuite with Matchers:
       .addHeader(Header.Custom(SessionIdHeader, "whatever"))
     run(routes, evilGet).status shouldBe Status.Forbidden
 
+    val evilDelete = Request
+      .delete(URL(Path.root / "mcp"))
+      .addHeader(Header.Custom("host", "evil.example.com"))
+      .addHeader(Header.Custom(SessionIdHeader, "whatever"))
+    run(routes, evilDelete).status shouldBe Status.Forbidden
+
     // Allowed host proceeds to normal processing (mints a session on initialize).
     val okPost = Request
       .post(URL(Path.root / "mcp"), Body.fromString(initFrame))
+      .addHeader(Header.Custom("content-type", "application/json"))
       .addHeader(Header.Custom("host", "127.0.0.1:8000"))
     run(routes, okPost).status shouldBe Status.Ok
   }
 
-  test("idle streamable sessions are swept; live-GET sessions are exempt") {
-    val settings = McpServerSettings(sessionIdleTimeout = Some(java.time.Duration.ofMillis(200)))
-    runUnsafe(
-      for
-        idle <- Session.make("idle")
-        live <- Session.make("live")
-        _ <- live.tryAcquireGet
-        store <- Ref.make(Map("idle" -> idle, "live" -> live))
-        sweeper <- JvmHttpBackend.evictIdleSessions(store, settings).fork
-        _ <- (ZIO.sleep(50.millis) *> store.get)
-          .map(m => !m.contains("idle") && m.contains("live"))
-          .repeatUntil(identity)
-          .timeoutFail(new RuntimeException("sweeper did not evict the idle session"))(10.seconds)
-        shutdown <- idle.outbound.isShutdown
-        _ <- sweeper.interrupt
-      yield shutdown shouldBe true
+  // ---- F5 §1: Origin is a full origin, matched against the request's Host authority ----
+
+  test("Origin route table: cross-port / cross-scheme / null / foreign origins are 403, same authority 200") {
+    val routes =
+      buildRoutes(stateless = true, allowedHosts = Some(Set("localhost", "127.0.0.1")))
+    def withOrigin(origin: String): Response =
+      rawPost(
+        routes,
+        listFrame,
+        ("host" -> "localhost:8000") :: ("origin" -> origin) :: JsonHeaders*
+      )
+    for refused <- List(
+        "http://localhost:3000",
+        "https://localhost",
+        "http://127.0.0.1:1",
+        "null",
+        "",
+        "http://evil.example.com",
+        "http://localhost:99999",
+        "http://localhost:",
+        "http://localhost:abc",
+        "http://localhost:0",
+        "http://localhost:8000/x",
+        "http://user@localhost:8000",
+        "ftp://localhost:8000",
+        "http://127.0.0.1:8000" // listed hostname, same port, but not the request's authority
+      )
+    do
+      withClue(s"Origin: $refused") {
+        val resp = withOrigin(refused)
+        resp.status shouldBe Status.Forbidden
+        bodyOf(resp) should include("-32000")
+        resp.rawHeader(SessionIdHeader) shouldBe None
+      }
+    withOrigin("http://localhost:8000").status shouldBe Status.Ok
+    withOrigin("HTTP://LocalHost:8000").status shouldBe Status.Ok
+    withOrigin("https://localhost:8000").status shouldBe Status.Ok // scheme not compared (documented)
+    // No Origin at all: non-browser client, still fine.
+    rawPost(routes, listFrame, ("host" -> "localhost:8000") :: JsonHeaders*).status shouldBe Status.Ok
+  }
+
+  test("allowedOrigins admits an explicitly listed origin that is not the request's authority") {
+    val routes = buildRoutes(
+      stateless = true,
+      allowedHosts = Some(Set("localhost", "127.0.0.1")),
+      allowedOrigins = Some(Set("http://localhost:3000", "https://app.example.com"))
     )
+    def withOrigin(origin: String): Response =
+      rawPost(
+        routes,
+        listFrame,
+        ("host" -> "localhost:8000") :: ("origin" -> origin) :: JsonHeaders*
+      )
+    withOrigin("http://localhost:3000").status shouldBe Status.Ok
+    withOrigin("https://app.example.com:443").status shouldBe Status.Ok
+    withOrigin("http://localhost:3001").status shouldBe Status.Forbidden
+    withOrigin("http://app.example.com").status shouldBe Status.Forbidden
+  }
+
+  test("serveHttp refuses to start on an unparseable allowedOrigins entry") {
+    val server = McpServer.typed[Any](
+      "BadOrigins",
+      "0.1.0",
+      McpServerSettings(allowedOrigins = Some(Set("app.example.com")))
+    )
+    val outcome = runUnsafe(
+      server.buildRouter.flatMap(r => JvmHttpBackend.serveHttp(r, server.settings)).either
+    )
+    outcome.isLeft shouldBe true
+    outcome.swap.map(_.getMessage).getOrElse("") should include("allowedOrigins")
+  }
+
+  // ---- F5 §2: every POST needs Content-Type: application/json, before body read or minting ----
+
+  test("415 for a legacy POST with text/plain or no Content-Type, on stateless and streamable, no session minted") {
+    for stateless <- List(true, false) do
+      val routes = buildRoutes(stateless = stateless)
+      withClue(s"stateless=$stateless text/plain") {
+        val resp = rawPost(
+          routes,
+          initFrame,
+          "content-type" -> "text/plain",
+          "accept" -> "application/json, text/event-stream"
+        )
+        resp.status.code shouldBe 415
+        bodyOf(resp) should include("-32000")
+        bodyOf(resp) should include("application/json")
+        resp.rawHeader(SessionIdHeader) shouldBe None
+      }
+      withClue(s"stateless=$stateless absent") {
+        val resp = rawPost(routes, initFrame, "accept" -> "application/json, text/event-stream")
+        resp.status.code shouldBe 415
+        resp.rawHeader(SessionIdHeader) shouldBe None
+      }
+      withClue(s"stateless=$stateless tools/call text/plain") {
+        val resp = rawPost(routes, callFrame, "content-type" -> "text/plain")
+        resp.status.code shouldBe 415
+        bodyOf(resp) should not include "42"
+      }
+    // A CORS-simple no-Content-Type initialize on the streamable route did not mint anything: a
+    // guessed follow-up session id is unknown.
+    val streamable = buildRoutes(stateless = false)
+    val _ = rawPost(streamable, initFrame)
+    post(streamable, listFrame, Some("guessed-session-id")).status shouldBe Status.NotFound
+  }
+
+  test("application/json with a charset parameter is accepted; JSON-ish other types are not") {
+    val routes = buildRoutes(stateless = true)
+    rawPost(routes, listFrame, "content-type" -> "application/json; charset=utf-8").status shouldBe
+      Status.Ok
+    rawPost(routes, listFrame, "content-type" -> "application/json-patch+json").status.code shouldBe
+      415
+    rawPost(routes, listFrame, "content-type" -> "application/json; charset=utf-16").status.code shouldBe
+      415
+  }
+
+  // ---- F1 §2: operator-configurable body cap, 413 before parsing ----
+
+  test("413 when the declared Content-Length exceeds maxRequestBodyBytes (before the body is read)") {
+    val routes = buildRoutes(stateless = false, maxRequestBodyBytes = 64)
+    val resp = rawPost(routes, initFrame, ("content-length" -> "200") :: JsonHeaders*)
+    resp.status.code shouldBe 413
+    val body = bodyOf(resp)
+    body should include("-32000")
+    body should include("64 bytes")
+    resp.rawHeader(SessionIdHeader) shouldBe None
+  }
+
+  test("413 for an oversized NON-JSON body: the cap fires before parseFrame (not -32700)") {
+    for stateless <- List(true, false) do
+      val routes = buildRoutes(stateless = stateless, maxRequestBodyBytes = 64)
+      val resp = rawPost(routes, "x" * 200, JsonHeaders*)
+      withClue(s"stateless=$stateless") {
+        resp.status.code shouldBe 413
+        val body = bodyOf(resp)
+        body should include("-32000")
+        body should not include "-32700"
+        resp.rawHeader(SessionIdHeader) shouldBe None
+      }
+    // At or under the cap the request proceeds normally.
+    val ok = buildRoutes(stateless = true, maxRequestBodyBytes = listFrame.length)
+    post(ok, listFrame, None).status shouldBe Status.Ok
+  }
+
+  // ---- F12: bounded legacy session store ----
+
+  test("maxSessions: at the cap the longest-idle session without a live GET is evicted, not the newcomer") {
+    val routes = buildRoutes(stateless = false, maxSessions = Some(2))
+    val sid1 = initSid(routes)
+    Thread.sleep(5)
+    val sid2 = initSid(routes)
+    Thread.sleep(5)
+    // Touch sid2 so sid1 is unambiguously the longest-idle session.
+    post(routes, listFrame, Some(sid2)).status shouldBe Status.Ok
+
+    val third = post(routes, initFrame, None)
+    third.status shouldBe Status.Ok
+    val sid3 = third.rawHeader(SessionIdHeader).getOrElse(fail("third initialize minted nothing"))
+    val _ = bodyOf(third)
+
+    post(routes, listFrame, Some(sid1)).status shouldBe Status.NotFound // evicted
+    post(routes, listFrame, Some(sid2)).status shouldBe Status.Ok
+    post(routes, listFrame, Some(sid3)).status shouldBe Status.Ok
+
+    // DELETE frees a slot; the next initialize is admitted without evicting.
+    run(
+      routes,
+      Request.delete(URL(Path.root / "mcp")).addHeader(Header.Custom(SessionIdHeader, sid3))
+    ).status shouldBe Status.Ok
+    val fourth = initSid(routes)
+    post(routes, listFrame, Some(sid2)).status shouldBe Status.Ok
+    post(routes, listFrame, Some(fourth)).status shouldBe Status.Ok
+  }
+
+  test("maxSessions: 503 only when every stored session holds a live GET stream") {
+    val routes = buildRoutes(stateless = false, maxSessions = Some(2))
+    val sid1 = initSid(routes)
+    val sid2 = initSid(routes)
+    for sid <- List(sid1, sid2) do
+      // Open (and never drain) the GET SSE channel: the session now has a live GET.
+      run(routes, Request.get(URL(Path.root / "mcp")).addHeader(Header.Custom(SessionIdHeader, sid)))
+        .status shouldBe Status.Ok
+
+    val refused = post(routes, initFrame, None)
+    refused.status.code shouldBe 503
+    val body = bodyOf(refused)
+    body should include("-32000")
+    body should include("Session limit reached")
+    refused.rawHeader(SessionIdHeader) shouldBe None
+    // Neither stored session was touched.
+    post(routes, listFrame, Some(sid1)).status shouldBe Status.Ok
+    post(routes, listFrame, Some(sid2)).status shouldBe Status.Ok
+  }
+
+  test("maxSessions = None disables the cap") {
+    val routes = buildRoutes(stateless = false, maxSessions = None)
+    val sids = (1 to 5).map(_ => initSid(routes))
+    sids.foreach(sid => post(routes, listFrame, Some(sid)).status shouldBe Status.Ok)
+  }
+
+  // ---- F10 §1: first-party error boundary ----
+
+  test("guarded: a defect becomes a JSON-RPC 500 with a fixed message; interrupts pass through") {
+    val dead = JvmHttpBackend.guarded[Any](ZIO.die(new IllegalStateException("boom: secret state")))
+    val resp = runUnsafe(dead)
+    resp.status shouldBe Status.InternalServerError
+    resp.rawHeader("content-type").getOrElse("") should include("application/json")
+    val body = bodyOf(resp)
+    body should include("-32000")
+    body should include("Internal server error")
+    body should not include "boom"
+    body should not include "IllegalStateException"
+    body should not include "secret"
+
+    // A client disconnect interrupts the handler fiber: zio-http keeps its own 408 path, so the
+    // boundary must not swallow interrupts into a 500.
+    val interrupted = runUnsafe(JvmHttpBackend.guarded[Any](ZIO.interrupt).exit)
+    interrupted.isInterrupted shouldBe true
+
+    val fine = runUnsafe(JvmHttpBackend.guarded[Any](ZIO.succeed(Response.status(Status.Accepted))))
+    fine.status shouldBe Status.Accepted
+  }
+
+  test("a tool that dies is answered in-band by the router (JSON -32603), never a raw 500 or HTML") {
+    // The router's dispatch awaits the handler fiber's Exit and maps defects to -32603, so the
+    // transport boundary above is defence in depth behind it. Pin the contract at the route level.
+    val routes = buildRoutes(stateless = true)
+    val frame =
+      """{"jsonrpc":"2.0","id":13,"method":"tools/call","params":{"name":"boom","arguments":{}}}"""
+    val resp = post(routes, frame, None)
+    resp.status shouldBe Status.Ok
+    resp.rawHeader("content-type").getOrElse("") should include("application/json")
+    val body = bodyOf(resp)
+    body should include("\"jsonrpc\"")
+    body should not include "<html"
+    body should not include "\tat "
   }
 
   test("stateless: a single POST initialize returns capabilities without logging") {
@@ -429,6 +691,7 @@ class JvmHttpTransportTest extends AnyFunSuite with Matchers:
     val routes = buildRoutes(stateless = true)
     val req = Request
       .post(URL(Path.root / "mcp"), Body.fromString(initFrame))
+      .addHeader(Header.Custom("content-type", "application/json"))
       .addHeader(Header.Custom("accept", "text/plain"))
     run(routes, req).status shouldBe Status.NotAcceptable
   }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/JvmHttpTransportTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/JvmHttpTransportTest.scala
@@ -629,6 +629,27 @@ class JvmHttpTransportTest extends AnyFunSuite with Matchers:
     post(routes, listFrame, Some(sid2)).status shouldBe Status.Ok
   }
 
+  test("maxSessions: concurrent header-less initializes at the cap all admit while idle sessions exist") {
+    val routes = buildRoutes(stateless = false, maxSessions = Some(2))
+    val idle = List(initSid(routes), initSid(routes))
+    val initReq = Request
+      .post(URL(Path.root / "mcp"), Body.fromString(initFrame))
+      .addHeader(Header.Custom("content-type", "application/json"))
+      .addHeader(Header.Custom("accept", "application/json, text/event-stream"))
+    // 16 initializes race for the two slots: admission + eviction are one serialised modifyZIO, so
+    // nobody sees a stale snapshot and nobody is refused while an idle (GET-less) session exists.
+    val responses = runUnsafe(
+      ZIO.foreachPar((1 to 16).toList)(_ => ZIO.scoped(routes.runZIO(initReq)))
+    )
+    responses.map(_.status.code).distinct shouldBe List(200)
+    val minted = responses.map(r => r.rawHeader(SessionIdHeader).getOrElse(fail("no session id")))
+    minted.distinct.size shouldBe 16
+    // The cap held: exactly two sessions survive (the idle pair was evicted first).
+    val alive = (idle ++ minted).count(sid => post(routes, listFrame, Some(sid)).status == Status.Ok)
+    alive shouldBe 2
+    idle.foreach(sid => post(routes, listFrame, Some(sid)).status shouldBe Status.NotFound)
+  }
+
   test("maxSessions = None disables the cap") {
     val routes = buildRoutes(stateless = false, maxSessions = None)
     val sids = (1 to 5).map(_ => initSid(routes))

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServerSettings.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServerSettings.scala
@@ -119,10 +119,31 @@ case class McpServerSettings(
     // Legacy adapter only: advertise and wire resources/subscribe + resources/unsubscribe.
     // Modern subscriptions use subscriptions/listen. Off by default.
     resourcesSubscribe: Boolean = false,
-    // DNS-rebinding protection (Streamable/stateless HTTP). When `Some`, an HTTP request whose
-    // `Host` (or `Origin`) hostname — port ignored — is not in the set is rejected with 403.
-    // `None` (default) disables host checking, preserving prior behavior.
+    // DNS-rebinding / CSRF guard for the HTTP transports. When `Some`, a request whose `Host`
+    // hostname (port ignored; a verbatim `host:port` entry also matches) is not listed is refused
+    // with 403. A present `Origin` header is matched as a FULL origin (scheme://host:port, default
+    // port per scheme): it must appear in `allowedOrigins`, or its hostname must be listed here AND
+    // its host:port must equal the request's `Host` authority. `null`, empty, malformed, cross-port
+    // and cross-scheme-default-port origins are refused; an absent `Host`/`Origin` passes (not the
+    // browser threat this guards). `None` here and in `allowedOrigins` disables the guard.
     allowedHosts: Option[Set[String]] = None,
+    // Explicit browser origins (`https://app.example.com`, `http://localhost:5173`) admitted in
+    // addition to the request's own authority. Needed for front-ends served from another origin or
+    // behind a TLS-terminating proxy whose Origin differs from the listener's Host. Entries that do
+    // not parse as `scheme://host[:port]` fail `runHttp()` at startup. `None` (default) = none.
+    allowedOrigins: Option[Set[String]] = None,
+    // Maximum HTTP request body accepted on the MCP endpoint, in bytes, on every backend. Enforced
+    // by the platform server (zio-http request aggregator / Bun.serve maxRequestBodySize) AND by a
+    // first-party Content-Length + post-read check, so oversized bodies answer 413 before any JSON
+    // decoding. 1 MiB default (the JVM was implicitly ~100 KiB; Bun was 128 MiB); raise it for
+    // tools that legitimately take large payloads. Must be > 0.
+    maxRequestBodyBytes: Int = 1024 * 1024,
+    // Legacy streamable adapter only: cap on concurrently stored sessions. When a header-less
+    // `initialize` arrives at the cap, the longest-idle session without a live GET stream is evicted
+    // (its queue shut down) to make room; only when every stored session has a live GET is the
+    // request refused with 503. Bounds memory without letting a flood lock new clients out.
+    // `None` disables. Modern 2026-07-28 requests never store sessions.
+    maxSessions: Option[Int] = Some(1000),
     // Optional io.modelcontextprotocol/tasks extension. Off by default.
     tasks: TaskSettings = TaskSettings(),
     // Inbound input limits (frame size, JSON depth, object width, URI length, subscriptions).

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/HostGuard.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/HostGuard.scala
@@ -1,36 +1,157 @@
 package com.tjclp.fastmcp.server.transport
 
-/** DNS-rebinding protection shared by the JVM and JS HTTP transports.
+import com.tjclp.fastmcp.server.McpServerSettings
+
+/** DNS-rebinding / CSRF protection shared by every HTTP backend (JVM, Bun, Native).
   *
-  * When `allowed` is non-empty, an inbound request is permitted only if its `Host` header — and its
-  * `Origin` header when present — names an allowed host. Comparison is case-insensitive and by
-  * hostname with the port stripped, so a single `127.0.0.1` entry covers any bound port; the
-  * verbatim `host:port` is also accepted. An absent `Host`/`Origin` is treated as allowed (HTTP/1.1
-  * always sends `Host`; absence is not the rebinding threat this guards against). `allowed.isEmpty`
-  * disables the check entirely (the default when `McpServerSettings.allowedHosts` is `None`).
+  * `Host` is matched by hostname, case-insensitively, with the port stripped — so a single
+  * `127.0.0.1` entry in `allowedHosts` covers whatever port the server binds; a verbatim
+  * `host:port` entry also matches. An absent `Host` is allowed (HTTP/1.1 always sends it; absence
+  * is not the rebinding threat this guards against).
+  *
+  * `Origin`, when present, is matched as a FULL origin — `scheme://host[:port]` with the port
+  * defaulting per scheme (80 / 443) — never by port-stripped hostname. It is admitted when either
+  *   - its normalised form is listed in `allowedOrigins`, or
+  *   - its hostname is listed in `allowedHosts` AND its `host:port` equals the request's `Host`
+  *     authority (a page served by the MCP host itself). The scheme is deliberately NOT compared in
+  *     this rule: the listener cannot know whether TLS is terminated upstream, so `https://h:p` is
+  *     admitted for `Host: h:p`. Use `allowedOrigins` for a stricter list.
+  *
+  * Parsing is fail-closed: `null`, empty, non-http(s) schemes, userinfo/path/query characters, an
+  * empty host, or an explicit port that is not 1..65535 decimal digits all refuse the request.
+  *
+  * Truth table (server on `127.0.0.1:8000`, `allowedHosts = Some(Set("127.0.0.1", "localhost"))`,
+  * `allowedOrigins = None`, request `Host: localhost:8000` unless stated):
+  *
+  * | Origin header                                                              | Result |
+  * |:---------------------------------------------------------------------------|:-------|
+  * | absent                                                                     | allow  |
+  * | `http://localhost:8000`, `HTTP://LocalHost:8000`                           | allow  |
+  * | `http://localhost:3000` (port differs)                                     | 403    |
+  * | `https://localhost` (default 443 != 8000)                                  | 403    |
+  * | `http://127.0.0.1:1`                                                       | 403    |
+  * | `null` / empty                                                             | 403    |
+  * | `http://evil.example.com`                                                  | 403    |
+  * | `http://localhost:99999`, `http://localhost:`, `:abc`, `:0`                | 403    |
+  * | `http://localhost:8000/x`, `http://user@localhost:8000`, `ftp://...`       | 403    |
+  * | `http://127.0.0.1:8000` with `Host: localhost:8000` (cross-origin)         | 403    |
+  * | `http://localhost:8000` with `Host` absent                                 | 403    |
+  * | `http://localhost` with `Host: localhost` (port-less Host = default)       | allow  |
+  * | `https://localhost:8000` with `Host: localhost:8000` (scheme not compared) | allow  |
+  * | `http://[::1]:8000` with `Host: [::1]:8000`, `[::1]` listed                | allow  |
+  * | listed in `allowedOrigins` (any/no Host)                                   | allow  |
+  * | `allowedHosts = None`, `allowedOrigins = Some(...)`, Origin not listed     | 403    |
+  * | both `None`                                                                | allow  |
+  *
+  * The guard closes the browser CSRF / DNS-rebinding path only; a non-browser client that omits
+  * `Origin` is not authenticated by it.
   */
 object HostGuard:
 
-  /** True if the request may proceed. */
+  /** Normalised origin: lowercase scheme and host, explicit port (default 80/443). The host keeps
+    * IPv6 brackets.
+    */
+  private[fastmcp] final case class Origin(scheme: String, host: String, port: Int)
+
+  /** Backend entry point: honours both `allowedHosts` and `allowedOrigins`. */
+  def isAllowed(
+      host: Option[String],
+      origin: Option[String],
+      settings: McpServerSettings
+  ): Boolean =
+    isAllowed(
+      host,
+      origin,
+      settings.allowedHosts.getOrElse(Set.empty),
+      settings.allowedOrigins.getOrElse(Set.empty)
+    )
+
+  @deprecated(
+    "Origin is now matched as a full origin; pass the McpServerSettings so allowedOrigins is honoured",
+    "1.0.0-RC4"
+  )
   def isAllowed(host: Option[String], origin: Option[String], allowed: Set[String]): Boolean =
-    if allowed.isEmpty then true
+    isAllowed(host, origin, allowed, Set.empty)
+
+  /** Raw-set core (tests). `allowedOrigins` entries are full origins; unparseable entries are
+    * ignored here — `HttpRequestGuards.validateSettings` rejects them at startup.
+    */
+  private[fastmcp] def isAllowed(
+      host: Option[String],
+      origin: Option[String],
+      allowedHosts: Set[String],
+      allowedOrigins: Set[String]
+  ): Boolean =
+    if allowedHosts.isEmpty && allowedOrigins.isEmpty then true
     else
-      val a = allowed.map(_.trim.toLowerCase)
-      host.forall(h => hostAllowed(h, a)) && origin.forall(o => originAllowed(o, a))
+      val hostsLower = allowedHosts.map(_.trim.toLowerCase)
+      val originsNorm = allowedOrigins.flatMap(parseOrigin)
+      val hostOk = hostsLower.isEmpty || host.forall(h => hostAllowed(h, hostsLower))
+      hostOk && origin.forall(o => originAllowed(o, host, hostsLower, originsNorm))
+
+  /** Entries of `allowedOrigins` that do not parse (for startup validation / diagnostics). */
+  private[fastmcp] def invalidOrigins(allowedOrigins: Set[String]): Set[String] =
+    allowedOrigins.filter(parseOrigin(_).isEmpty)
+
+  /** `scheme://host[:port]` → [[Origin]]. FAIL-CLOSED: `null`, empty, scheme not in {http, https},
+    * any of `/ ? # @ \` or whitespace in the authority, an empty host, or an explicit port that is
+    * not 1..65535 decimal digits (`:`, `:0`, `:abc`, `:99999`) → `None`. Only a completely absent
+    * port takes the scheme default (80 / 443).
+    */
+  private[fastmcp] def parseOrigin(raw: String): Option[Origin] =
+    val o = raw.trim.toLowerCase
+    val i = o.indexOf("://")
+    if o.isEmpty || o == "null" || i <= 0 then None
+    else
+      val scheme = o.substring(0, i)
+      val authority = o.substring(i + 3)
+      val default = scheme match
+        case "http" => Some(80)
+        case "https" => Some(443)
+        case _ => None
+      val badChars = authority.exists(ch => "/?#@\\".contains(ch) || ch.isWhitespace)
+      if default.isEmpty || badChars || authority.isEmpty then None
+      else
+        val h = hostnameOf(authority)
+        val portPart = authority.substring(h.length) // "" or ":<digits>" (or junk)
+        val port: Option[Int] =
+          if portPart.isEmpty then default
+          else if portPart.startsWith(":") then parsePort(portPart.substring(1))
+          else None // e.g. "[::1]junk"
+        val unclosedBracket = h.startsWith("[") && !h.endsWith("]")
+        if h.isEmpty || h == "[]" || unclosedBracket then None
+        else port.map(p => Origin(scheme, h, p))
+
+  private def originAllowed(
+      rawOrigin: String,
+      hostHeader: Option[String],
+      hostsLower: Set[String],
+      originsNorm: Set[Origin]
+  ): Boolean =
+    parseOrigin(rawOrigin) match
+      case None => false // null / empty / malformed
+      case Some(o) if originsNorm.contains(o) => true // explicit allow-list
+      case Some(o) =>
+        hostsLower.nonEmpty &&
+        (hostsLower.contains(o.host) || hostsLower.contains(s"${o.host}:${o.port}")) &&
+        sameAuthority(o, hostHeader)
+
+  /** Origin host:port must equal the request's Host authority. Host with an explicit port → both
+    * equal; Host without a port → hosts equal and the origin port is the scheme default; Host
+    * absent → false. The SCHEME is deliberately not compared (TLS-terminating proxies).
+    */
+  private def sameAuthority(o: Origin, hostHeader: Option[String]): Boolean =
+    hostHeader.map(_.trim.toLowerCase) match
+      case None => false
+      case Some(h) =>
+        val hn = hostnameOf(h)
+        val hp = portOf(h) // None when Host has no (valid) port
+        val schemeDefault = if o.scheme == "https" then 443 else 80
+        hn == o.host && hp.forall(_ == o.port) && (hp.nonEmpty || o.port == schemeDefault)
 
   private def hostAllowed(hostHeader: String, allowedLower: Set[String]): Boolean =
     val h = hostHeader.trim.toLowerCase
     allowedLower.contains(h) || allowedLower.contains(hostnameOf(h))
-
-  /** `Origin` is `scheme://host[:port]` (or the literal `null`); reduce to `host[:port]`. */
-  private def originAllowed(originHeader: String, allowedLower: Set[String]): Boolean =
-    val o = originHeader.trim.toLowerCase
-    if o == "null" || o.isEmpty then false
-    else
-      val hostPort = o.indexOf("://") match
-        case -1 => o
-        case i => o.substring(i + 3)
-      hostAllowed(hostPort, allowedLower)
 
   /** Strip a trailing `:port`, preserving bracketed IPv6 literals (`[::1]:8080` -> `[::1]`). */
   private def hostnameOf(hostPort: String): String =
@@ -40,3 +161,15 @@ object HostGuard:
     else
       val colon = hostPort.indexOf(':')
       if colon >= 0 then hostPort.substring(0, colon) else hostPort
+
+  /** Explicit port of a `host[:port]` authority, bracket-aware; `None` when absent or not 1..65535
+    * decimal digits.
+    */
+  private def portOf(hostPort: String): Option[Int] =
+    val rest = hostPort.substring(hostnameOf(hostPort).length)
+    if rest.startsWith(":") then parsePort(rest.substring(1)) else None
+
+  private def parsePort(digits: String): Option[Int] =
+    if digits.nonEmpty && digits.length <= 5 && digits.forall(ch => ch >= '0' && ch <= '9') then
+      digits.toIntOption.filter(p => p >= 1 && p <= 65535)
+    else None

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/HostGuard.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/HostGuard.scala
@@ -18,30 +18,35 @@ import com.tjclp.fastmcp.server.McpServerSettings
   *     admitted for `Host: h:p`. Use `allowedOrigins` for a stricter list.
   *
   * Parsing is fail-closed: `null`, empty, non-http(s) schemes, userinfo/path/query characters, an
-  * empty host, or an explicit port that is not 1..65535 decimal digits all refuse the request.
+  * empty host, or an explicit port that is not 1..65535 decimal digits all refuse the request — on
+  * the `Origin` AND on the `Host` side (a malformed `Host` port never degrades to "port-less"). A
+  * genuinely port-less `Host` (a listener on 80 or 443) admits the origin whose port is ITS scheme
+  * default, i.e. both `http://h` and `https://h`; use `allowedOrigins` for a stricter list.
   *
   * Truth table (server on `127.0.0.1:8000`, `allowedHosts = Some(Set("127.0.0.1", "localhost"))`,
   * `allowedOrigins = None`, request `Host: localhost:8000` unless stated):
   *
-  * | Origin header                                                              | Result |
-  * |:---------------------------------------------------------------------------|:-------|
-  * | absent                                                                     | allow  |
-  * | `http://localhost:8000`, `HTTP://LocalHost:8000`                           | allow  |
-  * | `http://localhost:3000` (port differs)                                     | 403    |
-  * | `https://localhost` (default 443 != 8000)                                  | 403    |
-  * | `http://127.0.0.1:1`                                                       | 403    |
-  * | `null` / empty                                                             | 403    |
-  * | `http://evil.example.com`                                                  | 403    |
-  * | `http://localhost:99999`, `http://localhost:`, `:abc`, `:0`                | 403    |
-  * | `http://localhost:8000/x`, `http://user@localhost:8000`, `ftp://...`       | 403    |
-  * | `http://127.0.0.1:8000` with `Host: localhost:8000` (cross-origin)         | 403    |
-  * | `http://localhost:8000` with `Host` absent                                 | 403    |
-  * | `http://localhost` with `Host: localhost` (port-less Host = default)       | allow  |
-  * | `https://localhost:8000` with `Host: localhost:8000` (scheme not compared) | allow  |
-  * | `http://[::1]:8000` with `Host: [::1]:8000`, `[::1]` listed                | allow  |
-  * | listed in `allowedOrigins` (any/no Host)                                   | allow  |
-  * | `allowedHosts = None`, `allowedOrigins = Some(...)`, Origin not listed     | 403    |
-  * | both `None`                                                                | allow  |
+  * | Origin header                                                               | Result |
+  * |:----------------------------------------------------------------------------|:-------|
+  * | absent                                                                      | allow  |
+  * | `http://localhost:8000`, `HTTP://LocalHost:8000`                            | allow  |
+  * | `http://localhost:3000` (port differs)                                      | 403    |
+  * | `https://localhost` (default 443 != 8000)                                   | 403    |
+  * | `http://127.0.0.1:1`                                                        | 403    |
+  * | `null` / empty                                                              | 403    |
+  * | `http://evil.example.com`                                                   | 403    |
+  * | `http://localhost:99999`, `http://localhost:`, `:abc`, `:0`                 | 403    |
+  * | `http://localhost:8000/x`, `http://user@localhost:8000`, `ftp://...`        | 403    |
+  * | `http://127.0.0.1:8000` with `Host: localhost:8000` (cross-origin)          | 403    |
+  * | `http://localhost:8000` with `Host` absent                                  | 403    |
+  * | `http://localhost` with `Host: localhost` (port-less Host = default)        | allow  |
+  * | `https://localhost` with `Host: localhost` (port-less Host admits :443 too) | allow  |
+  * | `http://localhost` with `Host: localhost:99999` (malformed Host port)       | 403    |
+  * | `https://localhost:8000` with `Host: localhost:8000` (scheme not compared)  | allow  |
+  * | `http://[::1]:8000` with `Host: [::1]:8000`, `[::1]` listed                 | allow  |
+  * | listed in `allowedOrigins` (any/no Host)                                    | allow  |
+  * | `allowedHosts = None`, `allowedOrigins = Some(...)`, Origin not listed      | 403    |
+  * | both `None`                                                                 | allow  |
   *
   * The guard closes the browser CSRF / DNS-rebinding path only; a non-browser client that omits
   * `Origin` is not authenticated by it.
@@ -137,17 +142,23 @@ object HostGuard:
         sameAuthority(o, hostHeader)
 
   /** Origin host:port must equal the request's Host authority. Host with an explicit port → both
-    * equal; Host without a port → hosts equal and the origin port is the scheme default; Host
-    * absent → false. The SCHEME is deliberately not compared (TLS-terminating proxies).
+    * equal; Host without a port → hosts equal and the origin port is the ORIGIN's scheme default
+    * (so a port-less `Host: h` admits both `http://h` and `https://h`); Host with a malformed port
+    * (`h:99999`, `h:abc`, `h:`) → false (fail-closed, mirroring [[parseOrigin]]); Host absent →
+    * false. The SCHEME is deliberately not compared (TLS-terminating proxies).
     */
   private def sameAuthority(o: Origin, hostHeader: Option[String]): Boolean =
     hostHeader.map(_.trim.toLowerCase) match
       case None => false
       case Some(h) =>
         val hn = hostnameOf(h)
-        val hp = portOf(h) // None when Host has no (valid) port
+        val portPart = h.substring(hn.length) // "" | ":<port>" | junk
         val schemeDefault = if o.scheme == "https" then 443 else 80
-        hn == o.host && hp.forall(_ == o.port) && (hp.nonEmpty || o.port == schemeDefault)
+        hn == o.host && {
+          if portPart.isEmpty then o.port == schemeDefault
+          else if portPart.startsWith(":") then parsePort(portPart.substring(1)).contains(o.port)
+          else false
+        }
 
   private def hostAllowed(hostHeader: String, allowedLower: Set[String]): Boolean =
     val h = hostHeader.trim.toLowerCase
@@ -161,13 +172,6 @@ object HostGuard:
     else
       val colon = hostPort.indexOf(':')
       if colon >= 0 then hostPort.substring(0, colon) else hostPort
-
-  /** Explicit port of a `host[:port]` authority, bracket-aware; `None` when absent or not 1..65535
-    * decimal digits.
-    */
-  private def portOf(hostPort: String): Option[Int] =
-    val rest = hostPort.substring(hostnameOf(hostPort).length)
-    if rest.startsWith(":") then parsePort(rest.substring(1)) else None
 
   private def parsePort(digits: String): Option[Int] =
     if digits.nonEmpty && digits.length <= 5 && digits.forall(ch => ch >= '0' && ch <= '9') then

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/HttpHeaderValidation.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/HttpHeaderValidation.scala
@@ -191,15 +191,21 @@ private[fastmcp] object HttpHeaderValidation:
 
   private def decodeHeaderValue(value: String): Either[McpError, String] =
     if value.startsWith(EncodedPrefix) && value.endsWith(EncodedSuffix) then
-      val payload = value.substring(EncodedPrefix.length, value.length - EncodedSuffix.length)
-      Try(Base64.getDecoder.decode(payload)).toEither.left
-        .map(_ => McpError.headerMismatch("Malformed Base64 header sentinel"))
-        .flatMap { bytes =>
-          val decoded = new String(bytes, StandardCharsets.UTF_8)
-          if java.util.Arrays.equals(bytes, decoded.getBytes(StandardCharsets.UTF_8)) then
-            Right(decoded)
-          else Left(McpError.headerMismatch("Base64 header value is not valid UTF-8"))
-        }
+      // `=?base64?=` (10 chars, prefix and suffix overlap on the `?`) and the empty-payload
+      // `=?base64??=` (11 chars) are malformed sentinels, not plain values; the substring below
+      // would throw StringIndexOutOfBounds for the first, so refuse before slicing.
+      if value.length <= EncodedPrefix.length + EncodedSuffix.length then
+        Left(McpError.headerMismatch("Malformed Base64 header sentinel"))
+      else
+        val payload = value.substring(EncodedPrefix.length, value.length - EncodedSuffix.length)
+        Try(Base64.getDecoder.decode(payload)).toEither.left
+          .map(_ => McpError.headerMismatch("Malformed Base64 header sentinel"))
+          .flatMap { bytes =>
+            val decoded = new String(bytes, StandardCharsets.UTF_8)
+            if java.util.Arrays.equals(bytes, decoded.getBytes(StandardCharsets.UTF_8)) then
+              Right(decoded)
+            else Left(McpError.headerMismatch("Base64 header value is not valid UTF-8"))
+          }
     else validatePlainValue(value)
 
   private def validatePlainValue(value: String): Either[McpError, String] =

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/HttpRequestGuards.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/HttpRequestGuards.scala
@@ -1,0 +1,124 @@
+package com.tjclp.fastmcp.server.transport
+
+import com.tjclp.fastmcp.server.McpServerSettings
+
+/** Every transport-level admission decision of the HTTP backends, as pure functions over the
+  * request headers and [[McpServerSettings]]. Backends (zio-http on the JVM, `Bun.serve` on
+  * Scala.js) only render a [[HttpRequestGuards.Rejection]] onto their own response type, so the
+  * security logic is written — and tested — once.
+  *
+  * Request order on every backend:
+  * {{{
+  * path 404 → hostGate 403 → Content-Type 415 → declared Content-Length 413 → Accept 406 →
+  *   body read (platform byte cap → 413) → bodyTooLarge 413 → parseFrame → dispatch →
+  *   session cap (evict oldest idle / 503) → any defect → JSON-RPC 500 (guarded)
+  * }}}
+  */
+private[fastmcp] object HttpRequestGuards:
+
+  /** A transport-level refusal: HTTP status + message for the JSON-RPC error body (404 → -32001,
+    * anything else → -32000, as every backend's `errorResponse` already maps).
+    */
+  final case class Rejection(status: Int, message: String)
+
+  val InternalErrorMessage: String = "Internal server error"
+  val SessionLimitMessage: String = "Session limit reached; retry later"
+  val HostRefusedMessage: String = "Host/Origin not allowed (DNS-rebinding protection)"
+
+  /** Startup validation, run by every `serveHttp` before binding: each `allowedOrigins` entry must
+    * parse as `scheme://host[:port]`, `maxRequestBodyBytes` must be positive and `maxSessions`,
+    * when set, must be positive (use `None` to disable the cap).
+    */
+  def validateSettings(settings: McpServerSettings): Either[String, Unit] =
+    val bad = HostGuard.invalidOrigins(settings.allowedOrigins.getOrElse(Set.empty))
+    if bad.nonEmpty then
+      Left(
+        s"allowedOrigins entries are not `scheme://host[:port]`: ${bad.toList.sorted.mkString(", ")}"
+      )
+    else if settings.maxRequestBodyBytes <= 0 then Left("maxRequestBodyBytes must be positive")
+    else if settings.maxSessions.exists(_ <= 0) then
+      Left("maxSessions must be positive (use None to disable the cap)")
+    // TODO(TJC-2294 merge): add `maxRequestBodyBytes <= limits.maxFrameChars` once Arc A's
+    // `LimitSettings` lands: `else if settings.maxRequestBodyBytes > settings.limits.maxFrameChars
+    // then Left("maxRequestBodyBytes must not exceed limits.maxFrameChars")`.
+    else Right(())
+
+  /** 403 when the Host/Origin guard refuses. Used for GET/DELETE and as step 1 of [[postGate]]. */
+  def hostGate(header: String => Option[String], settings: McpServerSettings): Option[Rejection] =
+    if HostGuard.isAllowed(header("host"), header("origin"), settings) then None
+    else Some(Rejection(403, HostRefusedMessage))
+
+  /** POST gate, evaluated on headers only (before any body read or session state), in this order:
+    * 403 host/origin → 415 media type → 413 declared Content-Length → 406 Accept. `requireSse`
+    * additionally demands `text/event-stream` in `Accept` (streamable transport: replies stream as
+    * SSE).
+    */
+  def postGate(
+      header: String => Option[String],
+      settings: McpServerSettings,
+      requireSse: Boolean
+  ): Option[Rejection] =
+    hostGate(header, settings).orElse {
+      if !isJsonContentType(header("content-type")) then
+        Some(Rejection(415, "Content-Type must be application/json"))
+      else if declaredLengthExceeds(header("content-length"), settings) then
+        Some(bodyTooLargeRejection(settings))
+      else if !acceptsAny(header("accept"), List("application/json", "application/*")) then
+        Some(Rejection(406, "Accept must allow application/json"))
+      else if requireSse && !acceptsAny(header("accept"), List("text/event-stream", "text/*")) then
+        Some(Rejection(406, "Accept must allow text/event-stream"))
+      else None
+    }
+
+  /** RFC 9110 media-type match: `application/json` with any parameters; a `charset` parameter, when
+    * present, must be utf-8 (JSON is UTF-8 and both backends decode the body as UTF-8). Absent or
+    * any other media type (`text/plain`, `application/json-patch+json`, a wildcard) → false.
+    */
+  def isJsonContentType(value: Option[String]): Boolean =
+    value.exists { v =>
+      val semi = v.indexOf(';')
+      val mediaType = (if semi < 0 then v else v.substring(0, semi)).trim
+      val params = if semi < 0 then "" else v.substring(semi + 1).toLowerCase
+      val charsetOk =
+        params.split(';').map(_.trim).filter(_.startsWith("charset=")).forall { p =>
+          val cs = p.stripPrefix("charset=").trim.stripPrefix("\"").stripSuffix("\"")
+          cs == "utf-8" || cs == "utf8"
+        }
+      mediaType.equalsIgnoreCase("application/json") && charsetOk
+    }
+
+  /** Absent `Accept` passes (header-less clients); present → must include one of `types` or the
+    * any-type wildcard.
+    */
+  def acceptsAny(accept: Option[String], types: List[String]): Boolean =
+    accept match
+      case None => true
+      case Some(a) =>
+        val lower = a.toLowerCase
+        lower.contains("*/*") || types.exists(lower.contains)
+
+  /** True when a parseable `Content-Length` declares more bytes than `maxRequestBodyBytes`. An
+    * absent or garbage header passes here — the platform byte cap and [[bodyTooLarge]] cover it.
+    */
+  def declaredLengthExceeds(contentLength: Option[String], settings: McpServerSettings): Boolean =
+    contentLength.flatMap(_.trim.toLongOption).exists(_ > settings.maxRequestBodyBytes.toLong)
+
+  /** Post-read heuristic on the decoded text: UTF-16 code units <= UTF-8 bytes, so `body.length >
+    * limit` implies the byte length exceeded the limit (never a false positive; may miss a
+    * multi-byte body just over the cap — the platform byte checks cover that).
+    */
+  def bodyTooLarge(body: String, settings: McpServerSettings): Boolean =
+    body.length > settings.maxRequestBodyBytes
+
+  def bodyTooLargeRejection(settings: McpServerSettings): Rejection =
+    Rejection(413, s"Request body exceeds ${settings.maxRequestBodyBytes} bytes")
+
+  /** Legacy session-store admission: true when the store is at (or beyond) `maxSessions`. */
+  def capReached(storeSize: Int, settings: McpServerSettings): Boolean =
+    settings.maxSessions.exists(storeSize >= _)
+
+  /** Victim for cap eviction: the longest-idle session WITHOUT a live GET. Tuples are `(sessionId,
+    * lastSeenMillis, hasActiveGet)`. `None` → nothing evictable → 503.
+    */
+  def pickEvictable(snapshot: Iterable[(String, Long, Boolean)]): Option[String] =
+    snapshot.filterNot(_._3).minByOption(_._2).map(_._1)

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/HttpTransportBackend.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/transport/HttpTransportBackend.scala
@@ -16,6 +16,20 @@ import com.tjclp.fastmcp.server.router.McpRouter
   * Each platform supplies exactly one given: [[JvmHttpBackend]] (ZIO HTTP / Netty) and the JS
   * backend (`Bun.serve`). Like [[TransportBackend]], implementations take the fully-built
   * [[McpRouter]] and run forever (until interrupted).
+  *
+  * Hardening contract every implementation must honour (the decisions live in the shared, pure
+  * [[HttpRequestGuards]] / [[HostGuard]]; backends only render the verdicts):
+  *   - run `HttpRequestGuards.validateSettings(settings)` before binding and fail startup on
+  *     `Left`;
+  *   - bound the request body at `settings.maxRequestBodyBytes` in the platform server AND apply
+  *     `postGate` (403 → 415 → 413 → 406) before reading the body or touching session state, then
+  *     `bodyTooLarge` before `MessageLoop.parseFrame`;
+  *   - `hostGate` on GET/DELETE;
+  *   - admit legacy `initialize` through `capReached` / `pickEvictable` (evict the longest-idle
+  *     session without a live GET, else 503 `SessionLimitMessage`);
+  *   - run the idle-session sweeper for the listener's whole lifetime on every start entry;
+  *   - wrap each handler in a Cause → JSON-RPC 500 (`InternalErrorMessage`) boundary that logs the
+  *     cause server-side only and never renders exception text, traces or paths to the client.
   */
 trait HttpTransportBackend:
 


### PR DESCRIPTION
## Summary

Hardens the HTTP transports on both platforms (JVM `JvmHttpBackend`, Bun `JsTransportBackend`) against the browser-driven and unauthenticated-client attacks found by the 2026-09-04 security scan: `HostGuard` reduced `Origin` to a port-stripped hostname, so any page on another loopback port could drive a guarded server; every legacy POST accepted any media type (CORS-simple `text/plain` requests, no preflight); the Bun listener had no body cap (Bun's 128 MiB default) and no error boundary (Bun's development-mode HTML error page rendered exception text, ZIO traces and the on-disk `main.js` path to the client); and `startStatefulHttp()` ran the legacy session store with no idle sweeper or cap, so header-less `initialize` POSTs grew the heap forever.

This PR introduces a shared, ordered request-gate chain (`403 → 415 → 413 → 406`) applied by both backends before a body is read or a session is minted, a fail-closed full-origin `HostGuard` with a new `allowedOrigins` list, `maxRequestBodyBytes` (1 MiB) and `maxSessions` (1000) settings, a first-party JSON-RPC 500 boundary around every route on both platforms, and a single sweeper-backed funnel (`startBun`) for every Bun entry.

Part 5/6 of the TJC-2294 security stack; base: `tjc-2295-core-input-limits`. Linear: TJC-2296.

## Findings addressed

| Finding | Severity | CWE | Title | Status |
|---|---|---|---|---|
| F1 | HIGH | CWE-407 | Bun HTTP: hash-colliding JSON keys make HashMap construction quadratic | Criterion 2 (body limit on both backends) fixed in this PR; criterion 1 (per-object field cap / linear envelope decode) fixed in #90; the `maxRequestBodyBytes <= limits.maxFrameChars` startup check is wired in #92 |
| F5 | MEDIUM | CWE-346 | HostGuard strips Origin port, so any localhost-origin page bypasses the guard for legacy POSTs | Fixed |
| F10 | LOW | CWE-209 | Bun fetch handler has no error boundary; crafted `Mcp-Name` header returns Bun's debug error page | Fixed |
| F12 | LOW | CWE-770 | Public `startStatefulHttp`/`startBun` run the session store with no idle eviction | Fixed |

## What changed

**Shared (`fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/`)**

- `McpServerSettings.scala:125-146` — `allowedHosts` doc rewritten for the new Origin semantics; three new fields directly after it:
  - `allowedOrigins: Option[Set[String]] = None` — explicit browser origins admitted alongside the request's own authority; unparseable entries fail `runHttp()` at startup.
  - `maxRequestBodyBytes: Int = 1024 * 1024` — request body cap on every backend (JVM was implicitly ~100 KiB via zio-http's aggregator; Bun was 128 MiB). Must be > 0.
  - `maxSessions: Option[Int] = Some(1000)` — cap on stored legacy streamable sessions; `None` disables.
- `transport/HostGuard.scala` (rewrite) — `Origin` is parsed fail-closed as `scheme://host[:port]` (default port per scheme; `null`/empty/non-http(s)/userinfo/path/bad port → refused) and admitted only when listed in `allowedOrigins` or its hostname is in `allowedHosts` AND its `host:port` equals the request `Host` authority. A `Host` with a malformed port refuses every Origin. New `isAllowed(host, origin, settings)` overload (`:62`); the 3-arg `isAllowed(host, origin, allowed)` is `@deprecated` since `1.0.0-RC4` (`:74-78`); `private[fastmcp]` 4-arg core, `parseOrigin`, `invalidOrigins`. `Host` matching is unchanged (hostname, port stripped, verbatim `host:port` also matches). Full truth table in the scaladoc.
- `transport/HttpRequestGuards.scala` (NEW) — the platform-neutral gate chain: `validateSettings` (`:32`), `hostGate` → 403 (`:47`), `postGate` 403 → 415 → 413 → 406 on headers only (`:56`), `isJsonContentType` (RFC 9110 media-type match, parameters allowed, charset must be utf-8; `:77`), `acceptsAny`, `declaredLengthExceeds` (`:103`), `bodyTooLarge` / `bodyTooLargeRejection` → `413 "Request body exceeds N bytes"` (`:110-114`), `capReached` (`:117`), `pickEvictable` (`:123`), `SessionLimitMessage = "Session limit reached; retry later"` (503). Rejections carry JSON-RPC `-32000` bodies; the host refusal message stays `Host/Origin not allowed (DNS-rebinding protection)`.
- `transport/HttpHeaderValidation.scala:192-202` — `decodeHeaderValue` checks `value.length <= EncodedPrefix.length + EncodedSuffix.length` before any `substring`; `=?base64?=` / `=?base64??=` now yield `-32020 Malformed Base64 header sentinel` instead of throwing `StringIndexOutOfBoundsException`.
- `transport/HttpTransportBackend.scala:25` — scaladoc: the hardening contract every backend must honour.

**JVM (`fast-mcp-scala/jvm/src/.../transport/JvmHttpBackend.scala`)**

- `serveHttp` validates settings before binding (`:39`) and builds the routes on `Ref.Synchronized[Map[String, Session]]` (`:47`); zio-http server config uses `.disableRequestStreaming(settings.maxRequestBodyBytes)` (`:144`) so netty's aggregator caps bodies at the operator's value.
- `guarded[R](effect: => URIO[R, Response])` (`:179`) — by-name, `ZIO.suspendSucceed(effect).catchSomeCause` (non-interrupt causes → fixed JSON-RPC 500 `Internal server error`); wraps every route handler.
- `postHeaderError` (`:681`, delegates to `HttpRequestGuards.postGate`) runs before `request.body.asString` and before `Session.make` on both the stateless (`:198`) and streamable (`:275`) POST paths; post-read `bodyTooLarge` → 413 before `parseFrame` (`:213`, `:290`). GET/DELETE run `hostError` (`:591`, `:637`).
- `mintSession` (`:329-360`) — cap check, idle/live snapshot, victim choice and insert inside ONE `store.modifyZIO`; the longest-idle session without a live GET is evicted, 503 only when every stored session holds a live GET.

**Bun (`fast-mcp-scala/js/src/...`)**

- `transport/JsTransportBackend.scala`:
  - `serveOptions` (`:157-173`) — the single `Bun.serve` options seam: `fetch` wrapped in `guarded`, `maxRequestBodySize = settings.maxRequestBodyBytes`, `development = false`, `error = bunErrorHandler` (`:151`, fixed JSON-RPC 500).
  - `guarded` (`:182`) — `ZIO.suspendSucceed(effect).catchAllCause`: Bun's `maxRequestBodySize` abort → 413, other typed failures → 400 `Body read error`, defects → 500; the cause goes only to `ZIO.logWarningCause`.
  - `startBun` is now `private[fastmcp]` (`:216-231`) and the sole funnel: validates settings (throws `IllegalArgumentException`), starts `Bun.serve`, forks `evictIdleSessions` for the listener's lifetime, returns a `BunHttpHandle`.
  - `evictIdleSessions` (`:126-146`) rewritten as `(sweep.catchAllCause(log) *> ZIO.sleep(interval)).forever` — the previous `repeat(Schedule.spaced)` died after its first tick on Scala.js (`ZoneRulesException`, no tzdb), so `sessionIdleTimeout` never actually evicted on Bun, including under `runHttp()`.
  - `handleFetch` (`:246`) — `postHeaderError` for POST, `hostGate` otherwise, before `readBody` / `mintSession`; post-read `bodyTooLarge` → 413 (`:266`, `:300`); `mintSession` (`:363`) applies `capReached` / `pickEvictable` / 503.
  - New `final class BunHttpHandle` (`:682`; `server`, `port`, `hostname`, `url`, `stop()` — stops the sweeper then the listener). `startStatelessHttp()` / `startStatefulHttp()` (`:699-702`) return it.
  - `clientKey` is computed on both backends (`clientKeyOf`) but not yet passed to `Session.make` — marked `TODO(TJC-2294 merge)` (JVM `:493-496`, Bun `:525-527`).
- `facades/runtime/Bun.scala:36-58` — `BunServeOptions` gains `maxRequestBodySize`, `development`, `error`; `fetch` becomes `js.Function2[Request, Server, Promise[Response]]`.
- `examples/conformance/ConformanceServerJs.scala` — doc comment only: `startStatefulHttp()` now runs the sweeper, `maxSessions` and every gate.

## Behaviour changes (pre-1.0)

- **415 on non-JSON POSTs.** Every POST to the MCP endpoint — legacy and modern — must carry `Content-Type: application/json` (parameters such as `charset=utf-8` allowed; `application/json-patch+json`, `text/plain`, absent → 415 `Content-Type must be application/json`). Test helpers and clients that omitted the header must add it. Gate order is 403 → 415 → 413 → 406.
- **Origin is a full origin.** With `allowedHosts` set, `Origin: http://localhost:3000`, `https://localhost`, `http://127.0.0.1:1`, `null` and any origin with a malformed port are refused 403 against a server on `:8000`; same-authority origins and requests without `Origin` still pass. A `Host` with a malformed port refuses every Origin. Front-ends served from another origin need the new `allowedOrigins`. Unparseable `allowedOrigins` entries fail `runHttp()` / `startStatefulHttp()` at startup.
- **413 body cap on both backends**, default 1 MiB (`maxRequestBodyBytes`). The JVM default rises from zio-http's implicit ~100 KiB; Bun drops from 128 MiB. Over TCP, netty and Bun answer an empty 413 when they cut the body themselves; first-party paths (declared `Content-Length`, post-read check) answer a JSON-RPC `-32000` 413.
- **`maxSessions` cap**, default `Some(1000)`, on the legacy streamable store on both platforms: at the cap the longest-idle session without a live GET is evicted (its queue shut down); 503 `Session limit reached; retry later` only when nothing is evictable. `None` restores the old unbounded behaviour.
- **Bun error responses.** `Bun.serve` runs with `development: false`, an `error` callback and a `catchAllCause` boundary; failures and defects answer a fixed JSON-RPC 400/413/500 regardless of `NODE_ENV`. The JVM answers the same fixed JSON-RPC 500 for non-interrupt defects (previously zio-http's bare 500). Tool-handler defects are unchanged: the router still answers them in-band as `-32603` with the handler's message.
- **`=?base64?=`-shaped headers** return `-32020 Malformed Base64 header sentinel` (HTTP 400) instead of a 500 / debug page.
- **Bun API (source-breaking):** `startStatefulHttp()` / `startStatelessHttp()` now return `BunHttpHandle` (call `.stop()`) instead of the raw Bun server; `startBun` is `private[fastmcp]`; `BunServeOptions.apply` grew from 3 to 6 required parameters and `fetch` is arity-2. `sessionIdleTimeout` now actually evicts on Bun (the sweeper used to die after one tick).
- **`HostGuard.isAllowed(host, origin, allowed: Set[String])`** is deprecated in favour of the `McpServerSettings` overload; it keeps Host semantics and full-origin matching but cannot see `allowedOrigins`.

## Fix criteria -> evidence

File paths are relative to `fast-mcp-scala/`; line numbers are on this branch.

**F1 §2 — explicit, operator-configurable body limit on BOTH backends (100 KiB–1 MiB default), 413 before parsing**
- Code: `shared/src/.../server/McpServerSettings.scala:140` (`maxRequestBodyBytes = 1024 * 1024`); `jvm/src/.../transport/JvmHttpBackend.scala:144` (`disableRequestStreaming`), `:213`/`:290` (`bodyTooLarge` before `parseFrame`); `js/src/.../transport/JsTransportBackend.scala:171` (`maxRequestBodySize`), `:187-189` (Bun abort → 413), `:266`/`:300`; `shared/src/.../transport/HttpRequestGuards.scala:103-114`.
- Tests: `JvmHttpTransportTest` "413 when the declared Content-Length exceeds maxRequestBodyBytes (before the body is read)" and "413 for an oversized NON-JSON body: the cap fires before parseFrame (not -32700)" (both routes); `JsServerHttpTest` "maxRequestBodyBytes on Bun should answer 413 for a declared oversize body and never 200/500 for a streamed one", plus fake-request rows in "Bun.serve options ..." (content-length 9999 → JSON 413, 5000-char body → JSON 413); `HttpRequestGuardsTest` `declaredLengthExceeds` / `bodyTooLarge` rows.
- F1 §1 (linear-time processing of colliding keys) is owned by #90 (`JsonLimits` pre-scan, `JsonFields` envelope decode, `maxObjectFields`); this PR's cap bounds N in the meantime. The `maxRequestBodyBytes <= limits.maxFrameChars` check in `validateSettings` is anchored by the `TODO(TJC-2294 merge)` at `HttpRequestGuards.scala:41` and lands in #92.

**F5 §1 — Origin matched as a full origin against the server's own origin or an explicit list, never by port-stripped hostname; route-level tests on both platforms**
- Code: `shared/src/.../transport/HostGuard.scala:62` (settings overload), `:84-95` (core), `:106` (`parseOrigin`, fail-closed), `:130` (`originAllowed`), `:150` (`sameAuthority`, malformed Host port → false); `McpServerSettings.scala:134` (`allowedOrigins`); `HttpRequestGuards.scala:32-49` (`validateSettings`, `hostGate`); JVM `JvmHttpBackend.scala:39`, `:591`, `:637`, `:669`; Bun `JsTransportBackend.scala:223`, `:246`, `:620`.
- Tests: `HostGuardTest` (23) — "cross-port localhost origins are refused (the F5 bypass)", "cross-scheme default port is refused", "null and empty origins are refused", "invalid explicit ports ... (fail-closed)", "malformed origins and non-http schemes are refused", "a Host with a malformed port is fail-closed", "explicit allowedOrigins entries win ..."; `JvmHttpTransportTest` "Origin route table: cross-port / cross-scheme / null / foreign origins are 403, same authority 200", "allowedOrigins admits an explicitly listed origin ...", "serveHttp refuses to start on an unparseable allowedOrigins entry"; `JsServerHttpTest` "HostGuard on Bun should match Origin as a full origin: cross-port/scheme/null are 403, same authority 200", "admit an explicitly listed allowedOrigins entry", "refuse to start on an unparseable allowedOrigins entry", "reject a foreign Origin with 403 when allowedHosts is set"; `ConformanceGapsTest` "HostGuard matches Origin as a full origin ...". Official conformance `dns-rebinding-protection` 2/2 on both platforms.

**F5 §2 — every POST (legacy and modern) rejected 415 before the body is read or a session minted unless `Content-Type: application/json`**
- Code: `HttpRequestGuards.scala:56-77` (`postGate`, `isJsonContentType`); JVM `JvmHttpBackend.scala:198` / `:275` (`postHeaderError` before `request.body.asString` and `Session.make`), `:681-690`; Bun `JsTransportBackend.scala:246` (before `readBody` / `mintSession`), `:631`. The gate is method-agnostic, so modern 2026-07-28 POSTs are covered too.
- Tests: `HttpRequestGuardsTest` "postGate: 415 comes before 413 and 406", "isJsonContentType ..." (2 matrices); `JvmHttpTransportTest` "415 for a legacy POST with text/plain or no Content-Type, on stateless and streamable, no session minted" (also asserts a guessed session id is 404 afterwards) and "application/json with a charset parameter is accepted; JSON-ish other types are not"; `JsServerHttpTest` "reject a text/plain legacy POST with 415 and no session header (stateless)", "reject a Content-Type-less Blob legacy tools/call with 415 (stateless)", "accept application/json with a charset parameter", "runHttp (streamable gates) should 415 a text/plain or Blob initialize and mint nothing".

**F10 §1 — every failure or defect inside the Bun fetch handler converted by first-party code into a JSON-RPC 400/500 with no exception text, trace or path, independent of `NODE_ENV`**
- Code: `js/src/.../transport/JsTransportBackend.scala:151` (`bunErrorHandler`), `:157-173` (`serveOptions`: `development = false`, `error`, `guarded(...)`), `:182-189` (`guarded`: `ZIO.suspendSucceed(...).catchAllCause`), `:226` (the only `Bun.serve` call site); `js/src/.../facades/runtime/Bun.scala:36-58`. JVM parity: `JvmHttpBackend.scala:179` (`guarded`, by-name, `catchSomeCause` non-interrupt → JSON 500).
- Tests: `JsServerHttpTest` "Bun.serve options should run with development=false, an error callback and the body cap (NODE_ENV-independent)" (asserts `development == false`, error callback → JSON 500 without the message, synchronous `new URL("not a url")` throw → JSON 500 with no `Exception`/stack/URL text, rejecting `text()` → JSON 400), "answer `Mcp-Name: =?base64?=` with a small JSON -32020, never a trace or a debug page", "a dying tool on Bun should be answered in-band as JSON (router boundary), never a raw 500 or HTML"; `JvmHttpTransportTest` "guarded: a defect becomes a JSON-RPC 500 with a fixed message; interrupts pass through", "a tool that dies is answered in-band by the router (JSON -32603), never a raw 500 or HTML".

**F10 §2 — a sentinel-shaped header shorter than prefix+suffix, or otherwise malformed, yields `Malformed Base64 header sentinel` (HTTP 400) on JVM and Bun; tests for `=?base64?=` and `=?base64??=`**
- Code: `shared/src/.../transport/HttpHeaderValidation.scala:192-202` (length check before `substring`; decode stays inside `Try`).
- Tests: `HttpHeaderValidationTest` (5) — "`=?base64?=` (prefix and suffix overlapping) is a malformed sentinel, not an exception", "`=?base64??=` (empty payload) is a malformed sentinel", "`=?base64?!!?=` (invalid Base64 payload) is a malformed sentinel", plus valid-sentinel and plain-value rows; `JsServerHttpTest` end-to-end for both values on Bun (above).

**F12 — every public entry serving the stateful adapter honours `sessionIdleTimeout` (or an equivalent bound) for the listener's lifetime; `startStatefulHttp()` drops idle sessions; a flood of header-less `initialize` POSTs does not grow the store without bound**
- Code: `JsTransportBackend.scala:216-231` (`startBun` `private[fastmcp]`, forks `evictIdleSessions`, returns `BunHttpHandle`), `:126-146` (sweeper loop fix), `:363-398` (`mintSession` cap/evict/503), `:682-702` (`BunHttpHandle`, `startStatelessHttp`/`startStatefulHttp` → `startHttpHandle` → `startBun`); `McpServerSettings.scala:146` (`maxSessions`); `HttpRequestGuards.scala:117-123`; JVM `JvmHttpBackend.scala:329-360` (`mintSession` in one `modifyZIO`).
- Tests: `JsServerHttpTest` "evictIdleSessions on Bun should drop an idle session from the dictionary when forked via unsafe.fork", "startStatefulHttp should run the idle-session sweeper: a session idle past sessionIdleTimeout 404s" (200 ms timeout; eviction necessarily happens on tick ≥ 2, pinning the `Schedule.spaced` regression), "maxSessions on Bun should evict the longest-idle session at the cap instead of growing the store"; `JvmHttpTransportTest` "maxSessions: at the cap the longest-idle session without a live GET is evicted, not the newcomer", "maxSessions: 503 only when every stored session holds a live GET stream", "maxSessions: concurrent header-less initializes at the cap all admit while idle sessions exist" (16-way race, exactly 2 survivors, no spurious 503), "maxSessions = None disables the cap"; `HttpRequestGuardsTest` `capReached` / `pickEvictable` rows.

## Tests

- `jvm/test/.../transport/HostGuardTest.scala` (NEW, 23) — full Origin truth table incl. cross-port/scheme, null, invalid and malformed ports/origins, IPv6 brackets, port-less Host, malformed Host port, `allowedOrigins`, deprecated overload, `parseOrigin` / `invalidOrigins`.
- `jvm/test/.../transport/HttpRequestGuardsTest.scala` (NEW, 15) — gate ordering, `isJsonContentType` matrices, `acceptsAny`, `declaredLengthExceeds`, `bodyTooLarge`, `capReached`, `pickEvictable`, `validateSettings` accept/reject rows.
- `jvm/test/.../transport/HttpHeaderValidationTest.scala` (NEW, 5) — malformed sentinels → `-32020`, valid sentinel decodes, plain values.
- `jvm/test/.../transport/JvmHttpTransportTest.scala` (38 total, 13 new) — Origin route table, `allowedOrigins`, startup refusal, 415 rows, 413 rows, four `maxSessions` rows, `guarded` unit test, dying-tool in-band; the `post` helper now sends `Content-Type` + `Accept`.
- `jvm/test/.../server/ConformanceGapsTest.scala` — HostGuard assertions moved to the settings overload; new full-origin refusal row and `allowedOrigins` acceptance.
- `js/test/.../conformance/JsServerHttpTest.scala` (16 new) — 415 rows, charset, `=?base64?=` / `=?base64??=` end-to-end, `serveOptions` seam (development=false, error callback, fake-request 413/400/500 rows), dying tool in-band, body cap on Bun, Origin table + `allowedOrigins` + startup refusal on Bun, streamable 415 mints nothing, sweeper via `unsafe.fork`, `startStatefulHttp` idle eviction, `maxSessions=2` on Bun. Binds fixed ports 38917–38931.

## Verification

Run on the arc worktree (these six commits on `main @ 906e694`), as recorded in the implementation report:

- `rm -rf out/fast-mcp-scala && ./mill fast-mcp-scala.compile` — 168/168 SUCCESS (JVM + Scala.js + Scala Native); warning counts unchanged, none in files touched here.
- `./mill fast-mcp-scala.reformat && ./mill fast-mcp-scala.checkFormat` — "Everything is formatted already".
- `./mill fast-mcp-scala.jvm.test.testOnly HostGuardTest JvmHttpTransportTest ConformanceGapsTest HttpRequestGuardsTest` — 23 + 38 + 9 + 15, all passed.
- `./mill fast-mcp-scala.test` — js 57/57, scalaNative 8/8, every JVM suite green EXCEPT `TaskHttpTransportTest` (15) and `LifecycleSoakTest` (1), whose legacy `post` helpers sent no `Content-Type` in that worktree and received 415. On this stacked branch those helpers already carry `content-type: application/json` (from #89 below it, `TaskHttpTransportTest.scala:123,172`), and the stack tip is verified green (532/532 Mill test tasks).
- `scripts/conformance.sh jvm` — 73 passed, 0 failed, baseline check passed with the EMPTY baseline (`dns-rebinding-protection` 2/2).
- `scripts/conformance.sh js` — 73 passed, 0 failed, baseline check passed with the EMPTY baseline.

Independent per-finding verification on the integrated tree (#92) additionally reproduced each finding live against real JVM and Bun listeners: `Origin: http://localhost:3000` + `text/plain` → 403; `text/plain` / no `Content-Type` → 415 with no session minted; the finding's exact `Mcp-Name: =?base64?=` request on Bun 1.4.1 with `NODE_ENV` unset → 93-byte JSON `-32020` (a mechanism probe confirmed Bun's default would have returned a ~50 KB HTML page); 1300 header-less initializes against the shipped `ConformanceServerJs` entry held the store at exactly 1000 with ~2 MiB heap growth on a second flood. No CI results are claimed here.

## Residual risk / follow-ups

- **Deferred to #92** (cross-arc symbols this branch cannot see): pass `clientKey` to `Session.make` (both backends, `TODO(TJC-2294 merge)`); replace `outbound.shutdown` with `Session.terminate` at eviction / DELETE / cap-eviction sites (JVM `:76,357,360,648`; Bun `:141,344,395,398`); add the `maxRequestBodyBytes <= limits.maxFrameChars` row to `validateSettings`; docs (CHANGELOG Security entries incl. the `BunServeOptions` break and the session-cap trade-off, README settings rows, `docs/transports.md`, `docs/platforms.md`, `SECURITY.md`, CLAUDE.md Transports bullet, 73-check conformance figure).
- **Session-cap trade-off (accepted):** at the cap an unauthenticated flood of header-less initializes evicts every legitimate legacy session not holding a live GET — on Bun (no GET channel) that is every session. Memory is bounded as F12 requires; non-loopback deployments should set `allowedHosts`/`allowedOrigins` and sit behind an authenticating proxy. Follow-up idea: key the cap per client address once `Session.clientKey` lands. Operators who set both `sessionIdleTimeout = None` and `maxSessions = None` re-open unbounded growth by choice.
- **Bun mint is not strictly atomic** (verifier minor): the idle/live snapshot and `Session.make` are separate ZIO steps from the admit/evict block, so an interleaving mint can yield a spurious 503 — never an over-cap store. Not observed in a 60-way burst; the JVM twin is atomic (`Ref.Synchronized.modifyZIO`).
- **Guard scope:** `allowedHosts`/`allowedOrigins` remain opt-in; a non-browser client that omits `Origin` and sends `Content-Type: application/json` is not authenticated by the guard (browser CSRF / DNS-rebinding path only). A port-less `Host` (listener on 80/443) admits both `http://h` and `https://h`; the same-authority rule deliberately does not compare scheme (TLS-terminating proxies) — use `allowedOrigins` for a stricter policy.
- **Platform parity nits (verifier minors, not bypasses):** Bun answers 500 instead of 403 for a malformed `Host` port (`new URL(req.url)` throws inside `guarded` before `hostGate`); the JVM reads only the first of duplicate `Origin` headers while Bun joins and refuses — browsers emit neither. Bun's over-cap abort is recognised by a `getMessage.contains("maxRequestBodySize")` substring (degrades safely to the fixed 400). `guarded` on Bun labels every non-cap typed failure `400 Body read error` (today `readBody` is the only typed-failure producer).
- **Empty 413 over TCP:** when netty or Bun cut an over-cap body themselves the 413 has no body; only first-party paths emit the JSON-RPC `-32000` body. Docs must not promise a JSON body over TCP.
- **Unchanged / out of scope:** tool-handler defects are still answered in-band by the router as `-32603` WITH the handler's message (separate, previously rejected record); the JVM stateless 400 still forwards netty's body-read error message; `ModernHttpValidation.contentTypeOk` keeps its lenient `contains("application/json")` (harmless — `postGate` runs first); the Bun stdio bridge has no `catchAllCause` (availability hygiene only).
- **Housekeeping:** the shipped `ConformanceServer` example lists `"0.0.0.0"` in `allowedHosts` (needless allow entry, not a rebinding vector) — drop or comment it in the docs step; `JsServerHttpTest` binds fixed ports 38917–38931, other Bun suites must start at ≥ 38932 (a shared port-allocator helper would be a good follow-up). If PR #84's `StreamableHttpHandler` lands later, re-point its gates to `HttpRequestGuards`, add `bodyTooLarge` before both `parseFrame` calls, adopt the `Ref.Synchronized` mint, call `validateSettings` in `make`, thread `maxRequestBodyBytes` into `SocketHttpServer.start` and wrap its routes in the by-name `guarded`.

## Stack & merge order

| # | PR | Branch | Base | Scope |
|---|---|---|---|---|
| 1/6 | #87 | `tjc-2299-ci-supply-chain` | `main` | TJC-2299 — CI supply chain (F6, F7) |
| 2/6 | #88 | `tjc-2298-macro-overload-binding` | `tjc-2299-ci-supply-chain` | TJC-2298 — macros (F4) |
| 3/6 | #89 | `tjc-2297-tasks-hardening` | `tjc-2298-macro-overload-binding` | TJC-2297 — tasks (F8, F9, F11) |
| 4/6 | #90 | `tjc-2295-core-input-limits` | `tjc-2297-tasks-hardening` | TJC-2295 — core input limits (F1, F2, F3) |
| **5/6** | **#91 (this PR)** | `tjc-2296-http-transport-hardening` | `tjc-2295-core-input-limits` | TJC-2296 — HTTP transports (F1, F5, F10, F12) |
| 6/6 | #92 | `tjc-2294-security-hardening` | `tjc-2296-http-transport-hardening` | TJC-2294 — cross-arc integration + docs |

Review and merge bottom-up. Merge each PR with a **merge commit, not squash** — squashing the bottom of a stack orphans the PRs above it (see TJC-2114). After each merge, retarget the next PR to `main` (GitHub does this automatically when the merged base branch is deleted). The stack tip (#92) is byte-identical to a fully verified integrated tree: 532/532 Mill test tasks incl. JVM, Bun and Scala Native suites; official MCP conformance 73/73 checks on both JVM and Bun with empty baselines; scalafmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
