### PR TITLE
docs(examples): modern-era HTTP scaladoc, loopback HttpServerJs, conformance and logger comment fixes (TJC-2330)

### DIFF
--- a/conformance/baseline-js.yml
+++ b/conformance/baseline-js.yml
@@ -2,6 +2,6 @@
 #
 # The Bun streamable transport streams every server->client message (progress, sampling,
 # elicitation, logging) on each request's own POST SSE response — identical semantics to the JVM
-# transport, reusing the shared Session/router logic. JS passes the entire active suite. No expected
-# failures.
+# transport, reusing the shared Session/router logic. JS passes the entire active suite across both
+# protocol eras (2026-07-28 and the 2025-11-25-and-earlier legacy adapter). No expected failures.
 server: []

--- a/conformance/baseline-jvm.yml
+++ b/conformance/baseline-jvm.yml
@@ -1,6 +1,7 @@
 # MCP conformance expected-failures baseline — JVM (streamable HTTP).
 #
-# The JVM transport passes the ENTIRE active server suite (spec 2025-11-25), including the
-# server->client scenarios (sampling / elicitation / progress / logging) which stream on each
-# request's own SSE response. No expected failures.
+# The JVM transport passes the ENTIRE active server suite — both protocol eras, 2026-07-28 and the
+# 2025-11-25-and-earlier legacy adapter — including the server->client scenarios (sampling /
+# elicitation / progress / logging) which stream on each request's own SSE response. No expected
+# failures.
 server: []

--- a/fast-mcp-scala/js/src/com/tjclp/fastmcp/examples/HttpServerJs.scala
+++ b/fast-mcp-scala/js/src/com/tjclp/fastmcp/examples/HttpServerJs.scala
@@ -11,11 +11,10 @@ import com.tjclp.fastmcp.{*, given}
   * `settings` for host / port / endpoint / statelessness. The typed contract below shows explicit
   * JSON Schema input via `McpTool.withSchema` — mount it in `override val tools`.
   *
-  * Bundle and run:
-  * {{{
-  *   ./mill fast-mcp-scala.js.fullLinkJS
-  *   bun run out/fast-mcp-scala/js/fullLinkJS.dest/main.js
-  * }}}
+  * The js module's linked bundle (`./mill fast-mcp-scala.js.fastLinkJS`) has no module initializer
+  * and exports only the conformance server's `startConformance`, so `bun run` on it starts nothing
+  * (runnable example entry points are on the roadmap). Run this object on Bun with the scala-cli
+  * recipe in `docs/platforms.md` (Scala.js / Bun), or link it from your own project.
   */
 object HttpServerJs extends McpServerApp[Http, HttpServerJs.type]:
 
@@ -36,7 +35,7 @@ object HttpServerJs extends McpServerApp[Http, HttpServerJs.type]:
   )(args => GreetResult(s"Hello, ${args.name}!"))
 
   override def settings: McpServerSettings = McpServerSettings(
-    host = "0.0.0.0",
+    host = "127.0.0.1", // bind loopback unless you set allowedHosts
     port = 8090,
     httpEndpoint = "/mcp",
     stateless = false

--- a/fast-mcp-scala/js/src/com/tjclp/fastmcp/server/transport/JsTransportBackend.scala
+++ b/fast-mcp-scala/js/src/com/tjclp/fastmcp/server/transport/JsTransportBackend.scala
@@ -91,7 +91,9 @@ object JsTransportBackend extends TransportBackend with HttpTransportBackend:
               case None => ZIO.unit
             }
             // Never surface a defect as an unhandled promise rejection — Bun terminates the whole
-            // process on those. The cause goes to stderr (the log); the client gets no frame.
+            // process on those. The cause goes to the ZIO logger — with ZIO's default Scala.js
+            // logger a warning is printed via `console.log`, i.e. to stdout, unless the app installs
+            // a stderr logger in `bootstrap` — and the client gets no frame.
             .catchAllCause(cause => ZIO.logWarningCause("stdio dispatch failed", cause))
         )
     stdin.on(

--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/examples/HttpServer.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/examples/HttpServer.scala
@@ -5,29 +5,66 @@ import com.tjclp.fastmcp.*
 
 /** MCP server over HTTP — transport is a phantom type parameter on `McpServerApp`.
   *
-  * `runHttp()` (dispatched by `McpServerApp[Http, ...]`) serves the full MCP Streamable HTTP spec —
-  * `POST /mcp` for JSON-RPC, session tracking via the `mcp-session-id` header, and SSE streams for
-  * long-running calls. Flip `stateless = true` on the settings for a sessionless, SSE-free
-  * transport.
+  * `runHttp()` (dispatched by `McpServerApp[Http, ...]`) serves MCP 2026-07-28 Streamable HTTP:
+  * one stateless JSON-RPC message per `POST /mcp`, answered with plain JSON or a request-scoped SSE
+  * stream — no protocol sessions, standalone GET stream, or DELETE on the modern path. Requests
+  * that speak an older revision (2025-11-25 and earlier) are routed to the legacy initialize /
+  * session / GET / DELETE adapter, which is on by default. `stateless = true` disables only that
+  * adapter's session store (legacy replies then come back as plain JSON); modern requests are
+  * unaffected. Every POST, on either path, must carry `Content-Type: application/json` — anything
+  * else is refused with 415 before the body is read.
   *
   * Start with: `./mill fast-mcp-scala.jvm.runMain com.tjclp.fastmcp.examples.HttpServer`
   *
-  * Then exercise via curl:
+  * Modern requests (2026-07-28): one self-contained POST each, no session. Header set:
+  * `MCP-Protocol-Version: 2026-07-28`, `Mcp-Method` (plus `Mcp-Name` for `tools/call`,
+  * `resources/read` and `prompts/get`), `Accept: application/json, text/event-stream` (both media
+  * types) and `Content-Type: application/json`; the body repeats the version and the client
+  * capabilities under `params._meta`:
   * {{{
-  *   # 1. Initialize (streamable mode returns an `mcp-session-id` response header)
+  *   # 1. Discover capabilities and supported protocol versions
+  *   curl -s -X POST http://localhost:8090/mcp \
+  *     -H "Content-Type: application/json" \
+  *     -H "Accept: application/json, text/event-stream" \
+  *     -H "MCP-Protocol-Version: 2026-07-28" \
+  *     -H "Mcp-Method: server/discover" \
+  *     -d '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}'
+  *
+  *   # 2. Call a tool (the reply arrives as JSON or as an SSE `event: message` frame)
+  *   curl -s -N -X POST http://localhost:8090/mcp \
+  *     -H "Content-Type: application/json" \
+  *     -H "Accept: application/json, text/event-stream" \
+  *     -H "MCP-Protocol-Version: 2026-07-28" \
+  *     -H "Mcp-Method: tools/call" \
+  *     -H "Mcp-Name: greet" \
+  *     -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"greet","arguments":{"name":"World"},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}'
+  *
+  *   # 3. Wrong media type: refused with 415 before the body is read, on either protocol path
+  *   curl -s -i -X POST http://localhost:8090/mcp \
+  *     -H "Content-Type: text/plain" \
+  *     -H "Accept: application/json, text/event-stream" \
+  *     -d '{"jsonrpc":"2.0","id":3,"method":"ping"}'
+  *   # HTTP/1.1 415 ...
+  *   # {"jsonrpc":"2.0","id":null,"error":{"code":-32000,"message":"Content-Type must be application/json"}}
+  * }}}
+  *
+  * Legacy 2025-11-25 adapter (also serves 2025-06-18 and earlier): `initialize` mints a session,
+  * every later request carries it in `mcp-session-id`, and DELETE closes it:
+  * {{{
+  *   # 1. Initialize (the response carries an `mcp-session-id` header)
   *   curl -s -D- -X POST http://localhost:8090/mcp \
   *     -H "Content-Type: application/json" \
   *     -H "Accept: application/json, text/event-stream" \
-  *     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
+  *     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
   *
-  *   # 2. Call a tool (SSE streamed back)
+  *   # 2. Call a tool on that session (SSE-framed reply)
   *   curl -N -X POST http://localhost:8090/mcp \
   *     -H "Content-Type: application/json" \
   *     -H "Accept: application/json, text/event-stream" \
   *     -H "mcp-session-id: <id-from-step-1>" \
   *     -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"greet","arguments":{"name":"World"}}}'
   *
-  *   # 3. Close the session (streamable mode only)
+  *   # 3. Close the session (legacy adapter only)
   *   curl -X DELETE http://localhost:8090/mcp -H "mcp-session-id: <id>"
   * }}}
   */

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/examples/conformance/ConformanceServer.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/examples/conformance/ConformanceServer.scala
@@ -16,14 +16,17 @@ import com.tjclp.fastmcp.core.wire.{
 import com.tjclp.fastmcp.jsonrpc.McpError
 
 /** Cross-platform MCP "everything" server mirroring the conformance harness's reference
-  * `everything-server.ts` legacy ACTIVE surface (spec 2025-11-25). One source of truth registered
-  * identically on JVM and JS; the thin platform mains (`ConformanceServerJvm` /
-  * `ConformanceServerJs`) just build an [[McpServer]] and `runHttp()`.
+  * `everything-server.ts` ACTIVE surface across both protocol eras (2026-07-28 stateless requests
+  * and the 2025-11-25-and-earlier session adapter). One source of truth registered identically on
+  * JVM and JS; the thin platform mains (`ConformanceServerJvm` / `ConformanceServerJs`) just build
+  * an [[McpServer]] and `runHttp()`.
   *
-  * Drives the official suite via `bunx @modelcontextprotocol/conformance server --url … --suite
-  * active` (see `scripts/conformance.sh`). Both JVM and JS stream every server→client message
-  * (sampling / elicitation / progress / logging) on each request's own POST SSE response, so the
-  * full active suite passes on both transports — no baseline.
+  * `scripts/conformance.sh {jvm|js|native}` drives the official suite: it installs the harness
+  * pinned by `conformance/package.json` + `conformance/bun.lock` (`bun install --frozen-lockfile`)
+  * and execs that installed binary — never `bunx`, which would auto-install a same-named package
+  * from the registry. Both JVM and JS stream every server→client message (sampling / elicitation /
+  * progress / logging) on each request's own POST SSE response, so the full active suite passes on
+  * both transports with EMPTY expected-failure baselines (`conformance/baseline-{jvm,js}.yml`).
   */
 object ConformanceServer:
 

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServerSettings.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServerSettings.scala
@@ -91,8 +91,8 @@ case class TaskSettings(
   require(minResultRetentionMs >= 0L, "TaskSettings.minResultRetentionMs must be >= 0")
   require(sweepIntervalMs >= 1L, "TaskSettings.sweepIntervalMs must be >= 1")
 
-/** Settings for an MCP server. HTTP-specific fields (`stateless`, `keepAliveInterval`,
-  * `sessionIdleTimeout`, `disallowDelete`, `httpEndpoint`, `allowedHosts`, `allowedOrigins`,
+/** Settings for an MCP server. HTTP-specific fields (`host`, `port`, `httpEndpoint`, `stateless`,
+  * `keepAliveInterval`, `sessionIdleTimeout`, `disallowDelete`, `allowedHosts`, `allowedOrigins`,
   * `maxRequestBodyBytes`, `maxSessions`) are ignored under stdio transports. `limits` and `tasks`
   * apply on every transport.
   */

--- a/scripts/examples.sc
+++ b/scripts/examples.sc
@@ -23,4 +23,6 @@
 // scala-cli examples.sc --main-class com.tjclp.fastmcp.examples.HttpServer
 //     HTTP transport: modern stateless POST + request-scoped SSE, with the legacy session adapter on by default.
 //
-// stdout is redirected to stderr inside each server so the stdio transport stays clean.
+// Nothing redirects stdout. On the stdio transport the JSON-RPC frame stream owns stdout, so
+// anything a handler prints or logs there (ZIO's default logger included) corrupts the stream;
+// write diagnostics to stderr instead. The library's own registration warnings already go there.


### PR DESCRIPTION
## What

Docs-in-code fixes flagged by the pre-v1.0.0 dogfooding session (R1 step 7b, arc N9). No behaviour change except the `HttpServerJs` example bind address.

| File | Before | After |
|---|---|---|
| `fast-mcp-scala/jvm/src/.../examples/HttpServer.scala` scaladoc | Presented the legacy initialize/session flow as "the full Streamable HTTP spec" and `stateless = true` as an "SSE-free" transport | Describes MCP 2026-07-28 stateless requests with the full header set (`MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name`, `Accept: application/json, text/event-stream`, `Content-Type: application/json`) and the `params._meta` body; curl recipes for `server/discover` and `tools/call`; one 415 example; the original curl kept as the "legacy 2025-11-25 adapter" (initialize now sends `2025-11-25`); `stateless` described as disabling only the legacy session store |
| `fast-mcp-scala/js/src/.../examples/HttpServerJs.scala` | `host = "0.0.0.0"` without `allowedHosts`; "Bundle and run" pointed at `bun run .../main.js` | Binds `127.0.0.1` with the comment "bind loopback unless you set allowedHosts"; the run paragraph now matches `docs/platforms.md` (the linked bundle exports only `startConformance`; runnable example entry points are on the roadmap) |
| `fast-mcp-scala/shared/src/.../examples/conformance/ConformanceServer.scala` scaladoc | "legacy ACTIVE surface (spec 2025-11-25)"; "drives the official suite via `bunx ...`"; "no baseline" | The active surface spans both protocol eras; `scripts/conformance.sh` installs the lock-pinned harness with `bun install --frozen-lockfile` and execs the installed binary, never `bunx`; EMPTY expected-failure baselines |
| `conformance/baseline-jvm.yml`, `conformance/baseline-js.yml` (comments only) | "(spec 2025-11-25)" on the JVM file; no era qualifier on the JS file | Both say the active suite spans both protocol eras; the `server: []` payload is unchanged |
| `fast-mcp-scala/js/src/.../server/transport/JsTransportBackend.scala` stdio dispatch comment | "The cause goes to stderr (the log)" | ZIO's default Scala.js logger prints warnings via `console.log` (stdout) unless the app installs a stderr logger in `bootstrap`; verified against `zio_sjs1_3` 2.1.20 `RuntimePlatformSpecific.defaultLoggers` (only `Error`/`Fatal` go to `console.error`) |
| `scripts/examples.sc` launcher comment | "stdout is redirected to stderr inside each server" | Nothing redirects stdout (no `setOut` anywhere under `fast-mcp-scala/*/src`); the stdio frame stream owns stdout, write diagnostics to stderr. The HTTP example description two lines above was already accurate and is unchanged |
| `fast-mcp-scala/shared/src/.../server/McpServerSettings.scala` class scaladoc | HTTP-only field list omitted `host`/`port` | List gains `host`, `port` (decision (i), S1.4.6) |

## Why

The session's api-docs and transports maps (S1.3.5, S1.3.6, S1.4.6, S1.9.9; D3.9 rows 4 and 80 confirmed twice on a stateless server; D3 step 2 recorded the modern header set and the 415 row against this very example server) found these code comments contradicting the shipped behaviour. They are code comments and examples, so they land in their own PR before the release-prep PR (gate G10) instead of the docs-only PR B.

## Verification

| Gate | Command | Result |
|---|---|---|
| Format | `./mill --no-server fast-mcp-scala.reformat` | 16/16 SUCCESS (22 s); produced no further changes |
| Format check | `./mill --no-server fast-mcp-scala.checkFormat` | 16/16 SUCCESS (26 s) |
| Compile (JVM + Scala.js + Scala Native) | `./mill --no-server fast-mcp-scala.compile` | 168/168 SUCCESS (157 s); the only warning is the pre-existing one at `McpServerApp.scala:19` (file untouched) |
| Whitespace | `git diff --check` | clean |
| Path scrub | the session's `git grep` over tracked files for home-directory / scratch-directory paths and dogfood version literals (the `$RC` / `$PREP` / `$SCRATCH` rule) | empty |
| Curl recipes vs. behaviour | Session evidence D3 step 2 (2026-09-08) against `HttpServer` on its default port: `server/discover` and `tools/call greet` with exactly these headers and `_meta` body answered `200 text/event-stream`; `Content-Type: text/plain` answered `415` with `{"code":-32000,"message":"Content-Type must be application/json"}` | matches the scaladoc; not re-run in this PR |

No test references `HttpServerJs` or any changed comment (`grep -rn HttpServerJs fast-mcp-scala/*/test` is empty).

Linear: [TJC-2330](https://linear.app/tjc-technologies/issue/TJC-2330) (parent TJC-2326).

Merge with a MERGE COMMIT (never squash); part of the pre-v1.0.0 stack, see TJC-2326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
