### PR TITLE
fix(macros): apply Scala default arguments; @Param no longer re-requires Option (TJC-2334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,6 +276,26 @@ Security-hardening wave (TJC-2294; findings F1–F12 of the 2026-09-04 scan). Um
 
 ### Fixed
 
+- **Scala default arguments are applied on the annotation path** (TJC-2334): a `tools/call` or
+  `prompts/get` that omits a parameter declared with a default (`operation: String = "add"`,
+  `title: String = ""`) now invokes the method with that default — exactly what a direct Scala
+  call does — instead of failing with `Key not found in map: <param>` (`isError: true` on tools,
+  `-32603` on prompts). The generated handler resolves the compiler's `<method>$default$N` getter
+  for every parameter flagged `HasDefault` on the annotated method itself, so the flagship
+  `AnnotatedServer.calculator` / `greeting_prompt` and the README `search` / `greeting` examples
+  work as documented on JVM, Scala.js/Bun and Scala Native. An omitted `Option` parameter with a
+  non-`None` default now also takes that default (previously `None`). An omitted parameter without
+  a default fails with `Missing required argument '<param>'`, naming the argument, in the same
+  place as before (an `isError` tool result; `-32602` on prompts and resources).
+- **`@Param` no longer re-requires `Option` parameters** (TJC-2334): a description-only
+  `@Param("Maximum results") limit: Option[Int]` used to land in the advertised `required` array
+  (the bare parameter was optional, the annotated one was not). `required` now defaults to
+  `!isOption` for `@Tool` parameters, typed-request case-class fields and `@Prompt` arguments
+  (whose `Option` parameters were advertised `required: true` even without `@Param`); only an
+  explicit `@Param(required = true)` re-requires an `Option`. Existing `required = false` spellings
+  keep working.
+- **Prompt failures carry their cause** (TJC-2334): the `-32603` for a failing `@Prompt` handler
+  reads `Error rendering prompt '<name>': <cause message>` instead of swallowing the cause.
 - **Annotation macros bind to the annotated overload** (F4 / CWE-706, TJC-2298): `scanAnnotations`
   used to re-resolve `@Tool` / `@Resource` / `@Prompt` targets by method name and could register,
   schema-describe and invoke a different same-named overload (for example an un-annotated raw

--- a/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/macros/DefaultArgumentsJsTest.scala
+++ b/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/macros/DefaultArgumentsJsTest.scala
@@ -1,0 +1,82 @@
+package com.tjclp.fastmcp.macros
+
+import org.scalatest.funsuite.AnyFunSuite
+import zio.*
+import zio.json.*
+import zio.json.ast.Json
+
+import com.tjclp.fastmcp.{*, given}
+
+/** Scala.js mirror of the JVM `DefaultArgumentsTest` (TJC-2334; D1.50, D1.51): the same macro
+  * expansion must apply Scala default arguments for an omitted `tools/call` / `prompts/get`
+  * parameter under Bun, and a description-only `@Param` on an `Option` parameter must not land in
+  * the advertised `required` array.
+  */
+class DefaultArgumentsJsTest extends AnyFunSuite:
+
+  object DefaultsJsTools:
+
+    @Tool(name = Some("with_default"))
+    def withDefault(
+        @Param("First") a: Int,
+        @Param("Suffix", required = false) s: String = "x"
+    ): String = s"$a:$s"
+
+    @Tool(name = Some("opt_param"))
+    def optParam(
+        @Param("Label") label: String,
+        @Param("Optional note") note: Option[String]
+    ): String = s"$label:${note.getOrElse("none")}"
+
+    @Prompt(name = Some("default_prompt"))
+    def defaultPrompt(
+        @Param("Name") name: String,
+        @Param("Greeting", required = false) greeting: String = "Hello"
+    ): String = s"$greeting, $name"
+
+  private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
+    Unsafe.unsafe { implicit unsafe =>
+      Runtime.default.unsafe.run(effect).getOrThrowFiberFailure()
+    }
+
+  private def requiredOf(server: McpServer[Any], tool: String): List[String] =
+    val toolDef = server.toolManager.getToolDefinition(tool)
+    assert(toolDef.isDefined, s"tool '$tool' should be registered")
+    toolDef.get.inputSchema.toJsonString
+      .fromJson[Json]
+      .toOption
+      .flatMap(_.asObject)
+      .flatMap(_.get("required"))
+      .flatMap(_.as[List[String]].toOption)
+      .getOrElse(Nil)
+
+  test("an omitted `required = false` parameter with a default takes the Scala default under Scala.js") {
+    val server = McpServer("DefaultsJs")
+    val _ = server.scanAnnotations[DefaultsJsTools.type]
+
+    assert(!requiredOf(server, "with_default").contains("s"))
+    assert(runUnsafe(server.toolManager.callTool("with_default", Map("a" -> 2), None)) == "2:x")
+  }
+
+  test("a description-only @Param on an Option parameter is not required under Scala.js") {
+    val server = McpServer("OptionJs")
+    val _ = server.scanAnnotations[DefaultsJsTools.type]
+
+    val required = requiredOf(server, "opt_param")
+    assert(!required.contains("note"), s"Option parameter 'note' must not be required: $required")
+    assert(required.contains("label"), s"non-Option parameter 'label' stays required: $required")
+    assert(runUnsafe(server.toolManager.callTool("opt_param", Map("label" -> "l"), None)) == "l:none")
+  }
+
+  test("an omitted `required = false` prompt argument with a default takes the Scala default under Scala.js") {
+    val server = McpServer("PromptDefaultsJs")
+    val _ = server.scanAnnotations[DefaultsJsTools.type]
+
+    val messages = runUnsafe(
+      server.promptManager.getPrompt("default_prompt", Map("name" -> "Ada"), None)
+    )
+    val text = messages.head.content match
+      case TextContent(t, _, _) => t
+      case other => fail(s"expected TextContent, got $other")
+    assert(text == "Hello, Ada")
+  }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/DefaultArgumentsTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/DefaultArgumentsTest.scala
@@ -1,0 +1,194 @@
+package com.tjclp.fastmcp
+package macros
+
+import org.scalatest.funsuite.AnyFunSuite
+import zio.*
+import zio.json.ast.Json
+
+import com.tjclp.fastmcp.JsonTestSupport.*
+import com.tjclp.fastmcp.core.*
+import com.tjclp.fastmcp.examples.AnnotatedServer
+import com.tjclp.fastmcp.macros.RegistrationMacro.scanAnnotations
+import com.tjclp.fastmcp.server.*
+import com.tjclp.fastmcp.server.transport.JvmTransportBackend.given
+
+/** Scala default arguments are applied when a `tools/call` / `prompts/get` omits the parameter, and
+  * `@Param` on an `Option[T]` parameter no longer re-requires it (TJC-2334; D1.14–D1.17, D1.29).
+  *
+  * Before the fix the generated `Map[String, Any] => R` handler threw `Key not found in map: <param>`
+  * for every omitted parameter — including the ones the advertised schema itself marked optional —
+  * and a description-only `@Param` flipped an `Option` parameter back into `required`.
+  */
+class DefaultArgumentsTest extends AnyFunSuite:
+
+  private def runUnsafe[A](effect: ZIO[Any, Throwable, A]): A =
+    Unsafe.unsafe { implicit unsafe =>
+      Runtime.default.unsafe.run(effect).getOrThrowFiberFailure()
+    }
+
+  private def failureOf[A](effect: ZIO[Any, Throwable, A]): Throwable =
+    runUnsafe(effect.either) match
+      case Left(t) => t
+      case Right(v) => fail(s"expected a failure, got $v")
+
+  private def requiredOf(server: McpServer[Any], tool: String): List[String] =
+    val toolDef = server.toolManager.getToolDefinition(tool)
+    assert(toolDef.isDefined, s"tool '$tool' should be registered")
+    val schemaJson = parse(toolDef.get.inputSchema.toJsonString).getOrElse(Json.Null)
+    schemaJson.hcursor.downField("required").as[List[String]].getOrElse(Nil)
+
+  private def promptArg(server: McpServer[Any], prompt: String, arg: String): PromptArgument =
+    val definition = server.promptManager.getPromptDefinition(prompt)
+    assert(definition.isDefined, s"prompt '$prompt' should be registered")
+    definition.get.arguments.getOrElse(Nil).find(_.name == arg) match
+      case Some(a) => a
+      case None => fail(s"prompt '$prompt' should advertise argument '$arg'")
+
+  private def promptText(messages: List[Message]): String =
+    messages.head.content match
+      case TextContent(text, _, _) => text
+      case other => fail(s"expected TextContent, got $other")
+
+  // ---- flagship example (D1.16, D1.17) ----
+
+  test("AnnotatedServer.calculator applies the `operation` default when the argument is omitted") {
+    val server = McpServer("CalculatorDefault")
+    val _ = server.scanAnnotations[AnnotatedServer.type]
+
+    val result = runUnsafe(
+      server.toolManager.callTool("calculator", Map("a" -> 1.0, "b" -> 2.0), None)
+    )
+    val text = result.toString
+    assert(text.contains("\"add\""), s"expected the default operation 'add', got: $text")
+    assert(text.contains("3.0"), s"expected 1.0 + 2.0 = 3.0, got: $text")
+  }
+
+  test("AnnotatedServer.greeting_prompt applies the `title` default when the argument is omitted") {
+    val server = McpServer("GreetingDefault")
+    val _ = server.scanAnnotations[AnnotatedServer.type]
+
+    val messages = runUnsafe(
+      server.promptManager.getPrompt("greeting_prompt", Map("name" -> "Ada"), None)
+    )
+    assert(promptText(messages) == "Generate a warm greeting for Ada.")
+  }
+
+  // ---- tools (D1.15) ----
+
+  test("an omitted `required = false` parameter with a default takes the Scala default") {
+    val server = McpServer("ToolDefaults")
+    val _ = server.scanAnnotations[DefaultArgumentsTest.Fixture.type]
+
+    assert(!requiredOf(server, "with_default").contains("s"))
+    assert(runUnsafe(server.toolManager.callTool("with_default", Map("a" -> 1), None)) == "1:x")
+    assert(
+      runUnsafe(server.toolManager.callTool("with_default", Map("a" -> 1, "s" -> "y"), None)) ==
+        "1:y"
+    )
+  }
+
+  test("an omitted parameter without a default fails with a message naming the argument") {
+    val server = McpServer("ToolMissing")
+    val _ = server.scanAnnotations[DefaultArgumentsTest.Fixture.type]
+
+    val err = failureOf(server.toolManager.callTool("with_default", Map("s" -> "y"), None))
+    val message = Option(err.getMessage).getOrElse("")
+    assert(
+      message.contains("Missing required argument 'a'"),
+      s"expected the failure to name the missing argument, got: $message"
+    )
+  }
+
+  test("an omitted Option parameter with a non-None default takes the Scala default") {
+    val server = McpServer("OptionDefault")
+    val _ = server.scanAnnotations[DefaultArgumentsTest.Fixture.type]
+
+    assert(runUnsafe(server.toolManager.callTool("opt_default", Map.empty, None)) == "7")
+    assert(runUnsafe(server.toolManager.callTool("opt_default", Map("x" -> 3), None)) == "3")
+  }
+
+  // ---- Option semantics (D1.14) ----
+
+  test("a description-only @Param on an Option parameter does not re-require it") {
+    val server = McpServer("OptionParam")
+    val _ = server.scanAnnotations[DefaultArgumentsTest.Fixture.type]
+
+    val required = requiredOf(server, "opt_param")
+    assert(!required.contains("x"), s"Option parameter 'x' must not be required, got: $required")
+    assert(required.contains("label"), s"non-Option parameter 'label' stays required: $required")
+    assert(runUnsafe(server.toolManager.callTool("opt_param", Map("label" -> "l"), None)) == "l:none")
+  }
+
+  test("an explicit @Param(required = true) re-requires an Option parameter") {
+    val server = McpServer("OptionRequired")
+    val _ = server.scanAnnotations[DefaultArgumentsTest.Fixture.type]
+
+    val required = requiredOf(server, "opt_required")
+    assert(required.contains("x"), s"explicit required = true must win, got: $required")
+  }
+
+  // ---- prompts (D1.17, D1.29) ----
+
+  test("an omitted `required = false` prompt argument with a default takes the Scala default") {
+    val server = McpServer("PromptDefaults")
+    val _ = server.scanAnnotations[DefaultArgumentsTest.Fixture.type]
+
+    assert(!promptArg(server, "default_prompt", "greeting").required)
+    val messages = runUnsafe(
+      server.promptManager.getPrompt("default_prompt", Map("name" -> "Ada"), None)
+    )
+    assert(promptText(messages) == "Hello, Ada")
+  }
+
+  test("an Option prompt argument is optional with and without a description-only @Param") {
+    val server = McpServer("PromptOption")
+    val _ = server.scanAnnotations[DefaultArgumentsTest.Fixture.type]
+
+    assert(!promptArg(server, "opt_prompt", "who").required)
+    assert(!promptArg(server, "bare_opt_prompt", "who").required)
+    assert(promptArg(server, "opt_prompt", "salutation").required)
+
+    val messages = runUnsafe(
+      server.promptManager.getPrompt("opt_prompt", Map("salutation" -> "hi"), None)
+    )
+    assert(promptText(messages) == "hi anon")
+  }
+
+object DefaultArgumentsTest:
+
+  object Fixture:
+
+    @Tool(name = Some("with_default"))
+    def withDefault(
+        @Param("First") a: Int,
+        @Param("Suffix", required = false) s: String = "x"
+    ): String = s"$a:$s"
+
+    @Tool(name = Some("opt_param"))
+    def optParam(
+        @Param("Label") label: String,
+        @Param("Optional count") x: Option[Int]
+    ): String = s"$label:${x.fold("none")(_.toString)}"
+
+    @Tool(name = Some("opt_required"))
+    def optRequired(@Param("Count", required = true) x: Option[Int]): String =
+      x.fold("none")(_.toString)
+
+    @Tool(name = Some("opt_default"))
+    def optDefault(@Param("Count", required = false) x: Option[Int] = Some(7)): String =
+      x.fold("none")(_.toString)
+
+    @Prompt(name = Some("default_prompt"))
+    def defaultPrompt(
+        @Param("Name") name: String,
+        @Param("Greeting", required = false) greeting: String = "Hello"
+    ): String = s"$greeting, $name"
+
+    @Prompt(name = Some("opt_prompt"))
+    def optPrompt(
+        @Param("Salutation") salutation: String,
+        @Param("Who") who: Option[String]
+    ): String = s"$salutation ${who.getOrElse("anon")}"
+
+    @Prompt(name = Some("bare_opt_prompt"))
+    def bareOptPrompt(who: Option[String]): String = s"hi ${who.getOrElse("anon")}"

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/MapToFunctionMacroSimpleTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/MapToFunctionMacroSimpleTest.scala
@@ -30,7 +30,7 @@ class MapToFunctionMacroSimpleTest extends AnyFunSuite with Matchers {
       mapFunction.asInstanceOf[Map[String, Any] => String](Map.empty)
     }
 
-    exception.getMessage should include("Key not found in map")
+    exception.getMessage should include("Missing required argument 'name'")
   }
 
   // Test for error handling with incorrect parameter types

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/MapToFunctionMacroTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/macros/MapToFunctionMacroTest.scala
@@ -177,7 +177,7 @@ class MapToFunctionMacroTest extends AnyFunSuite with Matchers {
       mapFunction.asInstanceOf[Map[String, Any] => String](Map.empty)
     }
 
-    exception.getMessage should include("Key not found in map")
+    exception.getMessage should include("Missing required argument 'name'")
   }
 
   // Test for error handling with incorrect parameter types

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/core/Annotations.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/core/Annotations.scala
@@ -82,7 +82,11 @@ class Tool(
   * @param examples
   *   List of example values for the parameter (follows JSON Schema specification)
   * @param required
-  *   Whether the parameter is required (defaults to true)
+  *   Whether the parameter is required. When not written, a non-`Option` parameter is required and
+  *   an `Option[T]` parameter is optional (the same rule the derived schema applies without
+  *   `@Param`); an explicit `required = true` re-requires an `Option`, and `required = false` is
+  *   accepted only on an `Option` or on a parameter with a default value — an omitted argument then
+  *   takes the Scala default (or `None`) when the tool or prompt is called
   * @param schema
   *   Optional JSON schema override for the parameter type. Literal values only (`Some("...")` /
   *   `None` / a `final val`); a non-literal argument is a compile-time error.

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/MacroUtils.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/MacroUtils.scala
@@ -154,16 +154,21 @@ private[macros] object MacroUtils:
     }
     (promptName, promptDesc)
 
-  // Helper to parse @Param annotation arguments for prompts
+  /** Parse the `@Param` annotation of a `@Prompt` method parameter into `(description, required)`.
+    *
+    * `required` defaults to `!isOptionType`: an `Option[T]` parameter is optional whether or not it
+    * carries a `@Param`, and only an explicit `required = true` re-requires it (TJC-2334).
+    */
   def parsePromptParamArgs(using quotes: Quotes)(
-      paramAnnotOpt: Option[quotes.reflect.Term]
+      paramAnnotOpt: Option[quotes.reflect.Term],
+      isOptionType: Boolean
   ): (Option[String], Boolean) =
     import quotes.reflect.*
 
     paramAnnotOpt match {
       case Some(annotTerm) =>
         var paramDesc: Option[String] = None
-        var paramRequired: Boolean = true // Default required for @Param
+        var paramRequired: Boolean = !isOptionType // Option parameters are optional by default
         var descriptionSetPositionally = false
         var requiredSetByName = false
 
@@ -199,7 +204,7 @@ private[macros] object MacroUtils:
           case _ => () // Ignore if annotation term is not an Apply
         }
         (paramDesc, paramRequired)
-      case None => (None, true) // Defaults if no @Param
+      case None => (None, !isOptionType) // Defaults if no @Param
     }
 
   /** Extract the `@Param` annotation from a method parameter symbol, if present. */
@@ -208,10 +213,16 @@ private[macros] object MacroUtils:
   ): Option[quotes.reflect.Term] =
     extractAnnotation[com.tjclp.fastmcp.core.Param](sym)
 
-  // Helper to parse @Param annotation arguments for @Tool methods
-  // Returns: (description: Option[String], examples: List[String], required: Boolean, schema: Option[String])
+  /** Parse the `@Param` annotation of a `@Tool` method parameter or a typed-request case-class
+    * field into `(description, examples, required, schema)`.
+    *
+    * `required` defaults to `!isOptionType`, matching the derived schema (`JsonSchemaMacro` lists
+    * every non-`Option` parameter in `required`): a description-only `@Param` on an `Option[T]`
+    * parameter no longer re-requires it, and only an explicit `required = true` does (TJC-2334).
+    */
   def parseToolParam(using quotes: Quotes)(
-      paramAnnotOpt: Option[quotes.reflect.Term]
+      paramAnnotOpt: Option[quotes.reflect.Term],
+      isOptionType: Boolean
   ): (Option[String], List[String], Boolean, Option[String]) =
     import quotes.reflect.*
 
@@ -219,7 +230,7 @@ private[macros] object MacroUtils:
       case Some(annotTerm) =>
         var paramDesc: Option[String] = None
         var paramExamples: List[String] = Nil
-        var paramRequired: Boolean = true // Default required for @Param
+        var paramRequired: Boolean = !isOptionType // Option parameters are optional by default
         var paramSchema: Option[String] = None
         var examplesSetByName = false
         var requiredSetByName = false
@@ -277,7 +288,7 @@ private[macros] object MacroUtils:
           case _ => () // Ignore if annotation term is not an Apply
         }
         (paramDesc, paramExamples, paramRequired, paramSchema)
-      case None => (None, Nil, true, None) // Defaults if no @Param
+      case None => (None, Nil, !isOptionType, None) // Defaults if no @Param
     }
 
   def schemaMetadataForType[T: Type](using Quotes): Expr[SchemaMetadataNode] =
@@ -325,9 +336,9 @@ private[macros] object MacroUtils:
             val fieldTpe = tpe.memberType(fieldSym)
             val nested = schemaMetadataForTypeRepr(fieldTpe)
             val parsedMeta = fieldAnnotation(fieldSym, ctorParams).map { annot =>
-              val (desc, examples, required, schema) = parseToolParam(Some(annot))
+              val isOption = fieldTpe <:< TypeRepr.of[Option[?]]
+              val (desc, examples, required, schema) = parseToolParam(Some(annot), isOption)
               if !required then
-                val isOption = fieldTpe <:< TypeRepr.of[Option[?]]
                 // `HasDefault` lives on the primary-constructor parameter itself (pickled), so a
                 // hand-written companion `apply` overload with defaults can no longer satisfy the
                 // gate on behalf of a field that has none.

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/MapToFunctionMacro.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/MapToFunctionMacro.scala
@@ -78,6 +78,67 @@ object MapToFunctionMacro:
         meth.symbol.paramSymss.headOption.map(_.map(_.name))
       case _ => None
 
+    /** The user-written method a (possibly eta-expanded) reference denotes. An eta-expansion is
+      * `Block(List(DefDef($anonfun, _, _, Some(Apply(Select(qual, m), args)))),
+      * Closure(Ident($anonfun)))` — the shape [[MacroUtils.getMethodRefExpr]] emits and the
+      * compiler produces for a bare `callByMap(m)` — so the callee is read off the synthetic
+      * method's body; a direct `Ident` / `Select` of a method is taken as is. `None` for lambdas
+      * and other function values.
+      */
+    def underlyingMethod(term: Term): Option[Symbol] =
+      @tailrec
+      def calleeOf(t: Term): Option[Symbol] = t match
+        case Apply(fn, _) => calleeOf(fn)
+        case TypeApply(fn, _) => calleeOf(fn)
+        case Inlined(_, _, inner) => calleeOf(inner)
+        case Typed(inner, _) => calleeOf(inner)
+        case Block(_, inner) => calleeOf(inner)
+        case s @ Select(_, _) if s.symbol.isDefDef => Some(s.symbol)
+        case i @ Ident(_) if i.symbol.isDefDef => Some(i.symbol)
+        case _ => None
+
+      term match
+        case Inlined(_, _, inner) => underlyingMethod(inner)
+        case Typed(inner, _) => underlyingMethod(inner)
+        case Block(stats, Closure(meth @ Ident(_), _)) if meth.symbol.isDefDef =>
+          stats.collectFirst { case dd: DefDef if dd.symbol == meth.symbol => dd } match
+            case Some(dd) => dd.rhs.flatMap(calleeOf)
+            case None => None
+        case Block(_, inner) => underlyingMethod(inner)
+        case ident @ Ident(_) if ident.symbol.isDefDef && !ident.symbol.flags.is(Flags.Synthetic) =>
+          Some(ident.symbol)
+        case select @ Select(_, _)
+            if select.symbol.isDefDef && !select.symbol.flags.is(Flags.Synthetic) =>
+          Some(select.symbol)
+        case _ => None
+
+    /** Scala default arguments of the denoted method's first parameter list, by parameter name: a
+      * reference to the compiler-generated `<method>$default$N` getter (`N` is the 1-based
+      * parameter position; the getter is declared next to the method, in the same class). Only
+      * parameters flagged `HasDefault` on the method's OWN symbol qualify (never a same-named
+      * sibling's getter), and only when the getter is nullary — a default in a FIRST parameter list
+      * cannot depend on other parameters, so a getter with parameters means the method is
+      * polymorphic and is left to the runtime "missing argument" failure.
+      */
+    def defaultGetters(methodSym: Symbol): Map[String, Expr[Any]] =
+      val owner = methodSym.owner
+      // Only object members: that is the sole shape `scanAnnotations` registers, and it gives the
+      // getter a stable qualifier (`Ref(module)`, `Outer.this.module` for a class-nested object).
+      if !(owner.isClassDef && owner.flags.is(Flags.Module)) then Map.empty
+      else
+        methodSym.paramSymss.headOption
+          .getOrElse(Nil)
+          .zipWithIndex
+          .flatMap {
+            case (pSym, idx) if pSym.flags.is(Flags.HasDefault) =>
+              owner.declaredMethod(s"${methodSym.name}$$default$$${idx + 1}") match
+                case getter :: Nil if getter.paramSymss.isEmpty =>
+                  Some(pSym.name -> Select(Ref(owner.companionModule), getter).asExprOf[Any])
+                case _ => None
+            case _ => None
+          }
+          .toMap
+
     def jsonDecoderToMcpDecoder[T: Type](jsonDecoderExpr: Expr[JsonDecoder[T]])(using
         Quotes
     ): Expr[McpDecoder[T]] =
@@ -168,9 +229,17 @@ object MapToFunctionMacro:
               )
             )
 
-    def buildArgConversionExpr(params: List[ParamInfo], mapExpr: Expr[Map[String, Any]])(using
-        Quotes
-    ): Expr[List[Any]] =
+    /** One decoded argument per parameter. An argument present in the map is decoded; an absent one
+      * takes the parameter's Scala default when it has one (exactly what a direct Scala call would
+      * do), an absent `Option` without a default is `None`, and anything else is a missing required
+      * argument — reported by name (a `NoSuchElementException`, which the dispatch boundary maps to
+      * `-32602` / an `isError` result).
+      */
+    def buildArgConversionExpr(
+        params: List[ParamInfo],
+        defaults: Map[String, Expr[Any]],
+        mapExpr: Expr[Map[String, Any]]
+    )(using Quotes): Expr[List[Any]] =
       Expr.ofList(params.map { p =>
         val nameExpr = Expr(p.name)
         val decoderExpr = summonDecoder(p.tpe)
@@ -178,22 +247,30 @@ object MapToFunctionMacro:
           case AppliedType(base, _) if base.typeSymbol.fullName == "scala.Option" => true
           case _ => false
 
-        if isOptionType then
-          '{
-            val key = $nameExpr
-            val rawOpt: Option[Any] = $mapExpr.get(key)
-            val raw: Any = rawOpt.getOrElse(None)
-            $decoderExpr.decode(key, raw, $contextExpr)
-          }.asExprOf[Any]
-        else
-          '{
-            val key = $nameExpr
-            val raw = $mapExpr.getOrElse(
-              key,
-              throw new NoSuchElementException("Key not found in map: " + key)
-            )
-            $decoderExpr.decode(key, raw, $contextExpr)
-          }.asExprOf[Any]
+        defaults.get(p.name) match
+          case Some(defaultExpr) =>
+            '{
+              val key = $nameExpr
+              $mapExpr.get(key) match
+                case Some(raw) => $decoderExpr.decode(key, raw, $contextExpr)
+                case None => $defaultExpr
+            }.asExprOf[Any]
+          case None if isOptionType =>
+            '{
+              val key = $nameExpr
+              val rawOpt: Option[Any] = $mapExpr.get(key)
+              val raw: Any = rawOpt.getOrElse(None)
+              $decoderExpr.decode(key, raw, $contextExpr)
+            }.asExprOf[Any]
+          case None =>
+            '{
+              val key = $nameExpr
+              val raw = $mapExpr.getOrElse(
+                key,
+                throw new NoSuchElementException("Missing required argument '" + key + "'")
+              )
+              $decoderExpr.decode(key, raw, $contextExpr)
+            }.asExprOf[Any]
       })
 
     val fnTerm = f.asTerm
@@ -202,12 +279,14 @@ object MapToFunctionMacro:
       case Some(names) if names.length == params.length =>
         params.zip(names).map((param, realName) => param.copy(name = realName))
       case _ => params
+    val defaults: Map[String, Expr[Any]] =
+      underlyingMethod(fnTerm).map(defaultGetters).getOrElse(Map.empty)
 
     retTpe.asType match
       case '[r] =>
         '{ (map: Map[String, Any]) =>
           val fnValue = $f
-          val argsList: List[Any] = ${ buildArgConversionExpr(namedParams, 'map) }
+          val argsList: List[Any] = ${ buildArgConversionExpr(namedParams, defaults, 'map) }
           val result = MacroUtils.invokeFunctionWithArgs(fnValue, argsList)
           result.asInstanceOf[r]
         }.asExprOf[Map[String, Any] => r]

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/PromptProcessor.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/PromptProcessor.scala
@@ -37,8 +37,12 @@ private[macros] object PromptProcessor extends AnnotationProcessorBase:
 
     val argExprs: List[Expr[PromptArgument]] =
       methodSym.paramSymss.headOption.getOrElse(Nil).map { pSym =>
+        // `Option` arguments are optional unless `@Param(required = true)` says otherwise; the
+        // generated handler applies a Scala default (or `None`) when the client omits them.
+        val isOptionType = pSym.termRef.widenTermRefByName <:< TypeRepr.of[Option[?]]
         val (descOpt, required) = MacroUtils.parsePromptParamArgs(
-          MacroUtils.extractParamAnnotation(pSym)
+          MacroUtils.extractParamAnnotation(pSym),
+          isOptionType
         )
         '{ PromptArgument(${ Expr(pSym.name) }, ${ Expr(descOpt) }, ${ Expr(required) }) }
       }

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ToolProcessor.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/macros/ToolProcessor.scala
@@ -117,10 +117,11 @@ private[macros] object ToolProcessor extends AnnotationProcessorBase:
         MacroUtils
           .extractParamAnnotation(pSym)
           .map { annotTerm =>
-            val (desc, examples, required, schema) = MacroUtils.parseToolParam(Some(annotTerm))
+            val isOptionType = pSym.termRef.widenTermRefByName <:< TypeRepr.of[Option[?]]
+            val (desc, examples, required, schema) =
+              MacroUtils.parseToolParam(Some(annotTerm), isOptionType)
 
             if !required then
-              val isOptionType = pSym.termRef.widenTermRefByName <:< TypeRepr.of[Option[?]]
               val hasDefault = paramsWithDefaults.contains(pSym.name)
 
               if !isOptionType && !hasDefault then

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/PromptManager.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/PromptManager.scala
@@ -128,7 +128,11 @@ class PromptManager[R] extends Manager[PromptDefinition]:
               // McpErrors pass through untouched — the MRTR input_required sentinel in
               // particular must reach the router intact to become an InputRequiredResult.
               case m: McpError => m
-              case e => new PromptExecutionError(s"Error rendering prompt '$name'", Some(e))
+              // Keep the cause's message: a `-32603` that only says "Error rendering prompt"
+              // leaves the client (and the operator) with nothing to act on (D1.29).
+              case e =>
+                val cause = Option(e.getMessage).getOrElse(e.getClass.getSimpleName)
+                new PromptExecutionError(s"Error rendering prompt '$name': $cause", Some(e))
             }
 
       case None =>


### PR DESCRIPTION
## What

Arc N7 of the pre-v1.0.0 session (TJC-2334, macro semantics only — the `Exports.scala` additions named in the issue land in arc N10 per decision (c)). Two behaviour fixes on the annotation path, identical on JVM, Scala.js/Bun and Scala Native:

1. **Scala default arguments are applied when a `tools/call` / `prompts/get` omits the parameter.** `MapToFunctionMacro.callByMap` now recovers the annotated method from the eta-expanded reference (`Block(DefDef($anonfun, …, Apply(Select(module, m), …)), Closure(…))`, the shape `MacroUtils.getMethodRefExpr` emits) and, for every parameter flagged `HasDefault` on that method's own symbol, binds the compiler's nullary `<method>$default$N` getter declared on the same object (`Select(Ref(module), getter)`): `map.get(key)` → decode when present, the default when absent. An omitted `Option` parameter with a non-`None` default takes that default (was `None`); an omitted `Option` without a default stays `None`. Only object members qualify (the only shape `scanAnnotations` registers); a polymorphic getter (has parameters) or a non-object owner falls back to the existing missing-argument failure. The failure now reads `Missing required argument '<param>'` (still a `NoSuchElementException`, so the dispatch boundary keeps mapping it to an `isError` tool result / `-32602` on prompts and resources — the response shape is unchanged, the message names the argument).
2. **`@Param` no longer re-requires `Option` parameters.** `MacroUtils.parseToolParam` / `parsePromptParamArgs` take the parameter's `isOptionType` and default `required` to `!isOptionType` — the same rule `JsonSchemaMacro` already applies to un-annotated parameters — so a description-only `@Param("Maximum results") limit: Option[Int]` is no longer listed in `required`; only an explicit `@Param(required = true)` re-requires an `Option`. Applied to `@Tool` parameters, typed-request case-class fields (`schemaMetadataForTypeRepr`) and `@Prompt` arguments (whose `Option` parameters were advertised `required: true` even without `@Param`). The `required = false`-on-non-Option-without-default compile error is unchanged.

Also: `PromptManager` keeps the cause's message in the `-32603` (`Error rendering prompt '<name>': <cause>`; D1.29 — the cause used to be swallowed), the `@Param.required` Scaladoc states the rule, and three CHANGELOG `[Unreleased] ### Fixed` bullets.

## Why

D1.14–D1.17, D1.29, D1.50, D1.51 (CONFIRMED P1): the flagship `AnnotatedServer.calculator` failed on its own documented optional argument (`{"a":1,"b":2}` → `isError` `Key not found in map: operation`), `greeting_prompt` / the README `greeting` prompt failed without `title` (`-32603 Error rendering prompt`, cause hidden), and `@Param("…") x: Option[Int]` flipped an optional parameter to required so schema-honouring clients always sent it. Both shapes are exactly what README.md:107 documents as optional. Fixing them before 1.0.0 freezes the semantics the 1.x line has to keep. README.md:107 wording ("`required = false`, combined with `Option[...]` or a default value, marks the field optional") is now accurate as written; the release-prep PR may still tighten it ("`Option` parameters are optional; `required = false` is for parameters with a default").

## Canary (RED, first commit)

`./mill --no-server fast-mcp-scala.jvm.test.testOnly com.tjclp.fastmcp.macros.DefaultArgumentsTest` before the fix — 8 of 9 fail:

```
- AnnotatedServer.calculator applies the `operation` default when the argument is omitted *** FAILED ***
  zio.FiberFailure: Key not found in map: operation
- AnnotatedServer.greeting_prompt applies the `title` default when the argument is omitted *** FAILED ***
  zio.FiberFailure: Error rendering prompt 'greeting_prompt'
  Cause: java.util.NoSuchElementException: Key not found in map: title
- an omitted `required = false` parameter with a default takes the Scala default *** FAILED ***
  zio.FiberFailure: Key not found in map: s
- an omitted parameter without a default fails with a message naming the argument *** FAILED ***
  "Key not found in map: a" did not contain "Missing required argument 'a'"
- an omitted Option parameter with a non-None default takes the Scala default *** FAILED ***
  "[none]" did not equal "[7]"
- a description-only @Param on an Option parameter does not re-require it *** FAILED ***
  List("label", "x") contained "x" Option parameter 'x' must not be required, got: List(label, x)
- an explicit @Param(required = true) re-requires an Option parameter          (passes before and after)
- an omitted `required = false` prompt argument with a default takes the Scala default *** FAILED ***
  Cause: java.util.NoSuchElementException: Key not found in map: greeting
- an Option prompt argument is optional with and without a description-only @Param *** FAILED ***
  promptArg(server, "opt_prompt", "who").required was true
Tests: succeeded 1, failed 8
```

The Scala.js mirror `DefaultArgumentsJsTest` (3 cases) was committed in the same RED commit and runs GREEN under Bun in the table below.

## Verification

All gates ran locally on this branch's worktree after `rm -rf <worktree>/out/fast-mcp-scala` (macro edits), Mill 1.1.8 `--no-server`:

| Gate | Command | Result |
|---|---|---|
| RED canary (before the fix) | `./mill --no-server fast-mcp-scala.jvm.test.testOnly com.tjclp.fastmcp.macros.DefaultArgumentsTest` | 1 succeeded, 8 failed (text above) |
| Targeted GREEN | same, plus `MapToFunctionMacroTest`, `MapToFunctionMacroSimpleTest` | 9 + 9 + 3 succeeded, 0 failed |
| Format | `./mill --no-server fast-mcp-scala.reformat` then `fast-mcp-scala.checkFormat` | SUCCESS |
| Compile (JVM + Scala.js + Scala Native) | `./mill --no-server fast-mcp-scala.compile` | 168/168 SUCCESS, 0 errors (the 16 warnings are pre-existing wart/`Array[a]` notes plus `-Wnonunit-statement` on test `assert`s) |
| JVM tests | `./mill --no-server fast-mcp-scala.jvm.test` | 492 succeeded, 0 failed (483 before + 9 new) |
| Scala Native tests | `./mill --no-server fast-mcp-scala.scalaNative.test` | 14 succeeded, 0 failed |
| Scala.js/Bun tests | `./mill --no-server fast-mcp-scala.js.test` | 73 succeeded, 0 failed (70 before + 3 new `DefaultArgumentsJsTest`) |
| Conformance, JVM | `scripts/conformance.sh jvm 8077 active` | 73 passed, 0 failed; baseline check passed |
| Path scrub | the R2 per-PR checklist `git grep` for absolute home / scratch / dogfood-version literals over the tree (excluding `out/`) | empty |

Not run here: `scripts/conformance.sh js` (the conformance server registers no defaulted/Option-annotated parameters, and the Bun expansion is covered by `DefaultArgumentsJsTest` + the full `js.test`); CI runs conformance.yml on both platforms.

## Test changes

- New `jvm/test/.../macros/DefaultArgumentsTest.scala` (9 cases: the two AnnotatedServer repros, tool/prompt defaults, Option-with-default, missing-argument message, Option not re-required, explicit `required = true`, prompt Option semantics).
- New `js/test/.../macros/DefaultArgumentsJsTest.scala` (3 cases, `OverloadBindingJsTest` style: in-process Scala.js macro expansion under Bun).
- `MapToFunctionMacroTest` / `MapToFunctionMacroSimpleTest`: the missing-argument assertion follows the new message (`Missing required argument 'name'`).

Linear: https://linear.app/tjc-technologies/issue/TJC-2334

Merge with a MERGE COMMIT (never squash); part of the pre-v1.0.0 stack, see TJC-2326. Based on #98 (`tjc-2335-drop-experimental`): merge bottom-up, retarget this PR to `main` after #98 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
