### PR TITLE
build: pin netty to 4.2.17.Final over zio-http 3.4.0 (TJC-2327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,25 @@ Security-hardening wave (TJC-2294; findings F1–F12 of the 2026-09-04 scan). Um
   harness-running jobs restore the shared Mill/coursier cache read-only. `ci.yml` no longer exports
   `GITHUB_TOKEN` workflow-wide: it is scoped to the Mill steps that need it (as `native.yml`
   already did), so the third-party setup actions never see it.
+- **Netty pinned to 4.2.17.Final** (TJC-2327): zio-http 3.4.0 declares netty 4.2.3.Final, whose
+  16 modules carried 27 OSV advisories (12 HIGH / 13 MODERATE / 2 LOW), 7 of them reachable from
+  the default JVM HTTP path — CVE-2026-33870 (HIGH, request smuggling), CVE-2026-42577 (HIGH,
+  epoll DoS on every Linux JVM), CVE-2026-42585, CVE-2026-42580, CVE-2026-42581, CVE-2026-50020
+  and CVE-2025-58056 — plus 20 in code paths this library never installs (TLS, compression,
+  WebSocket, proxy, IP filtering): CVE-2025-58057, CVE-2025-67735, CVE-2026-41417,
+  CVE-2026-42578, CVE-2026-42583, CVE-2026-42584, CVE-2026-42587, CVE-2026-44249,
+  CVE-2026-45416, CVE-2026-45536, CVE-2026-50010, CVE-2026-55831, CVE-2026-55833,
+  CVE-2026-56745, CVE-2026-56746, CVE-2026-59898, CVE-2026-59899, CVE-2026-59901,
+  CVE-2026-59903, CVE-2026-59921. `build.mill` now pins `Versions.netty`, and the JVM module
+  declares all 16 `io.netty` modules zio-http brings as direct dependencies and imports
+  `io.netty:netty-bom` into the published POM's `<dependencyManagement>`, so the resolved
+  classpath and every consumer's resolution (coursier, Maven, Gradle) see a single netty version;
+  the OSV audit of the resolved 1.0.0 classpath reports 0 advisories. zio-http itself stays at
+  3.4.0 (netty 4.2.x is binary-compatible within the line; the pairing is gated by the JVM test
+  suite, the official conformance suite and the GraalVM HTTP smoke). **Consequence for
+  stdio-only GraalVM builds**: netty is now a direct `<dependency>` of `fast-mcp-scala_3`, so
+  the netty-free recipe must exclude both `dev.zio:zio-http_3` and `io.netty:*` — excluding
+  zio-http alone no longer sheds netty (see [docs/native-image.md](docs/native-image.md)).
 
 ### Added
 

--- a/DEPENDENCY_POLICY.md
+++ b/DEPENDENCY_POLICY.md
@@ -27,7 +27,13 @@ new distributions' SHA-256 lines in the same PR.
 
 A production dependency is updated when one of these applies:
 
-- a **security vulnerability** is disclosed in it (GitHub security alerts are enabled on the repo);
+- a **security vulnerability** is disclosed in it. Detection is an explicit OSV audit of the
+  resolved Maven tree (`cs resolve` of the published coordinates queried against
+  `api.osv.dev/v1/querybatch`), run before every release and whenever `build.mill` or
+  `package.mill` changes a dependency; GitHub's dependency graph cannot see Mill-resolved Maven
+  dependencies, so Dependabot alerts cover only the Actions and bun ecosystems. A transitive
+  dependency with a security surface of its own (netty, via zio-http) is pinned explicitly in
+  `Versions` so it can move independently of the library that brings it;
 - a bug in the dependency affects fast-mcp-scala's behavior;
 - a new dependency feature is needed;
 - the dependency drops support for a Scala, Scala.js, Scala Native, or JDK version this library

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ All settings, required request headers, error-code mapping, the legacy adapter, 
 
 ## Native image (GraalVM)
 
-Stdio servers compile to self-contained GraalVM binaries with **zero hand-written reachability metadata** (about 35 MB, instant startup, no JVM in the container): registration and schema derivation are compile-time macros, and the transport-seam split keeps zio-http/netty out of stdio-only images. HTTP servers compile too and pass the official conformance suite as a native binary in CI. Recipes, flags, and the metadata audit loop: [docs/native-image.md](docs/native-image.md).
+Stdio servers compile to self-contained GraalVM binaries with **zero hand-written reachability metadata** (about 35 MB, instant startup, no JVM in the container): registration and schema derivation are compile-time macros, and the transport-seam split keeps zio-http/netty out of stdio-only images — exclude both `dev.zio:zio-http_3` and `io.netty:*` from the dependency (netty is a direct, version-pinned dependency of the JVM artifact, so excluding zio-http alone is not enough). HTTP servers compile too and pass the official conformance suite as a native binary in CI. Recipes, flags, and the metadata audit loop: [docs/native-image.md](docs/native-image.md).
 
 ## Platforms
 

--- a/build.mill
+++ b/build.mill
@@ -24,6 +24,13 @@ object Versions {
   val zio = "2.1.20"
   val zioJson = "0.7.44"
   val zioHttp = "3.4.0"
+  // Netty is zio-http's transitive dependency, but it is the JVM artifact's largest CVE surface, so
+  // its version is pinned here rather than inherited: zio-http 3.4.0 declares 4.2.3.Final, which
+  // carries 27 OSV advisories (7 reachable on the default HTTP path). The jvm module pins every
+  // io.netty module zio-http brings AND imports the netty BOM, so the resolved classpath and every
+  // downstream POM consumer see a single netty version. Bump when a netty 4.2.x advisory lands;
+  // re-run the OSV audit (DEPENDENCY_POLICY.md) and the native-image HTTP smoke afterwards.
+  val netty = "4.2.17.Final"
   val scalaTest = "3.2.19"
   // Scala 3.9.0 emits Scala.js 1.22 IR, so the linker must be at least 1.22. mill-bun 0.3.x
   // delegates to Mill's standard ScalaJSModule and makes this pin explicit (Mill 1.1.x's own

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -29,9 +29,10 @@ object server extends ScalaModule with mill.javalib.NativeImageModule {
   def mainClass = Some("com.example.MyServer")
 
   def mvnDeps = Seq(
-    // stdio-only: exclude the HTTP stack — see "The stdio/HTTP split" below
+    // stdio-only: exclude the HTTP stack. BOTH exclusions are needed — netty is a direct,
+    // version-pinned dependency of the JVM artifact — see "The stdio/HTTP split" below
     mvn"com.tjclp::fast-mcp-scala:1.0.0-RC3"
-      .exclude("dev.zio" -> "zio-http_3")
+      .exclude("dev.zio" -> "zio-http_3", "io.netty" -> "*")
   )
 
   // GraalVM provisioned by Mill via the coursier JVM index — no GRAALVM_HOME, no setup-graalvm.
@@ -58,21 +59,27 @@ stack: `serveHttp` lives on the separate `HttpTransportBackend` trait, `runHttp(
 `using` parameter, and the `TransportRunner[Http]` given is conditional. Closed-world analysis
 therefore drops zio-http and netty from stdio-only binaries entirely.
 
-**Stdio-only builds should also exclude the `zio-http` dependency** (as in the recipe above).
-This is not just size hygiene: netty's own in-jar reflect-config unconditionally registers
-methods whose signatures mention netty buffer types, forcing them reachable, and netty's
-`--initialize-at-build-time=io.netty` directive then allocates a native `MemorySegment` in
-`EmptyByteBuf.<clinit>` on JDK 25 — failing the build with "Detected a native MemorySegment in
-the image heap". With the dependency excluded, none of that metadata is on the image classpath —
-and Mill's GraalVM-reachability-metadata-repo integration can stay at its defaults, so any OTHER
-dependency you add keeps its repo metadata. (HTTP builds keep netty and counter the stale-repo
-problem with a scoped override — see the HTTP section below.)
+**Stdio-only builds must also exclude the HTTP stack from the dependency — both
+`dev.zio:zio-http_3` and `io.netty:*`** (as in the recipe above). Since 1.0.0 the JVM artifact
+pins every netty module zio-http brings as a direct dependency (the CVE override, see
+[DEPENDENCY_POLICY.md](../DEPENDENCY_POLICY.md)), so excluding zio-http alone no longer removes
+netty from the classpath. This is not just size hygiene: netty's own in-jar reflect-config
+unconditionally registers methods whose signatures mention netty buffer types, forcing them
+reachable, and netty's `--initialize-at-build-time=io.netty` directive then allocates a native
+`MemorySegment` in `EmptyByteBuf.<clinit>` on JDK 25 — failing the build with "Detected a native
+MemorySegment in the image heap". With both exclusions in place, none of that metadata is on the
+image classpath — and Mill's GraalVM-reachability-metadata-repo integration can stay at its
+defaults, so any OTHER dependency you add keeps its repo metadata. (HTTP builds keep netty and
+counter the stale-repo problem with a scoped override — see the HTTP section below.)
 
-The in-repo proof: `fast-mcp-scala.nativeSmoke.stdio` builds
-`examples.AnnotatedServer` with exactly this shape (it filters netty/zio-http from
-`nativeImageClasspath`, which is the moduleDeps equivalent of the dependency exclusion), and
-`scripts/native-smoke.sh` asserts both the full MCP handshake and that the binary contains no
-`io.netty` / `zio.http` strings.
+The in-repo proof: `fast-mcp-scala.nativeSmoke.stdio` builds `examples.AnnotatedServer` with
+the same classpath shape — it filters the `netty-*` and `zio-http*` jars from
+`nativeImageClasspath`, the moduleDeps stand-in for the two dependency exclusions (a module
+dependency cannot carry an exclusion) — and `scripts/native-smoke.sh` asserts both the full MCP
+handshake and that the binary contains no `io.netty` / `zio.http` strings. That filter proves the
+transport seam, not the published recipe; the recipe is checked against the published POM instead:
+`cs resolve com.tjclp:fast-mcp-scala_3:<version> --exclude dev.zio:zio-http_3 --exclude 'io.netty:*' | grep -c io.netty`
+must print `0`.
 
 ## Notes and troubleshooting
 

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -20,7 +20,9 @@ use. One durable session per process; shutdown is EOF-driven (the client closing
 loop). The stdio lifecycle (`StdioLoop`: session, single-writer stdout, outbound drainer, EOF
 teardown) is shared by the JVM and Scala Native backends; the Scala.js backend drives Node's
 callback IO directly. Because `runStdio()` has no reachable call path into the HTTP stack,
-stdio-only programs never link zio-http or netty. That is what makes small GraalVM images possible
+stdio-only programs never link zio-http or netty; exclude both `dev.zio:zio-http_3` and `io.netty:*`
+from the dependency (netty is a direct, version-pinned dependency of the JVM artifact) to keep them
+off the classpath too. That is what makes small GraalVM images possible
 (see [native-image.md](./native-image.md)).
 
 ## HTTP

--- a/fast-mcp-scala/package.mill
+++ b/fast-mcp-scala/package.mill
@@ -61,8 +61,41 @@ object `package` extends Module {
       mvn"dev.zio::zio:${Versions.zio}",
       mvn"dev.zio::zio-json:${Versions.zioJson}",
       // ZIO HTTP for HTTP transports (stateless + streamable)
-      mvn"dev.zio::zio-http:${Versions.zioHttp}"
+      mvn"dev.zio::zio-http:${Versions.zioHttp}",
+      // Netty override (TJC-2327). zio-http 3.4.0 declares netty 4.2.3.Final, which carries 27 OSV
+      // advisories, 7 of them reachable on the default HTTP path (request smuggling in
+      // HttpRequestDecoder/HttpObjectAggregator, epoll RST DoS). Every io.netty module zio-http
+      // resolves is pinned directly — ALL of them, not just codec-http: a partial pin leaves the
+      // rest (incl. transport-classes-epoll, the HIGH epoll CVE) at 4.2.3 and mixes netty versions
+      // in one JVM. Direct pins are resolver-agnostic (coursier, Maven, Gradle all pick 4.2.17), at
+      // the cost that netty is now a direct <dependency> of the published POM: a stdio-only
+      // consumer that sheds the HTTP stack must exclude BOTH `dev.zio:zio-http_3` and
+      // `io.netty:*` (docs/native-image.md). Keep this list in sync with
+      // `cs resolve dev.zio:zio-http_3:${Versions.zioHttp} | grep io.netty`.
+      mvn"io.netty:netty-buffer:${Versions.netty}",
+      mvn"io.netty:netty-codec-base:${Versions.netty}",
+      mvn"io.netty:netty-codec-compression:${Versions.netty}",
+      mvn"io.netty:netty-codec-http:${Versions.netty}",
+      mvn"io.netty:netty-codec-socks:${Versions.netty}",
+      mvn"io.netty:netty-common:${Versions.netty}",
+      mvn"io.netty:netty-handler:${Versions.netty}",
+      mvn"io.netty:netty-handler-proxy:${Versions.netty}",
+      mvn"io.netty:netty-pkitesting:${Versions.netty}",
+      mvn"io.netty:netty-resolver:${Versions.netty}",
+      mvn"io.netty:netty-transport:${Versions.netty}",
+      mvn"io.netty:netty-transport-classes-epoll:${Versions.netty}",
+      mvn"io.netty:netty-transport-classes-kqueue:${Versions.netty}",
+      mvn"io.netty:netty-transport-native-epoll:${Versions.netty}",
+      mvn"io.netty:netty-transport-native-kqueue:${Versions.netty}",
+      mvn"io.netty:netty-transport-native-unix-common:${Versions.netty}"
     )
+
+    // Belt and braces for the pins above: the netty BOM lands in the published POM as a
+    // `<dependencyManagement>` import, so a consumer whose resolver honours it (coursier: Mill,
+    // sbt, scala-cli) stays on `Versions.netty` even for the classified native artifacts
+    // (`linux-x86_64`, `osx-aarch_64`, ...) that zio-http requests and that a plain
+    // `groupId:artifactId` pin cannot address under Maven's per-classifier mediation.
+    override def bomMvnDeps = Seq(mvn"io.netty:netty-bom:${Versions.netty}")
 
     object test extends ScalaTests with FastMCPTestModule {
       override def mvnDeps = Seq(
@@ -255,9 +288,10 @@ object `package` extends Module {
 
       // Netty-scoped counter to the stale GraalVM-metadata-repo entries: the repo marks netty
       // `override: true` but its newest netty configs are 4.1.x-era (predating netty 4.2's
-      // module renames). With the latest-config fallback off, the untested 4.2.3 gets no repo
-      // config and no `--exclude-config` stripping of its own (correct) in-jar metadata — while
-      // every other dependency keeps Mill's default repo-metadata behavior.
+      // module renames). With the latest-config fallback off, the 4.2.x version in use
+      // (`Versions.netty`, untested by the repo) gets no repo config and no `--exclude-config`
+      // stripping of its own (correct) in-jar metadata — while every other dependency keeps
+      // Mill's default repo-metadata behavior.
       override def nativeUseLatestConfigWhenVersionIsUntested = Task { false }
 
       override def nativeImageOptions = Task {


### PR DESCRIPTION
## What

Pins netty to **4.2.17.Final** on the JVM artifact, over an unchanged zio-http 3.4.0 (TJC-2327, decision (b) of the pre-v1.0.0 session).

- `build.mill`: `Versions.netty = "4.2.17.Final"` — netty is now pinned in the one place DEPENDENCY_POLICY.md names.
- `fast-mcp-scala/package.mill` (`jvm.mvnDeps`): the 16 `io.netty:*` modules that `cs resolve dev.zio:zio-http_3:3.4.0` lists (buffer, codec-base, codec-compression, codec-http, codec-socks, common, handler, handler-proxy, pkitesting, resolver, transport, transport-classes-epoll/kqueue, transport-native-epoll/kqueue, transport-native-unix-common) are declared directly at `Versions.netty`. All of them, not just codec-http: a partial pin leaves the rest (incl. `transport-classes-epoll`, the HIGH epoll CVE) at 4.2.3 and mixes netty versions in one JVM.
- `jvm.bomMvnDeps = Seq(mvn"io.netty:netty-bom:${Versions.netty}")` (Mill 1.1.8 `JavaModule.bomMvnDeps`, verified present and rendered): the published POM carries a `<dependencyManagement>` `import` of the netty BOM, so coursier consumers stay on 4.2.17 even for the classified native artifacts (`linux-x86_64`, `osx-aarch_64`, ...) that a plain `groupId:artifactId` pin cannot address under Maven's per-classifier mediation.
- `package.mill` `nativeSmoke.http` comment no longer hard-codes "the untested 4.2.3".

Docs in the same PR (netty is now a **direct** `<dependency>` of `fast-mcp-scala_3`, so the documented stdio-only shed changes):

- `docs/native-image.md`: recipe becomes `.exclude("dev.zio" -> "zio-http_3", "io.netty" -> "*")`; the stdio/HTTP-split section says why both are needed; the "in-repo proof" paragraph now states honestly that `nativeSmoke.stdio`'s jar-name filter proves the seam, not the recipe, and gives the `cs resolve ... --exclude ... | grep -c io.netty` check for the published POM.
- `README.md` native-image sentence and `docs/transports.md` stdio paragraph: the netty-free claim now names both exclusions.
- `DEPENDENCY_POLICY.md`: "GitHub security alerts are enabled" replaced by the real mechanism (explicit OSV audit of the resolved Maven tree; GitHub's dependency graph cannot see Mill-resolved Maven deps, so Dependabot alerts cover only Actions and bun) and the rule that a transitive dependency with its own security surface (netty) is pinned in `Versions`.
- `CHANGELOG.md` `[Unreleased] ### Security`: bullet naming netty 4.2.17.Final, all 27 CVE ids closed (7 reachable from the default JVM HTTP path: CVE-2026-33870, CVE-2026-42577, CVE-2026-42585, CVE-2026-42580, CVE-2026-42581, CVE-2026-50020, CVE-2025-58056; 20 in code paths this library never installs), the mechanism, the 0-advisory OSV result, and the recipe consequence.

## Why

zio-http 3.4.0 declares netty 4.2.3.Final; the S1 OSV audit found 27 advisories on those 16 modules (12 HIGH / 13 MODERATE / 2 LOW), 7 reachable from `JvmHttpBackend`'s default path, all published before the RC3 tag. 4.2.17.Final is the minimum clean version and the newest 4.2.x on Central. Bumping zio-http instead is not viable for 1.0.0 (only 3.11.4 carries 4.2.17 and drags zio 2.1.26 + zio-json 0.10.0 across all three platforms). Direct pins are the resolver-agnostic fix (coursier, Maven, Gradle all mediate to 4.2.17); the BOM import is a no-cost addition for the classified artifacts. zio-http 3.4.0 on netty 4.2.17 is an upstream-untested pairing (netty 4.2.x is binary-compatible within the line); the gates below are the evidence.

## Verification

All Mill commands ran as `./mill --no-server ...` in this branch's worktree.

| Gate | Command | Result |
|---|---|---|
| Single netty version on the classpath | `./mill --no-server show fast-mcp-scala.jvm.resolvedMvnDeps \| grep -o 'netty[^"]*' \| sort -u` | 20 jar paths (16 modules + linux-x86_64/linux-aarch_64/osx-x86_64/osx-aarch_64 classified), **all 4.2.17.Final**, no 4.2.3 |
| Format | `./mill --no-server fast-mcp-scala.checkFormat` (and `reformat` before the commit) | SUCCESS, no Scala source changed |
| JVM tests | `./mill --no-server fast-mcp-scala.jvm.test` | 138/138 targets SUCCESS, 483 tests passed, 0 failed (172 s) |
| Conformance, JVM | `scripts/conformance.sh jvm 8077 active` | **73 passed, 0 failed**, baseline check passed (empty baseline) |
| Conformance, native HTTP image (netty 4.2.17 under GraalVM 25.0.2 with the flags tuned on 4.2.3) | `scripts/conformance.sh native 8077 active` | **73 passed, 0 failed** against the unchanged JVM baseline; clean server log |
| Stdio GraalVM smoke (in-repo shed) | `scripts/native-smoke.sh` | `native stdio smoke: OK`; netty-shed check `io.netty: 0, zio.http: 0` strings |
| Published POM | `PUBLISH_VERSION=1.0.0-netty ./mill --no-server fast-mcp-scala.jvm.publishLocal`; inspect `~/.ivy2/local/com.tjclp/fast-mcp-scala_3/1.0.0-netty/poms/fast-mcp-scala_3.pom` | 16 direct `io.netty:*` `<dependency>` entries at 4.2.17.Final + `<dependencyManagement>` import of `io.netty:netty-bom:4.2.17.Final` (`<scope>import</scope><type>pom</type>`); zio-http_3 3.4.0 unchanged |
| OSV audit of the resolved 1.0.0 classpath | `CS_ARGS='-r ivy2Local' bash $SCRATCH/r1/osv-scan-ivy.sh com.tjclp:fast-mcp-scala_3:1.0.0-netty` (S1's `osv-scan.sh` with the coordinate filter tolerant of ivy2Local's `:default;runtime` suffixes; same `api.osv.dev/v1/querybatch` query) | **40 coordinates, 0 advisories**, exit 0 → `$SCRATCH/s1/osv-after.json` (before: 27 advisories, `$SCRATCH/s1/osv-before.json`) |
| Shed proof, resolver | `cs resolve -r ivy2Local com.tjclp:fast-mcp-scala_3:1.0.0-netty --exclude dev.zio:zio-http_3 --exclude 'io.netty:*' \| grep -c io.netty` | **0** (12 coordinates left: zio, zio-json, scala libs). Control with the OLD recipe (zio-http exclude only): 28 netty lines remain — the doc change is load-bearing |
| Shed proof, scala-cli consumer | `scala-cli compile --server=false HelloWorld.scala` with `//> using dep com.tjclp::fast-mcp-scala:1.0.0-netty,exclude=dev.zio%zio-http_3,exclude=io.netty%*` (README HelloWorld, Scala 3.9.0, `-experimental`) | compiles; `--print-class-path` has no `netty-*` / `zio-http` jars |
| Shed proof, Mill consumer + stdio-only GraalVM link | scratch `ScalaModule with NativeImageModule` using the exact documented recipe `mvn"com.tjclp::fast-mcp-scala:1.0.0-netty".exclude("dev.zio" -> "zio-http_3", "io.netty" -> "*")`; `./mill --no-server server.compile`, `server.nativeImage` | compile SUCCESS (no netty/zio-http in `resolvedMvnDeps`); 33 MB image links in 48 s with `--no-fallback`; `strings` → `io.netty: 0, zio.http: 0`; driven over stdio: initialize ✓, `tools/list` → `add` with derived schema ✓, `tools/call add(2,3)` → `5` ✓, exit 0 on EOF |
| Hygiene | the session's `git grep` for absolute home/scratch paths and scratch identifiers over the tree (excluding `out/`); `git diff --check` | empty; clean |

The throwaway `1.0.0-netty` was deleted from `~/.ivy2/local` afterwards.

Deviation from the brief: `./mill --no-server -i ...` is rejected by Mill 1.1.8 ("Only one of -i/--interactive, --no-daemon or --bsp may be given"), so every command ran with `--no-server` only (which already reads `PUBLISH_VERSION` fresh per invocation).

Follow-ups (not in this PR): PR B adds the 1.0.0 gate-ledger "Dependencies" row; a 1.0.1 issue adds the OSV query as a CI gate (`osv.yml`, TJC-2329 scope).

Linear: https://linear.app/tjc-technologies/issue/TJC-2327/fast-mcp-scala-override-netty-to-4217final-in-jvmmvndeps-high

Merge with a MERGE COMMIT (never squash); part of the pre-v1.0.0 stack, see TJC-2326

🤖 Generated with [Claude Code](https://claude.com/claude-code)
