### PR TITLE
fix(js): Bun SSE keepalive heartbeat fiber — a reply can no longer race the ping timer (TJC-2337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,6 +296,14 @@ Security-hardening wave (TJC-2294; findings F1–F12 of the 2026-09-04 scan). Um
   search finds nothing), never exported givens that could shadow
   companions. Parameterized-case enums intentionally keep wrapper-object
   codecs; provide an `McpInputCodec` for a custom shape.
+- **Bun SSE keepalive no longer drops a reply that lands on a heartbeat tick** (TJC-2337): with
+  `keepAliveInterval` set, the Scala.js/Bun HTTP backend implemented the heartbeat as a timed `take`
+  on the per-request stream queue; a tool reply arriving in the same tick as the timeout was
+  discarded by the interrupted take and the stream then ended as `: ping` frames only — HTTP 200,
+  nothing logged (deterministic when the handler ran for exactly one interval, intermittent at
+  multiples; legacy per-request streams from the first frame, modern 2026-07-28 streams from the
+  second). The heartbeat is now a fiber that offers a ping marker into the queue — the Bun twin of
+  the JVM's stream merge — so the pull is a plain `take` and every reply frame is delivered.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,6 +304,15 @@ Security-hardening wave (TJC-2294; findings F1–F12 of the 2026-09-04 scan). Um
   multiples; legacy per-request streams from the first frame, modern 2026-07-28 streams from the
   second). The heartbeat is now a fiber that offers a ping marker into the queue — the Bun twin of
   the JVM's stream merge — so the pull is a plain `take` and every reply frame is delivered.
+- **Bun's `idleTimeout` no longer cuts a slow tool's reply** (TJC-2337): the Scala.js/Bun HTTP
+  backend passed no `idleTimeout` to `Bun.serve`, whose 10 s default closes any connection with no
+  bytes in either direction — a per-request SSE response awaiting a slow tool included. With the
+  documented default `keepAliveInterval = None` a `tools/call` slower than that lost its reply: the
+  socket was cut mid-stream (measured 9–12 s) and the client saw only its own request timeout
+  (`-32001`). The listener now runs with `idleTimeout: 0`, disabling Bun's runtime idle close —
+  parity with the JVM listener, which has none; legacy session lifetime is still governed by
+  `sessionIdleTimeout` — so a quiet stream stays open until the reply. `keepAliveInterval` remains
+  the knob for intermediaries with idle timers of their own.
 
 ### Removed
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -40,7 +40,8 @@ What the Scala.js target gives you:
 
 - The same native MCP **server runtime** on Bun: stdio (`runStdio`, Node stdin) and modern
   stateless Streamable HTTP (`runHttp`, `Bun.serve`), plus the version-selected legacy session
-  adapter. The Bun listener runs with `development: false`, an `error` callback and a first-party
+  adapter. The Bun listener runs with `development: false`, an `error` callback, `idleTimeout: 0`
+  (Bun's 10 s default would close a quiet SSE response before a slow tool replies) and a first-party
   `catchAllCause` boundary (`NODE_ENV` is not security-relevant); `startStatefulHttp()` /
   `startStatelessHttp()` return a `BunHttpHandle` (call `.stop()`), and idle-session eviction plus
   the `maxSessions` cap run on every entry.

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -105,7 +105,7 @@ clients share one session identity, which is why legacy task requests there are 
 | `httpEndpoint` | `/mcp` | JSON-RPC endpoint path. |
 | `stateless` | `false` | Disable the legacy HTTP session store; modern requests are always stateless. |
 | `sessionIdleTimeout` | `30 minutes` | Evict legacy sessions with no client activity (live legacy GET streams are exempt); `None` disables. |
-| `keepAliveInterval` | `None` | When set, emit SSE heartbeats on quiet streams so proxies do not kill long calls. |
+| `keepAliveInterval` | `None` | When set, emit SSE heartbeats on quiet streams so proxies do not kill long calls. Neither listener closes a quiet stream on its own: the JVM has no idle timeout and Bun runs with `idleTimeout: 0` (its 10 s default used to cut a slow tool's reply). |
 | `allowedHosts` | `None` | DNS-rebinding/CSRF guard: the `Host` hostname must be listed (port ignored); a present `Origin` must be the same origin as the request `Host` (`scheme://host:port`; scheme not compared; a port-less `Host` admits `http://h` and `https://h`) or appear in `allowedOrigins`; cross-port loopback origins, `null`, and malformed `Host`/`Origin` ports are refused (403). |
 | `allowedOrigins` | `None` | Extra browser origins (`https://app.example.com`, `http://localhost:5173`) admitted alongside the request's own authority; malformed entries fail `runHttp()` at startup. |
 | `maxRequestBodyBytes` | `1 MiB` | Request body cap on every backend; larger bodies get 413 before decoding (empty 413 on the wire from netty/Bun, JSON-RPC `-32000` on first-party paths); must not exceed `limits.maxFrameChars`. |

--- a/fast-mcp-scala/js/src/com/tjclp/fastmcp/facades/runtime/Bun.scala
+++ b/fast-mcp-scala/js/src/com/tjclp/fastmcp/facades/runtime/Bun.scala
@@ -29,6 +29,15 @@ object Bun extends js.Object:
   *   - `development = false` — Bun otherwise defaults to `NODE_ENV !== "production"` and renders a
   *     ~100 KB HTML debug page (stack traces, on-disk paths) for a rejected `fetch` promise.
   *   - `error` — last-resort callback for anything Bun still sees; returns a plain JSON 500.
+  *   - `idleTimeout` — seconds a connection may sit with no bytes in either direction before Bun
+  *     closes it. Bun's own default is 10 s (its timer is coarse: Bun 1.4.1 fires between ~9 and
+  *     ~12 s) and it applies to a per-request SSE response awaiting a slow tool, so with
+  *     `keepAliveInterval = None` any tool slower than that lost its reply — the socket was cut
+  *     mid-stream and the client saw only its own request timeout (dogfood finding D6 8.15). The
+  *     transport passes `0`, which disables the runtime's idle close: parity with the JVM listener
+  *     (zio-http's `Server.Config.default.idleTimeout` is `None`). A non-zero value is capped by
+  *     Bun at 255 s. Legacy session lifetime stays governed by `sessionIdleTimeout`, and
+  *     `keepAliveInterval` remains the knob for intermediaries with idle timers of their own.
   */
 trait BunServeOptions extends js.Object:
   val port: js.UndefOr[Int]
@@ -37,6 +46,7 @@ trait BunServeOptions extends js.Object:
   val maxRequestBodySize: js.UndefOr[Int]
   val development: js.UndefOr[Boolean]
   val error: js.UndefOr[js.Function1[js.Dynamic, js.Dynamic]]
+  val idleTimeout: js.UndefOr[Int]
 
 object BunServeOptions:
 
@@ -46,7 +56,8 @@ object BunServeOptions:
       fetch: js.Function2[js.Dynamic, js.Dynamic, js.Promise[js.Dynamic]],
       maxRequestBodySize: Int,
       development: Boolean,
-      error: js.Function1[js.Dynamic, js.Dynamic]
+      error: js.Function1[js.Dynamic, js.Dynamic],
+      idleTimeout: Int
   ): BunServeOptions =
     js.Dynamic
       .literal(
@@ -55,7 +66,8 @@ object BunServeOptions:
         fetch = fetch,
         maxRequestBodySize = maxRequestBodySize,
         development = development,
-        error = error
+        error = error,
+        idleTimeout = idleTimeout
       )
       .asInstanceOf[BunServeOptions]
 

--- a/fast-mcp-scala/js/src/com/tjclp/fastmcp/server/transport/JsTransportBackend.scala
+++ b/fast-mcp-scala/js/src/com/tjclp/fastmcp/server/transport/JsTransportBackend.scala
@@ -479,7 +479,8 @@ object JsTransportBackend extends TransportBackend with HttpTransportBackend:
             .flatMap(reply => ZIO.foreachDiscard(reply)(reqQueue.offer))
             .ensuring(reqQueue.offer(MessageLoop.CloseSentinel))
             .forkDaemon
-        yield sseResponse(reqQueue, req.id, session, isNew, fiber, settings, modern = false)
+          response <- sseResponse(reqQueue, req.id, session, isNew, fiber, settings, modern = false)
+        yield response
       case other =>
         val extra =
           if isNew then Map(SessionIdHeader -> session.sessionId) else Map.empty[String, String]
@@ -489,8 +490,25 @@ object JsTransportBackend extends TransportBackend with HttpTransportBackend:
           case None => webResponse(202, "")
         }
 
+  /** Heartbeat marker the keepalive fiber offers into a request's `reqQueue`; the pull turns it
+    * into an SSE comment frame (`: ping`). Like [[MessageLoop.CloseSentinel]] it never reaches the
+    * wire as a JSON-RPC message.
+    */
+  private val KeepAliveSentinel: JsonRpcMessage =
+    JsonRpcMessage.Notification("$fastmcp/internal/keepalive", None)
+
   /** Build a Bun SSE `Response` whose `ReadableStream` is pull-fed from `reqQueue`: each take emits
     * one `event: message` frame, and the stream closes right after the request's final reply.
+    *
+    * Keepalive (`settings.keepAliveInterval`) is a daemon heartbeat fiber that OFFERS
+    * [[KeepAliveSentinel]] into `reqQueue` on a `sleep *> offer` loop — the Bun twin of the JVM's
+    * `sse.mergeHaltLeft(pings)`. The pull stays a plain `take`, so a heartbeat can never discard a
+    * reply (TJC-2337: `take.timeout(interval)` interrupted a take whose promise already held the
+    * reply; the next pull took the close sentinel and the stream ended pings-only, HTTP 200, with
+    * nothing logged). A sleep loop rather than `Schedule.spaced` for the reason given on
+    * [[evictIdleSessions]]. The heartbeat is interrupted when the stream closes (final reply or
+    * close sentinel), when the client cancels, and when a pull fails; an offer into an already
+    * shut-down queue interrupts it on its own.
     */
   private def sseResponse(
       reqQueue: Queue[JsonRpcMessage],
@@ -501,63 +519,73 @@ object JsTransportBackend extends TransportBackend with HttpTransportBackend:
       settings: McpServerSettings,
       modern: Boolean,
       initial: Option[JsonRpcMessage] = None
-  ): js.Dynamic =
-    val encoder = js.Dynamic.newInstance(js.Dynamic.global.TextEncoder)()
-    var initialMessage = initial
-    // Keepalive: when configured, a quiet `take` emits an SSE comment frame instead of blocking
-    // forever, so proxies / idle timeouts don't kill long-running calls.
-    val takeNext: UIO[Option[JsonRpcMessage]] = ZIO.suspendSucceed {
-      initialMessage match
-        case Some(message) =>
-          initialMessage = None
-          ZIO.some(message)
-        case None =>
-          settings.keepAliveInterval match
-            case None => reqQueue.take.map(Some(_))
-            case Some(interval) => reqQueue.take.timeout(Duration.fromJava(interval))
-    }
-    val source = js.Dynamic.literal(
-      pull = js.Any.fromFunction1((controller: js.Dynamic) =>
-        ZioJsPromise.zioToPromise(
-          takeNext
-            .map {
-              case None =>
-                val _ = controller.enqueue(encoder.encode(": ping\n\n"))
-              case Some(msg) if MessageLoop.isCloseSentinel(msg) =>
-                // Dispatch ended replyless (cancelled): end the stream without emitting a frame.
-                val _ = controller.close()
-              case Some(msg) =>
-                val frame = s"event: message\ndata: ${MessageLoop.encodeOutbound(msg)}\n\n"
-                val _ = controller.enqueue(encoder.encode(frame))
-                if isFinalReply(msg, reqId) then
-                  val _ = controller.close()
-            }
-            // A defect mid-stream ends the stream instead of rejecting the pull promise — Bun
-            // would otherwise surface the raw error itself. A pull racing the client's cancel
-            // (interrupted `take`, or the controller already closed) is benign and not logged.
-            .catchAllCause { cause =>
-              val benign = cause.isInterruptedOnly || cause.dieOption.exists {
-                case _: js.JavaScriptException => true
-                case _ => false
+  ): UIO[js.Dynamic] =
+    val heartbeat: UIO[Option[Fiber.Runtime[Nothing, Nothing]]] =
+      settings.keepAliveInterval match
+        case None => ZIO.none
+        case Some(interval) =>
+          val tick = Duration.fromJava(interval)
+          (ZIO.sleep(tick) *> reqQueue.offer(KeepAliveSentinel)).forever.forkDaemon.map(Some(_))
+    heartbeat.map { hb =>
+      val stopHeartbeat: UIO[Unit] = hb.fold(ZIO.unit)(_.interrupt.unit)
+      val encoder = js.Dynamic.newInstance(js.Dynamic.global.TextEncoder)()
+      var initialMessage = initial
+      val takeNext: UIO[JsonRpcMessage] = ZIO.suspendSucceed {
+        initialMessage match
+          case Some(message) =>
+            initialMessage = None
+            ZIO.succeed(message)
+          case None => reqQueue.take
+      }
+      val source = js.Dynamic.literal(
+        pull = js.Any.fromFunction1((controller: js.Dynamic) =>
+          ZioJsPromise.zioToPromise(
+            takeNext
+              .flatMap {
+                case msg if msg == KeepAliveSentinel =>
+                  ZIO.succeed { val _ = controller.enqueue(encoder.encode(": ping\n\n")) }
+                case msg if MessageLoop.isCloseSentinel(msg) =>
+                  // Dispatch ended replyless (cancelled): end the stream without emitting a frame.
+                  stopHeartbeat *> ZIO.succeed { val _ = controller.close() }
+                case msg =>
+                  val frame = s"event: message\ndata: ${MessageLoop.encodeOutbound(msg)}\n\n"
+                  ZIO.succeed {
+                    val _ = controller.enqueue(encoder.encode(frame))
+                  } *>
+                    (if isFinalReply(msg, reqId) then
+                       stopHeartbeat *> ZIO.succeed { val _ = controller.close() }
+                     else ZIO.unit)
               }
-              (if benign then ZIO.unit else ZIO.logWarningCause("SSE pull failed", cause)) *>
-                ZIO.succeed { val _ = scala.util.Try(controller.error(js.Error("stream failed"))) }
-            }
+              // A defect mid-stream ends the stream instead of rejecting the pull promise — Bun
+              // would otherwise surface the raw error itself. A pull racing the client's cancel
+              // (interrupted `take`, or the controller already closed) is benign and not logged.
+              .catchAllCause { cause =>
+                val benign = cause.isInterruptedOnly || cause.dieOption.exists {
+                  case _: js.JavaScriptException => true
+                  case _ => false
+                }
+                (if benign then ZIO.unit else ZIO.logWarningCause("SSE pull failed", cause)) *>
+                  stopHeartbeat *>
+                  ZIO.succeed {
+                    val _ = scala.util.Try(controller.error(js.Error("stream failed")))
+                  }
+              }
+          )
+        ),
+        // Client disconnected mid-request: stop the heartbeat, interrupt the dispatch and drop the
+        // queue, otherwise the pending `take` leaks a fiber per aborted request.
+        cancel = js.Any.fromFunction1((_: js.Any) =>
+          ZioJsPromise.zioToPromise(stopHeartbeat *> dispatchFiber.interrupt *> reqQueue.shutdown)
         )
-      ),
-      // Client disconnected mid-request: interrupt the dispatch and drop the queue, otherwise the
-      // pending `take` leaks a fiber per aborted request.
-      cancel = js.Any.fromFunction1((_: js.Any) =>
-        ZioJsPromise.zioToPromise(dispatchFiber.interrupt *> reqQueue.shutdown)
       )
-    )
-    val stream = js.Dynamic.newInstance(js.Dynamic.global.ReadableStream)(source)
-    val headers =
-      Map("content-type" -> "text/event-stream", "cache-control" -> "no-cache") ++
-        (if modern then Map("x-accel-buffering" -> "no") else Map.empty[String, String]) ++
-        (if isNew then Map(SessionIdHeader -> session.sessionId) else Map.empty[String, String])
-    val init = js.Dynamic.literal(status = 200, headers = js.Dictionary[String](headers.toSeq*))
-    js.Dynamic.newInstance(js.Dynamic.global.Response)(stream, init)
+      val stream = js.Dynamic.newInstance(js.Dynamic.global.ReadableStream)(source)
+      val headers =
+        Map("content-type" -> "text/event-stream", "cache-control" -> "no-cache") ++
+          (if modern then Map("x-accel-buffering" -> "no") else Map.empty[String, String]) ++
+          (if isNew then Map(SessionIdHeader -> session.sessionId) else Map.empty[String, String])
+      val init = js.Dynamic.literal(status = 200, headers = js.Dictionary[String](headers.toSeq*))
+      js.Dynamic.newInstance(js.Dynamic.global.Response)(stream, init)
+    }
 
   private def isFinalReply(message: JsonRpcMessage, reqId: RequestId): Boolean =
     message match
@@ -600,17 +628,15 @@ object JsTransportBackend extends TransportBackend with HttpTransportBackend:
                     jsonResponse(first.toJson, Map.empty, status)
                   )
                 case None =>
-                  ZIO.succeed(
-                    sseResponse(
-                      reqQueue,
-                      rpc.id,
-                      session,
-                      isNew = false,
-                      fiber,
-                      settings,
-                      modern = true,
-                      initial = Some(first)
-                    )
+                  sseResponse(
+                    reqQueue,
+                    rpc.id,
+                    session,
+                    isNew = false,
+                    fiber,
+                    settings,
+                    modern = true,
+                    initial = Some(first)
                   )
             yield response
       case _: JsonRpcMessage.Invalid =>

--- a/fast-mcp-scala/js/src/com/tjclp/fastmcp/server/transport/JsTransportBackend.scala
+++ b/fast-mcp-scala/js/src/com/tjclp/fastmcp/server/transport/JsTransportBackend.scala
@@ -185,7 +185,7 @@ object JsTransportBackend extends TransportBackend with HttpTransportBackend:
     (_: js.Dynamic) => jsonRpcErrorResponse(500, HttpRequestGuards.InternalErrorMessage)
 
   /** The options handed to `Bun.serve` — a seam so tests can assert `development == false`, the
-    * `error` callback and `maxRequestBodySize` without depending on `NODE_ENV`.
+    * `error` callback, `maxRequestBodySize` and `idleTimeout == 0` without depending on `NODE_ENV`.
     */
   private[fastmcp] def serveOptions[R](
       router: McpRouter[R],
@@ -203,7 +203,10 @@ object JsTransportBackend extends TransportBackend with HttpTransportBackend:
       ),
       maxRequestBodySize = settings.maxRequestBodyBytes,
       development = false,
-      error = bunErrorHandler
+      error = bunErrorHandler,
+      // Bun's 10 s default would cut a quiet SSE response before a slow tool replies (D6 8.15);
+      // 0 disables the runtime idle close, as on the JVM listener. See `BunServeOptions`.
+      idleTimeout = 0
     )
 
   /** First-party error boundary, independent of `NODE_ENV`. The by-name `effect` is evaluated

--- a/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerHttpTest.scala
+++ b/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerHttpTest.scala
@@ -416,7 +416,7 @@ class JsServerHttpTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAl
     }
   }
 
-  "Bun.serve options" should "run with development=false, an error callback and the body cap (NODE_ENV-independent)" in {
+  "Bun.serve options" should "run with development=false, an error callback, the body cap and idleTimeout 0 (NODE_ENV-independent)" in {
     val settings = McpServerSettings(
       host = "127.0.0.1",
       port = 1, // never bound: serveOptions does not call Bun.serve
@@ -431,6 +431,8 @@ class JsServerHttpTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAl
       opts.maxRequestBodySize.getOrElse(0) shouldBe 4096
       opts.port.getOrElse(0) shouldBe 1
       opts.error.isDefined shouldBe true
+      // 0 disables Bun's runtime idle close (its 10 s default cut quiet SSE streams, D6 8.15).
+      opts.idleTimeout.getOrElse(-1) shouldBe 0
       // Bun calls fetch(request, server): the closure must take both.
       opts.fetch.asInstanceOf[js.Dynamic].length.asInstanceOf[Int] shouldBe 2
 

--- a/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerHttpTest.scala
+++ b/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerHttpTest.scala
@@ -87,6 +87,7 @@ class JsServerHttpTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAl
   override def afterAll(): Unit =
     if bunServer != null then bunServer.stop()
     keepAliveHandle.foreach(_.stop())
+    idleTimeoutHandle.foreach(_.stop())
     super.afterAll()
 
   private def delay(ms: Int): Future[Unit] =
@@ -1026,6 +1027,24 @@ class JsServerHttpTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAl
     """{"type":"object","properties":{"millis":{"type":"integer"}},"required":["millis"]}"""
   )
 
+  /** Sleeps exactly `millis`, then replies. Shared by the keepalive server (called with a multiple
+    * of `keepAliveMs`, so the reply is offered in the same tick as a heartbeat) and the
+    * keepalive-less idle-timeout server below. Given a progress token it first emits a
+    * notification, which makes the reply the stream's SECOND frame — the only shape in which a
+    * modern POST (whose first frame is taken before the SSE response exists) is exposed to the
+    * keepalive path.
+    */
+  private val sleepTool = McpTool
+    .withSchema[SleepArgs, String](
+      name = "sleep",
+      inputSchema = sleepSchema,
+      description = Some("Sleeps for millis, then replies")
+    )
+    .contextual { (args, ctx) =>
+      ZIO.foreachDiscard(ctx.get.progressToken)(t => ctx.get.sendProgress(t, 0.0)) *>
+        ZIO.sleep(args.millis.millis).as(s"slept ${args.millis}")
+    }
+
   /** Heartbeat period of the shared keepalive server. The `sleep` tool below is called with N and
     * 3N so its reply lands ON a heartbeat tick.
     */
@@ -1060,20 +1079,6 @@ class JsServerHttpTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAl
             // The early notification opens the SSE stream; the sleep leaves it quiet for pings.
             ZIO.foreachDiscard(ctx.get.progressToken)(t => ctx.get.sendProgress(t, 0.5)) *>
               ZIO.sleep(30.seconds).as("done")
-          }
-        // Sleeps exactly `millis`, so with a multiple of `keepAliveMs` the reply is offered in the
-        // same tick as a heartbeat. Given a progress token it first emits a notification, which
-        // makes the reply the stream's SECOND frame — the only shape in which a modern POST (whose
-        // first frame is taken before the SSE response exists) is exposed to the keepalive path.
-        val sleepTool = McpTool
-          .withSchema[SleepArgs, String](
-            name = "sleep",
-            inputSchema = sleepSchema,
-            description = Some("Sleeps for millis, then replies")
-          )
-          .contextual { (args, ctx) =>
-            ZIO.foreachDiscard(ctx.get.progressToken)(t => ctx.get.sendProgress(t, 0.0)) *>
-              ZIO.sleep(args.millis.millis).as(s"slept ${args.millis}")
           }
         runZio(server.tool(slowProgressTool) *> server.tool(sleepTool).unit).map { _ =>
           val handle = server.startStatefulHttp()
@@ -1199,6 +1204,92 @@ class JsServerHttpTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAl
       val firstLost = streams.flatten.find(b => !b.contains("event: message"))
       withClue(s"first reply-less stream: ${firstLost.map(_.replace("\n", "\\n"))}\n") {
         summary shouldBe labels.map(l => s"$l: 20/20 replies delivered")
+      }
+    checked
+  }
+
+  // --- Bun idleTimeout: a slow reply must survive with the documented default keepAliveInterval = None ---
+
+  /** Port of the keepalive-less server, and how long its one `sleep` call takes: past `Bun.serve`'s
+    * default 10 s `idleTimeout` (measured ~12 s on Bun 1.4.1), so a quiet per-request SSE response
+    * is exposed to the runtime's own idle close. One call, once — the whole suite pays these
+    * seconds exactly one time.
+    */
+  private val idleTimeoutPort = 38932
+  private val slowReplyMs = 14000
+
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  private var idleTimeoutHandle: Option[BunHttpHandle] = None
+
+  private def idleTimeoutServer(): Future[BunHttpHandle] =
+    idleTimeoutHandle match
+      case Some(handle) => Future.successful(handle)
+      case None =>
+        // `keepAliveInterval` deliberately left at its default (None): nothing but the reply is
+        // ever written to the stream, exactly the shape a slow tool has out of the box.
+        val server = com.tjclp.fastmcp.server.McpServer(
+          "JsHttpIdleTimeoutServer",
+          "0.1.0",
+          McpServerSettings(
+            host = "127.0.0.1",
+            port = idleTimeoutPort,
+            httpEndpoint = "/mcp",
+            stateless = false
+          )
+        )
+        runZio(server.tool(sleepTool).unit).map { _ =>
+          val handle = server.startStatefulHttp()
+          idleTimeoutHandle = Some(handle)
+          handle
+        }
+
+  // D6 8.15 (TJC-2337 follow-up): `Bun.serve` closes any connection with no bytes in either
+  // direction after its default 10 s `idleTimeout` — a per-request SSE response waiting on a slow
+  // tool included. With `keepAliveInterval = None` a tools/call longer than that lost its reply:
+  // the stream ended replyless, HTTP 200, and the client saw only its own request timeout.
+  "Bun idleTimeout" should "not cut a quiet legacy POST SSE stream before a 14 s tool reply (keepAliveInterval None)" in {
+    val checked = for
+      _ <- idleTimeoutServer()
+      initResp <- fetchAt(
+        idleTimeoutPort,
+        js.Dynamic.literal(method = "POST", headers = jsonHeaders(), body = legacyInitBody)
+      )
+      sid = header(initResp, "mcp-session-id").getOrElse("")
+      _ <- text(initResp)
+      initialized <- fetchAt(
+        idleTimeoutPort,
+        js.Dynamic.literal(
+          method = "POST",
+          headers = jsonHeaders("mcp-session-id" -> sid),
+          body = """{"jsonrpc":"2.0","method":"notifications/initialized"}"""
+        )
+      )
+      started = java.lang.System.currentTimeMillis()
+      body <- withTimeout(
+        fetchAt(
+          idleTimeoutPort,
+          js.Dynamic.literal(
+            method = "POST",
+            headers = jsonHeaders("mcp-session-id" -> sid),
+            body =
+              s"""{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"sleep","arguments":{"millis":$slowReplyMs}}}"""
+          )
+        ).flatMap(text)
+          // Bun's idle close cuts the socket mid-chunked-body, so the client's `text()` rejects
+          // rather than ending cleanly: fold that into the body so the clue below reports WHEN.
+          .recover { case e => s"<stream failed: ${e.getMessage}>" },
+        slowReplyMs + 10000,
+        s"legacy sleep ${slowReplyMs}ms"
+      )
+      elapsedMs = java.lang.System.currentTimeMillis() - started
+    yield
+      status(initResp) shouldBe 200
+      status(initialized) shouldBe 202
+      withClue(
+        s"stream ended after ${elapsedMs}ms with body: ${body.replace("\n", "\\n")}\n"
+      ) {
+        body should include("event: message")
+        body should include(s"\"slept $slowReplyMs\"")
       }
     checked
   }

--- a/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerHttpTest.scala
+++ b/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerHttpTest.scala
@@ -86,11 +86,26 @@ class JsServerHttpTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAl
 
   override def afterAll(): Unit =
     if bunServer != null then bunServer.stop()
+    keepAliveHandle.foreach(_.stop())
     super.afterAll()
 
   private def delay(ms: Int): Future[Unit] =
     val promise = Promise[Unit]()
     val _ = js.timers.setTimeout(ms.toDouble)(promise.success(()))
+    promise.future
+
+  /** Fail `f` with a clear message instead of hanging the suite when a stream never closes. */
+  private def withTimeout[A](f: Future[A], ms: Int, what: String): Future[A] =
+    val promise = Promise[A]()
+    val timer = js.timers.setTimeout(ms.toDouble) {
+      val _ = promise.tryFailure(
+        new java.util.concurrent.TimeoutException(s"$what did not complete within ${ms}ms")
+      )
+    }
+    f.onComplete { result =>
+      js.timers.clearTimeout(timer)
+      val _ = promise.tryComplete(result)
+    }
     promise.future
 
   private def text(resp: js.Dynamic): Future[String] =
@@ -1002,31 +1017,71 @@ class JsServerHttpTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAl
     done.andThen { case _ => taskBunServer.stop() }
   }
 
-  "runHttp (stateless keepalive)" should "emit pings on a quiet modern POST SSE stream" in {
-    val kaPort = 38923
-    val server = com.tjclp.fastmcp.server.McpServer(
-      "JsHttpKeepaliveServer",
-      "0.1.0",
-      McpServerSettings(
-        host = "127.0.0.1",
-        port = kaPort,
-        httpEndpoint = "/mcp",
-        stateless = true,
-        keepAliveInterval = Some(java.time.Duration.ofMillis(50))
-      )
-    )
-    val slowProgressTool = McpTool
-      .withSchema[PingArgs, String](
-        name = "slow-progress",
-        inputSchema = pingSchema,
-        description = Some("Reports progress, then sleeps")
-      )
-      .contextual { (_, ctx) =>
-        // The early notification opens the SSE stream; the sleep leaves it quiet for pings.
-        ZIO.foreachDiscard(ctx.get.progressToken)(t => ctx.get.sendProgress(t, 0.5)) *>
-          ZIO.sleep(30.seconds).as("done")
-      }
+  // --- keepalive: one stateful server (legacy sessions AND modern POSTs) shared by the tests below ---
 
+  case class SleepArgs(millis: Int)
+  given JsonDecoder[SleepArgs] = DeriveJsonDecoder.gen[SleepArgs]
+
+  private val sleepSchema = ToolInputSchema.unsafeFromJsonString(
+    """{"type":"object","properties":{"millis":{"type":"integer"}},"required":["millis"]}"""
+  )
+
+  /** Heartbeat period of the shared keepalive server. The `sleep` tool below is called with N and
+    * 3N so its reply lands ON a heartbeat tick.
+    */
+  private val keepAliveMs = 150
+  private val keepAlivePort = 38923
+
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  private var keepAliveHandle: Option[BunHttpHandle] = None
+
+  private def keepAliveServer(): Future[BunHttpHandle] =
+    keepAliveHandle match
+      case Some(handle) => Future.successful(handle)
+      case None =>
+        val server = com.tjclp.fastmcp.server.McpServer(
+          "JsHttpKeepaliveServer",
+          "0.1.0",
+          McpServerSettings(
+            host = "127.0.0.1",
+            port = keepAlivePort,
+            httpEndpoint = "/mcp",
+            stateless = false,
+            keepAliveInterval = Some(java.time.Duration.ofMillis(keepAliveMs.toLong))
+          )
+        )
+        val slowProgressTool = McpTool
+          .withSchema[PingArgs, String](
+            name = "slow-progress",
+            inputSchema = pingSchema,
+            description = Some("Reports progress, then sleeps")
+          )
+          .contextual { (_, ctx) =>
+            // The early notification opens the SSE stream; the sleep leaves it quiet for pings.
+            ZIO.foreachDiscard(ctx.get.progressToken)(t => ctx.get.sendProgress(t, 0.5)) *>
+              ZIO.sleep(30.seconds).as("done")
+          }
+        // Sleeps exactly `millis`, so with a multiple of `keepAliveMs` the reply is offered in the
+        // same tick as a heartbeat. Given a progress token it first emits a notification, which
+        // makes the reply the stream's SECOND frame — the only shape in which a modern POST (whose
+        // first frame is taken before the SSE response exists) is exposed to the keepalive path.
+        val sleepTool = McpTool
+          .withSchema[SleepArgs, String](
+            name = "sleep",
+            inputSchema = sleepSchema,
+            description = Some("Sleeps for millis, then replies")
+          )
+          .contextual { (args, ctx) =>
+            ZIO.foreachDiscard(ctx.get.progressToken)(t => ctx.get.sendProgress(t, 0.0)) *>
+              ZIO.sleep(args.millis.millis).as(s"slept ${args.millis}")
+          }
+        runZio(server.tool(slowProgressTool) *> server.tool(sleepTool).unit).map { _ =>
+          val handle = server.startStatefulHttp()
+          keepAliveHandle = Some(handle)
+          handle
+        }
+
+  "runHttp (keepalive)" should "emit pings on a quiet modern POST SSE stream" in {
     def readUntilPing(reader: js.Dynamic, acc: String, remaining: Int): Future[String] =
       if acc.contains("ping") || remaining <= 0 then Future.successful(acc)
       else
@@ -1040,35 +1095,112 @@ class JsServerHttpTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAl
             readUntilPing(reader, acc + piece, remaining - 1)
         }
 
-    runZio(server.tool(slowProgressTool).unit).flatMap { _ =>
-      val bun = server.startStatelessHttp()
-      val checked = for
-        resp <- fromJsPromise(
-          js.Dynamic.global
-            .fetch(
-              s"http://127.0.0.1:$kaPort/mcp",
-              js.Dynamic.literal(
-                method = "POST",
-                headers = js.Dictionary(
-                  "content-type" -> "application/json",
-                  "accept" -> "application/json, text/event-stream",
-                  "mcp-protocol-version" -> "2026-07-28",
-                  "mcp-method" -> "tools/call",
-                  "mcp-name" -> "slow-progress"
-                ),
-                body =
-                  """{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"slow-progress","arguments":{"msg":"hi"},"_meta":{"progressToken":"kp","io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}"""
-              )
-            )
-            .asInstanceOf[js.Promise[js.Dynamic]]
+    keepAliveServer().flatMap { _ =>
+      for
+        resp <- fetchAt(
+          keepAlivePort,
+          js.Dynamic.literal(
+            method = "POST",
+            headers = jsonHeaders(
+              "mcp-protocol-version" -> "2026-07-28",
+              "mcp-method" -> "tools/call",
+              "mcp-name" -> "slow-progress"
+            ),
+            body =
+              """{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"slow-progress","arguments":{"msg":"hi"},"_meta":{"progressToken":"kp","io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}"""
+          )
         )
         reader = resp.body.getReader()
         seen <- readUntilPing(reader, "", remaining = 40)
       yield
         val _ = reader.cancel()
         seen should include("ping")
-      checked.andThen { case _ => bun.stop() }
     }
+  }
+
+  // TJC-2337: a `take.timeout(interval)` keepalive interrupted a take whose promise already held the
+  // reply; the next pull then took the close sentinel and the stream ended as pings-only, HTTP 200.
+  it should "deliver the reply when the tool completes on a heartbeat tick (legacy + modern, N and 3N)" in {
+    val callTimeoutMs = 10 * keepAliveMs + 5000
+
+    // Legacy: plain per-request SSE, the reply is frame 1 (the D4 dogfood repro shape).
+    def legacyCall(sid: String, id: Int, millis: Int): Future[String] =
+      fetchAt(
+        keepAlivePort,
+        js.Dynamic.literal(
+          method = "POST",
+          headers = jsonHeaders("mcp-session-id" -> sid),
+          body =
+            s"""{"jsonrpc":"2.0","id":$id,"method":"tools/call","params":{"name":"sleep","arguments":{"millis":$millis}}}"""
+        )
+      ).flatMap(text)
+
+    // Modern: the progress token makes the reply frame 2, i.e. taken under the keepalive path.
+    def modernCall(id: Int, millis: Int): Future[String] =
+      fetchAt(
+        keepAlivePort,
+        js.Dynamic.literal(
+          method = "POST",
+          headers = jsonHeaders(
+            "mcp-protocol-version" -> "2026-07-28",
+            "mcp-method" -> "tools/call",
+            "mcp-name" -> "sleep"
+          ),
+          body =
+            s"""{"jsonrpc":"2.0","id":$id,"method":"tools/call","params":{"name":"sleep","arguments":{"millis":$millis},"_meta":{"progressToken":"tick-$id","io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}"""
+        )
+      ).flatMap(text)
+
+    // One stream at a time per lane, like a client awaiting a slow tool; legacy and modern lanes
+    // run side by side.
+    def lane(label: String, n: Int)(call: Int => Future[String]): Future[List[String]] =
+      (1 to n).foldLeft(Future.successful(List.empty[String])) { (acc, i) =>
+        acc.flatMap(bodies =>
+          withTimeout(call(i), callTimeoutMs, s"$label call $i").map(bodies :+ _)
+        )
+      }
+
+    def delivered(label: String, bodies: List[String]): String =
+      val ok = bodies.count(b => b.contains("event: message") && b.contains("\"slept "))
+      s"$label: $ok/${bodies.size} replies delivered"
+
+    val labels = List(
+      s"legacy sleep ${keepAliveMs}ms",
+      s"modern sleep ${keepAliveMs}ms",
+      s"legacy sleep ${3 * keepAliveMs}ms",
+      s"modern sleep ${3 * keepAliveMs}ms"
+    )
+
+    val checked = for
+      _ <- keepAliveServer()
+      initResp <- fetchAt(
+        keepAlivePort,
+        js.Dynamic.literal(method = "POST", headers = jsonHeaders(), body = legacyInitBody)
+      )
+      sid = header(initResp, "mcp-session-id").getOrElse("")
+      _ <- text(initResp)
+      initialized <- fetchAt(
+        keepAlivePort,
+        js.Dynamic.literal(
+          method = "POST",
+          headers = jsonHeaders("mcp-session-id" -> sid),
+          body = """{"jsonrpc":"2.0","method":"notifications/initialized"}"""
+        )
+      )
+      onTick <- lane(labels(0), 20)(i => legacyCall(sid, 100 + i, keepAliveMs))
+        .zip(lane(labels(1), 20)(i => modernCall(200 + i, keepAliveMs)))
+      thirdTick <- lane(labels(2), 20)(i => legacyCall(sid, 300 + i, 3 * keepAliveMs))
+        .zip(lane(labels(3), 20)(i => modernCall(400 + i, 3 * keepAliveMs)))
+    yield
+      status(initResp) shouldBe 200
+      status(initialized) shouldBe 202
+      val streams = List(onTick._1, onTick._2, thirdTick._1, thirdTick._2)
+      val summary = labels.zip(streams).map(delivered)
+      val firstLost = streams.flatten.find(b => !b.contains("event: message"))
+      withClue(s"first reply-less stream: ${firstLost.map(_.replace("\n", "\\n"))}\n") {
+        summary shouldBe labels.map(l => s"$l: 20/20 replies delivered")
+      }
+    checked
   }
 
   "runHttp (stateless tasks)" should "refuse legacy task augmentation on the shared stateless session" in {


### PR DESCRIPTION
## What / why

On the Scala.js/Bun HTTP backend with `keepAliveInterval` set, `JsTransportBackend.sseResponse` implemented the heartbeat as `reqQueue.take.timeout(interval)`. When the tool reply landed in the same tick as the timeout, the interrupt discarded a `take` whose promise already held the reply; the next pull took the close sentinel and the stream ended as `: ping` frames only — HTTP 200, nothing logged. Dogfood finding D4.9: 10/10 replies lost when the handler ran for exactly one interval, ~20% at three; legacy per-request streams were exposed from frame 1, modern 2026-07-28 streams from frame 2. The JVM backend was immune (`sse.mergeHaltLeft(pings)`).

**Fix.** The heartbeat is now a daemon fiber that offers a `KeepAliveSentinel` into `reqQueue` on a `sleep *> offer` loop — the Bun twin of the JVM stream merge, and the same sleep-loop shape as the idle-session sweeper (no `Schedule` on Scala.js). The pull stays a plain `take` and emits `: ping` for the sentinel. The fiber is interrupted when the stream closes (final reply / close sentinel), when the client cancels, and when a pull fails; an offer into an already shut-down queue interrupts it on its own. `sseResponse` becomes `UIO[js.Dynamic]` so it can fork; both callers thread the effect. The modern first-frame hold (D3.4 / D4.8, a 1.0.1 item) is neither fixed nor worsened: the heartbeat starts exactly where the timed take used to start, after the first frame has been taken.

**Regression test** (`JsServerHttpTest`): the keepalive tests now share one stateful Bun server (legacy sessions + modern POSTs, `keepAliveInterval = 150 ms`, port 38923, stopped in `afterAll`) with a `sleep` tool that completes exactly on a heartbeat tick. Twenty legacy and twenty modern streams at N and at 3N must each carry the `event: message` reply frame. The legacy lane is the D4 repro shape (reply = frame 1); the modern lane sends a progress token so the reply is frame 2, the only shape in which a modern POST reaches the keepalive path.

## Canary — RED on main's code (commit e2cc578)

```
- should deliver the reply when the tool completes on a heartbeat tick (legacy + modern, N and 3N) *** FAILED ***
  first reply-less stream: Some(: ping\n\n)
  List("legacy sleep 150ms: 0/20 replies delivered", "modern sleep 150ms: 0/20 replies delivered", "legacy sleep 450ms: 16/20 replies delivered", "modern sleep 450ms: 16/20 replies delivered") was not equal to List("legacy sleep 150ms: 20/20 replies delivered", "modern sleep 150ms: 20/20 replies delivered", "legacy sleep 450ms: 20/20 replies delivered", "modern sleep 450ms: 20/20 replies delivered") (JsServerHttpTest.scala:1201)
```

GREEN with the fix (efcaa06): 33/33 in `JsServerHttpTest`; 71/71 across `fast-mcp-scala.js.test` (the regression ran twice).

## Verification

| Gate | Command | Result |
|---|---|---|
| Format | `./mill --no-server fast-mcp-scala.checkFormat` | pass |
| Compile (Scala.js) | `./mill --no-server fast-mcp-scala.js.compile` | pass |
| RED (test commit only) | `./mill --no-server fast-mcp-scala.js.test.testOnly com.tjclp.fastmcp.conformance.JsServerHttpTest` @ e2cc578 | 1 failed / 32 passed — text above |
| GREEN | same @ efcaa06 | 33 passed / 0 failed |
| Bun test suites | `./mill --no-server fast-mcp-scala.js.test` | 71 passed / 0 failed |
| Conformance (Bun) | `scripts/conformance.sh js 8077 active` | 73 passed, 0 failed; baseline check passed |
| Path scrub | `git grep -nE '/Users/\|/private/tmp\|claude-501\|1\.0\.0-dogfood' -- . ':(exclude)out'` | empty |

Only `js/` sources and the CHANGELOG change; the JVM and Scala Native suites run in CI.

CHANGELOG: `[Unreleased] ### Fixed` bullet.

Linear: https://linear.app/tjc-technologies/issue/TJC-2337/fast-mcp-scala-bun-sse-keepalive-tick-coinciding-with-the-tool-reply

Merge with a MERGE COMMIT (never squash); part of the pre-v1.0.0 stack, see TJC-2326

🤖 Generated with [Claude Code](https://claude.com/claude-code)
