### PR TITLE
build: drop -experimental; macros use only stable reflect API (TJC-2335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,12 @@ Security-hardening wave (TJC-2294; findings F1–F12 of the 2026-09-04 scan). Um
   - `@Tool(description = Some(...))` / `@Prompt(description = Some(...))` without `name` now
     registers under the method name with that description (previously the description text became
     the registered name).
+- **No more `-experimental`** (TJC-2335): fast-mcp-scala is no longer compiled with
+  `-experimental`; consumers may drop the flag (annotation and typed-contract paths, all three
+  platforms). The annotation macros use only stable reflect API: the five `Symbol.info` uses
+  (the only `@experimental` reflect member the macros touched) became
+  `Symbol.termRef.widenTermRefByName`. The Scaladoc-as-description fallback (`Symbol.docstring`,
+  stable) is unchanged.
 - **Scala 3.9.0 LTS** (TJC-2273): all three platforms now build with Scala 3.9.0
   (LTS, released 2026-09-03), up from 3.8.3. Companion bumps: WartRemover
   3.5.6 → 3.6.1 (first release for the 3.9.0 compiler) and the Scala.js

--- a/build.mill
+++ b/build.mill
@@ -60,7 +60,6 @@ object BuildConfig {
     "-Wnonunit-statement",
     // Macro-specific options (CRITICAL for this project)
     "-Xcheck-macros",
-    "-experimental",
     "-Xmax-inlines:128"
   )
 

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/MacroUtils.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/MacroUtils.scala
@@ -597,7 +597,7 @@ private[macros] object MacroUtils:
   ): EffectShape =
     import quotes.reflect.*
 
-    val resType = (methodSym.info match
+    val resType = (methodSym.termRef.widenTermRefByName match
       case mt: MethodType => mt.resType
       case other => other
     ).dealias
@@ -617,7 +617,7 @@ private[macros] object MacroUtils:
   ): Option[quotes.reflect.TypeRepr] =
     import quotes.reflect.*
 
-    val resType = (methodSym.info match
+    val resType = (methodSym.termRef.widenTermRefByName match
       case mt: MethodType => mt.resType
       case other => other
     ).dealias

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ToolProcessor.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ToolProcessor.scala
@@ -90,7 +90,7 @@ private[macros] object ToolProcessor extends AnnotationProcessorBase:
     val methodRefExpr = methodRef(ownerSym, methodSym)
 
     val ctxParamPresent = methodSym.paramSymss.headOption.exists(_.exists { p =>
-      p.name == "ctx" && p.info <:< TypeRepr.of[McpContext]
+      p.name == "ctx" && p.termRef.widenTermRefByName <:< TypeRepr.of[McpContext]
     })
 
     val ctxParamPresentExpr = Expr(ctxParamPresent)
@@ -120,14 +120,14 @@ private[macros] object ToolProcessor extends AnnotationProcessorBase:
             val (desc, examples, required, schema) = MacroUtils.parseToolParam(Some(annotTerm))
 
             if !required then
-              val isOptionType = pSym.info <:< TypeRepr.of[Option[?]]
+              val isOptionType = pSym.termRef.widenTermRefByName <:< TypeRepr.of[Option[?]]
               val hasDefault = paramsWithDefaults.contains(pSym.name)
 
               if !isOptionType && !hasDefault then
                 report.errorAndAbort(
                   s"Parameter '${pSym.name}' in method '$methodName' is marked as required=false " +
                     s"but is not an Option type and has no default value. " +
-                    s"Use Option[${pSym.info.show}] or provide a default value."
+                    s"Use Option[${pSym.termRef.widenTermRefByName.show}] or provide a default value."
                 )
 
             pSym.name -> ParamMetadata(desc, examples, required, schema)


### PR DESCRIPTION
## What

Drop `-experimental` from the library build (decision (h) of the pre-v1.0.0 session).

- `build.mill`: remove `"-experimental"` from `BuildConfig.crossScalacOptions` (`-Xcheck-macros` stays).
- Replace the five `Symbol.info` uses — the only `@experimental` reflect member the annotation macros touched (scala-library 3.9.0 `Quotes.scala`: `Symbol.info` is `@experimental`; `termRef`, `widenTermRefByName`, `docstring`, `memberType` are stable) — with `Symbol.termRef.widenTermRefByName`:
  - `MacroUtils.detectEffectShape` / `extractZioRequirement` (method result type)
  - `ToolProcessor`: `ctx: McpContext` parameter detection, the `required = false` Option check and its error message
- CHANGELOG `[Unreleased] ### Changed` bullet.

`Symbol.termRef` is `TermRef(owner.thisType, sym)`, so the widened type equals `info` for object members and for parameter symbols (prefix `NoPrefix`); the extra by-name widening is a no-op for tool methods. `TypeRepr.of[T].memberType(m)` (the `RegistrationMacro` precedent) was not used: `detectEffectShape` / `extractZioRequirement` receive only the `Symbol`, and `@Tool` owners are objects without type parameters, so `memberType` would be equivalent, not more faithful. The Scaladoc-as-description fallback (`Symbol.docstring`) is stable and unchanged.

## Why

Every top-level definition in the published jars was stamped `@experimental` (the flag applies to all three modules), which forced `-experimental` onto every consumer on both registration paths and all three platforms (S1.5.1 / S1.5.2). Removing it before 1.0.0 is source- and binary-compatible for consumers; adding it back later would not be. Docs (README, docs/, scripts, CONTRIBUTING flag lines) are updated in the release-prep PR, not here.

## Verification

| Gate | Command | Result |
|---|---|---|
| Format | `./mill --no-server fast-mcp-scala.checkFormat` | 16/16 SUCCESS |
| Compile (JVM + Scala.js + Scala Native) | `./mill --no-server fast-mcp-scala.compile` | 168/168 SUCCESS, 0 errors |
| JVM tests | `./mill --no-server fast-mcp-scala.jvm.test` | 483 succeeded, 0 failed |
| Scala Native tests | `./mill --no-server fast-mcp-scala.scalaNative.test` | 14 succeeded, 0 failed |
| Scala.js/Bun tests | `./mill --no-server fast-mcp-scala.js.test` | 70 succeeded, 0 failed |
| Conformance, JVM | `scripts/conformance.sh jvm 8077 active` | 73 passed, 0 failed; baseline check passed |
| Conformance, Bun | `scripts/conformance.sh js 8077 active` | 73 passed, 0 failed; baseline check passed |
| Local publish | `PUBLISH_VERSION=1.0.0-noexp ./mill --no-server __.publishLocal` | 318/318 SUCCESS (`_3`, `_sjs1_3`, `_native0.5_3`) |
| TASTy stamp | for every `.tasty` entry: `unzip -p <jar> <entry> \| grep -a -c 'Added by -experimental'` | `_3` 0/241, `_sjs1_3` 0/251, `_native0.5_3` 0/237 files stamped (control: the RC4-SNAPSHOT local build made with the flag is 228/228) |
| Consumer probe, annotation path | README quickstart with `//> using repository ivy2Local`, `//> using dep com.tjclp::fast-mcp-scala:1.0.0-noexp`, no `-experimental`; `scala-cli compile --server=false .`; `initialize` + `tools/list` over stdin | compiles; `tools/list` returns `add` with the `@Param` descriptions and `readOnlyHint: true` |
| Consumer probe, typed contracts | `McpTool[AddArgs, AddResult]` variant, same directives, no `-experimental` | compiles; `tools/list` returns `add` with the derived `inputSchema` |

Notes:
- The literal `strings \| grep -c experimental` on `Protocol.tasty` reports 1, because TASTy embeds the source path and this branch's worktree is named `tjc-2335-drop-experimental`; the other hits in `MacroUtils.tasty` are the "experimental Tasks feature" docstring. The compiler stamp `Added by -experimental` is what the flag adds, and it is absent from every entry.
- Mill 1.1.8 refuses `--no-server -i` together ("Only one of -i/--interactive, --no-daemon or --bsp may be given"); every gate ran with `--no-server` alone.
- The `1.0.0-noexp` ivy2-local artifacts were deleted after the probes.

Linear: https://linear.app/tjc-technologies/issue/TJC-2335

Merge with a MERGE COMMIT (never squash); part of the pre-v1.0.0 stack, see TJC-2326

🤖 Generated with [Claude Code](https://claude.com/claude-code)
