### PR TITLE
fix(tasks): legacy tasks/result answers -32602 for cancelled/expired tasks instead of silence (TJC-2353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,6 +270,16 @@ Security-hardening wave (TJC-2294; findings F1–F12 of the 2026-09-04 scan). Um
 
 ### Fixed
 
+- **Legacy `tasks/result` always answers** (TJC-2353): a `tasks/result` for a task that was
+  cancelled — by `tasks/cancel`, by the TTL sweep, or with its session's release, whether the task
+  was already terminal or the waiter was parked when it happened — now fails with JSON-RPC
+  `-32602` (`Task <id> was cancelled`, the same family as `Unknown task`; new
+  `TaskCancelledError` carrier in `server.manager`). The awaiting handler used to re-raise the
+  task fiber's interrupt-only cause, which the router treated as a client-cancelled request and
+  answered with nothing: the streamable-HTTP SSE stream closed after at most a keepalive ping (JVM
+  and Bun), stdio wrote no frame, and the TypeScript SDK's `getTaskResult` hung until its 60 s
+  timeout. Real task failures keep their full cause; `tasks/get` snapshots of a cancelled task are
+  unchanged (no `result` / `error` block).
 - **Annotation macros bind to the annotated overload** (F4 / CWE-706, TJC-2298): `scanAnnotations`
   used to re-resolve `@Tool` / `@Resource` / `@Prompt` targets by method name and could register,
   schema-describe and invoke a different same-named overload (for example an un-annotated raw

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -107,4 +107,7 @@ On the compatibility adapter, clients send `params.task: {ttl}` and poll `tasks/
 outlives a single request: the legacy streamable-HTTP adapter and stdio (one durable session per
 process). On the **stateless** legacy adapter all clients share one session identity, so legacy
 task requests there are rejected with `-32601`. Bearer tasks are invisible to legacy sessions and
-vice versa.
+vice versa. `tasks/result` is always answered: for a task that was cancelled (`tasks/cancel`, TTL
+sweep, session release) — whether already terminal or cancelled while the waiter was parked — it
+fails with `-32602` (`Task <id> was cancelled`); once the TTL has swept the entry, with `-32602`
+`Unknown task`, the same code `tasks/get` uses.

--- a/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerHttpTest.scala
+++ b/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerHttpTest.scala
@@ -1002,6 +1002,74 @@ class JsServerHttpTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAl
     done.andThen { case _ => taskBunServer.stop() }
   }
 
+  // TJC-2353 twin of TaskHttpTransportTest: a legacy tasks/result for a cancelled task must be
+  // answered with an error frame on Bun too (the stream used to be closed with nothing in it).
+  it should "answer tasks/result for a cancelled task with -32602 instead of closing the stream" in {
+    val cancelPort = 38937
+    val server = com.tjclp.fastmcp.server.McpServer(
+      "JsHttpCancelledResultServer",
+      "0.1.0",
+      McpServerSettings(
+        host = "127.0.0.1",
+        port = cancelPort,
+        httpEndpoint = "/mcp",
+        stateless = false,
+        tasks = TaskSettings(enabled = true, pollIntervalMs = 50)
+      )
+    )
+    val slowTaskTool = McpTool
+      .withSchema[PingArgs, PingResult](
+        name = "slow-task",
+        inputSchema = pingSchema,
+        description = Some("Sleeps long enough to be cancelled")
+      )
+      .contextual((args, _) => ZIO.sleep(30.seconds).as(PingResult(args.msg)))
+      .withTaskSupport(TaskSupport.Optional)
+    val taskIdPattern = """"taskId":"([^"]+)"""".r
+
+    def post(body: String, sid: Option[String]): Future[js.Dynamic] =
+      fetchAt(
+        cancelPort,
+        js.Dynamic.literal(
+          method = "POST",
+          headers = jsonHeaders(sid.toList.map("mcp-session-id" -> _)*),
+          body = body
+        )
+      )
+
+    runZio(server.tool(slowTaskTool).unit).flatMap { _ =>
+      val bun = server.startStatefulHttp()
+      val checked = for
+        initResp <- post(legacyInitBody, None)
+        _ <- text(initResp)
+        sid = header(initResp, "mcp-session-id").getOrElse(fail("no session id"))
+        created <- post(
+          """{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"slow-task","arguments":{"msg":"hi"},"task":{"ttl":60000}}}""",
+          Some(sid)
+        ).flatMap(text)
+        taskId = taskIdPattern
+          .findFirstMatchIn(created)
+          .map(_.group(1))
+          .getOrElse(fail(s"no taskId in: $created"))
+        cancelled <- post(
+          s"""{"jsonrpc":"2.0","id":3,"method":"tasks/cancel","params":{"taskId":"$taskId"}}""",
+          Some(sid)
+        ).flatMap(text)
+        result <- post(
+          s"""{"jsonrpc":"2.0","id":4,"method":"tasks/result","params":{"taskId":"$taskId"}}""",
+          Some(sid)
+        ).flatMap(text)
+      yield
+        cancelled should include(""""status":"cancelled"""")
+        withClue(s"tasks/result body after cancel: <$result> ") {
+          result should include(""""id":4""")
+          result should include(""""code":-32602""")
+          result should include(s"Task $taskId was cancelled")
+        }
+      checked.andThen { case _ => bun.stop() }
+    }
+  }
+
   "runHttp (stateless keepalive)" should "emit pings on a quiet modern POST SSE stream" in {
     val kaPort = 38923
     val server = com.tjclp.fastmcp.server.McpServer(

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/manager/TaskManagerSpec.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/manager/TaskManagerSpec.scala
@@ -5,6 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import zio.{Task as _, *}
 
 import com.tjclp.fastmcp.core.*
+import com.tjclp.fastmcp.jsonrpc.McpErrorCarrier
 import com.tjclp.fastmcp.server.TaskSettings
 
 /** Tests for [[TaskManager]] lifecycle, status transitions, session isolation, and cancellation
@@ -199,6 +200,53 @@ class TaskManagerSpec extends AnyFlatSpec with Matchers {
     val tm = newManager()
     val cancelOutcome = runUnsafe(tm.cancel("does-not-exist", Some("s1")))
     cancelOutcome shouldBe Left("Task not found")
+  }
+
+  // TJC-2353: `result` on a cancelled task must fail with a VALUE the dispatch layer can put on
+  // the wire. Re-raising the fiber's interrupt-only cause made the awaiting `tasks/result` handler
+  // look like a cancelled request, and the router answered it with nothing at all.
+  it should "make result fail with an McpErrorCarrier (-32602), parked or after the fact" in {
+    val tm = newManager()
+    val gate = runUnsafe(Promise.make[Nothing, Unit])
+    val never: ZIO[Any, Throwable, Any] = gate.await
+    val created = runUnsafe(
+      tm.create(sessionId = Some("s1"), requestedTtlMs = None, run = never, _ => ZIO.unit)
+    )
+    val taskId = created.task.taskId
+
+    def carrierOf(exit: Exit[Throwable, Any]): McpErrorCarrier =
+      exit match
+        case Exit.Failure(cause) =>
+          cause.failureOption match
+            case Some(c: McpErrorCarrier) => c
+            case other =>
+              fail(s"expected an McpErrorCarrier failure value but got $other (cause: $cause)")
+        case Exit.Success(v) => fail(s"expected a failure but result succeeded with $v")
+
+    // 1. A waiter parked BEFORE the cancel.
+    val (parkedExit, cancelOutcome) = runUnsafe(
+      for
+        waiter <- tm.result(taskId, Some("s1")).exit.fork
+        _ <- ZIO.sleep(100.millis)
+        cancelled <- tm.cancel(taskId, Some("s1"))
+        exit <- waiter.join.timeoutFail(new RuntimeException("parked result never resolved"))(
+          5.seconds
+        )
+      yield (exit, cancelled)
+    )
+    cancelOutcome.map(_.status) shouldBe Right(TaskStatus.Cancelled)
+    val parked = carrierOf(parkedExit)
+    parked.toMcpError.code shouldBe ErrorCodes.InvalidParams
+    parked.toMcpError.message should include(taskId)
+
+    // 2. A result requested AFTER the task is already Cancelled.
+    val late = carrierOf(exitOf(tm.result(taskId, Some("s1"))))
+    late.toMcpError.code shouldBe ErrorCodes.InvalidParams
+    late.toMcpError.message should include("cancelled")
+
+    // The stored status is Cancelled (not Failed): the error value is the waiter's answer, not a
+    // reclassification of the task.
+    runUnsafe(tm.get(taskId, Some("s1"))).map(_.status) shouldBe Some(TaskStatus.Cancelled)
   }
 
   "session isolation" should "hide tasks from other sessions" in {

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/StdioLoopLifecycleTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/StdioLoopLifecycleTest.scala
@@ -6,6 +6,8 @@ import org.scalatest.matchers.should.Matchers
 import zio.*
 import zio.stream.*
 
+import com.tjclp.fastmcp.core.*
+import com.tjclp.fastmcp.macros.RegistrationMacro.*
 import com.tjclp.fastmcp.server.*
 import com.tjclp.fastmcp.server.router.Session
 import com.tjclp.fastmcp.server.transport.JvmTransportBackend.given
@@ -72,4 +74,68 @@ class StdioLoopLifecycleTest extends AnyFunSuite with Matchers:
       )
     )
     exit.isInterrupted shouldBe true
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // TJC-2353: every request gets a response, tasks/result for a cancelled task included. Over
+  // stdio there is no stream to close, so the symptom was simply a request id that never came
+  // back (the D6 stdio driver's id 7 stayed unanswered until stdin EOF).
+  // ---------------------------------------------------------------------------------------------
+
+  object StdioTaskServer:
+
+    @Tool(name = Some("blocky"), description = Some("Long-running"), taskSupport = Some("optional"))
+    def blocky(): ZIO[Any, Throwable, String] = ZIO.sleep(30.seconds).as("blocky")
+
+  private val TaskIdPattern = """"taskId":"([^"]+)"""".r
+
+  /** Take frames until one carries the given request id (notifications carry none). */
+  private def replyTo(outQ: Queue[String], id: Int): UIO[String] =
+    outQ.take.repeatUntil(_.contains(s""""id":$id,"""))
+
+  test("tasks/result for a cancelled task is answered over stdio (request id never left dangling)") {
+    val program =
+      for
+        server <- ZIO.succeed(
+          McpServer.typed[Any](
+            "StdioTasks",
+            "0.1.0",
+            McpServerSettings(tasks = TaskSettings(enabled = true, pollIntervalMs = 50))
+          )
+        )
+        _ <- ZIO.attempt(server.scanAnnotations[StdioTaskServer.type])
+        router <- server.buildRouter
+        session <- Session.make("stdio-tasks")
+        inQ <- Queue.unbounded[String]
+        outQ <- Queue.unbounded[String]
+        loop <- StdioLoop.run(router, session, ZStream.fromQueue(inQ), s => outQ.offer(s).unit).fork
+        _ <- inQ.offer(initFrame)
+        _ <- replyTo(outQ, 1)
+        _ <- inQ.offer("""{"jsonrpc":"2.0","method":"notifications/initialized"}""")
+        _ <- inQ.offer(
+          """{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"blocky","arguments":{},"task":{"ttl":60000}}}"""
+        )
+        created <- replyTo(outQ, 2)
+        taskId <- ZIO
+          .fromOption(TaskIdPattern.findFirstMatchIn(created).map(_.group(1)))
+          .orElseFail(new RuntimeException(s"no taskId in: $created"))
+        _ <- inQ.offer(
+          s"""{"jsonrpc":"2.0","id":3,"method":"tasks/cancel","params":{"taskId":"$taskId"}}"""
+        )
+        cancelled <- replyTo(outQ, 3)
+        _ <- inQ.offer(
+          s"""{"jsonrpc":"2.0","id":4,"method":"tasks/result","params":{"taskId":"$taskId"}}"""
+        )
+        answer <- replyTo(outQ, 4).timeoutFail(
+          new RuntimeException("tasks/result (id 4) for a cancelled task was never answered")
+        )(5.seconds)
+        _ <- loop.interrupt
+      yield (cancelled, answer, taskId)
+
+    val (cancelled, answer, taskId) = runUnsafe(
+      program.timeoutFail(new RuntimeException("stdio task lifecycle did not complete"))(20.seconds)
+    )
+    cancelled should include(""""status":"cancelled"""")
+    answer should include(""""code":-32602""")
+    answer should include(s"Task $taskId was cancelled")
   }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/TaskHttpTransportTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/TaskHttpTransportTest.scala
@@ -495,3 +495,39 @@ class TaskHttpTransportTest extends AnyFunSuite with Matchers:
     gone should include(""""code":-32602""")
     gone should include("Unknown task")
   }
+
+  test("a cancelled bearer task's tasks/get snapshot renders no result or error block (guard)") {
+    // The promise now completes with a TaskCancelledError value; `renderSnapshot` must keep
+    // treating a Cancelled task as detail-less (details are for Completed / Failed only).
+    val routes = buildRoutes()
+    val created = bodyOf(
+      modernPost(
+        routes,
+        s"""{"jsonrpc":"2.0","id":80,"method":"tools/call","params":{"name":"blocky","arguments":{},$taskMeta}}""",
+        "tools/call",
+        "blocky"
+      )
+    )
+    val taskId = extractTaskId(created)
+    val cancelled = bodyOf(
+      modernPost(
+        routes,
+        s"""{"jsonrpc":"2.0","id":81,"method":"tasks/cancel","params":{"taskId":"$taskId",$taskMeta}}""",
+        "tasks/cancel",
+        taskId
+      )
+    )
+    cancelled should include(""""resultType":"complete"""")
+    val snapshot = bodyOf(
+      modernPost(
+        routes,
+        s"""{"jsonrpc":"2.0","id":82,"method":"tasks/get","params":{"taskId":"$taskId",$taskMeta}}""",
+        "tasks/get",
+        taskId
+      )
+    )
+    snapshot should include(""""status":"cancelled"""")
+    snapshot should not include """"error":"""
+    // Exactly one "result": the JSON-RPC envelope's — no nested task result payload.
+    snapshot.sliding(9).count(_ == "\"result\":") shouldBe 1
+  }

--- a/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/TaskHttpTransportTest.scala
+++ b/fast-mcp-scala/jvm/test/src/com/tjclp/fastmcp/server/transport/TaskHttpTransportTest.scala
@@ -423,3 +423,75 @@ class TaskHttpTransportTest extends AnyFunSuite with Matchers:
     val overflowAnon = bodyOf(modernPost(routes, blockyCall(64), "tools/call", "blocky", None))
     overflowAnon should include(""""code":-32602""")
   }
+
+  // ---------------------------------------------------------------------------------------------
+  // TJC-2353: a legacy `tasks/result` must ALWAYS be answered. A cancelled task (tasks/cancel, TTL
+  // sweep) used to complete its promise with the fiber's interrupt-only cause; the awaiting handler
+  // re-raised it and the router read that as "the request itself was cancelled" — no frame at all
+  // (the SSE stream closed after a keepalive ping; the TS SDK's getTaskResult hung 60 s).
+  // ---------------------------------------------------------------------------------------------
+
+  private def augmentedCallTtl(id: Int, tool: String, ttlMs: Long): String =
+    s"""{"jsonrpc":"2.0","id":$id,"method":"tools/call","params":{"name":"$tool","arguments":{},"task":{"ttl":$ttlMs}}}"""
+
+  private val CancelledFrame = """"code":-32602"""
+
+  test("tasks/result after tasks/cancel answers an error frame (-32602), never silence") {
+    val routes = buildRoutes()
+    val sid = initSession(routes)
+    val taskId = extractTaskId(bodyOf(post(routes, augmentedCall(70, "blocky"), Some(sid))))
+    bodyOf(post(routes, tasksCancel(71, taskId), Some(sid))) should include(""""status":"cancelled"""")
+    val result = bodyOf(post(routes, tasksResult(72, taskId), Some(sid)))
+    withClue(s"tasks/result body after cancel: <$result> ") {
+      result should include(""""id":72""")
+      result should include(CancelledFrame)
+      result should include(s"Task $taskId was cancelled")
+    }
+  }
+
+  test("a parked tasks/result waiter is answered when the task is cancelled") {
+    val routes = buildRoutes()
+    val sid = initSession(routes)
+    val taskId = extractTaskId(bodyOf(post(routes, augmentedCall(73, "blocky"), Some(sid))))
+    val result = runUnsafe(
+      for
+        waiter <- ZIO.attemptBlocking(bodyOf(post(routes, tasksResult(74, taskId), Some(sid)))).fork
+        _ <- ZIO.sleep(300.millis) // let the waiter park on the task promise
+        cancelled <- ZIO.attemptBlocking(bodyOf(post(routes, tasksCancel(75, taskId), Some(sid))))
+        _ = cancelled should include(""""status":"cancelled"""")
+        body <- waiter.join.timeoutFail(
+          new RuntimeException("parked tasks/result was never answered after tasks/cancel")
+        )(10.seconds)
+      yield body
+    )
+    withClue(s"parked tasks/result body: <$result> ") {
+      result should include(""""id":74""")
+      result should include(CancelledFrame)
+      result should include(s"Task $taskId was cancelled")
+    }
+  }
+
+  test("a parked tasks/result waiter is answered when the task's TTL expires") {
+    val routes = buildRoutes()
+    val sid = initSession(routes)
+    // ttl 300 ms on a 2 s tool: the sweeper removes the entry and interrupts the fiber while the
+    // waiter is parked. The waiter must get a frame, not an EOF.
+    val created = bodyOf(post(routes, augmentedCallTtl(76, "blocky", 300L), Some(sid)))
+    created should include(""""ttl":300""")
+    val taskId = extractTaskId(created)
+    val result = runUnsafe(
+      ZIO
+        .attemptBlocking(bodyOf(post(routes, tasksResult(77, taskId), Some(sid))))
+        .timeoutFail(
+          new RuntimeException("parked tasks/result was never answered after TTL expiry")
+        )(10.seconds)
+    )
+    withClue(s"tasks/result body during TTL expiry: <$result> ") {
+      result should include(""""id":77""")
+      result should include(CancelledFrame)
+    }
+    // Once swept, the id is simply unknown — same -32602 family as tasks/get.
+    val gone = bodyOf(post(routes, tasksGet(78, taskId), Some(sid)))
+    gone should include(""""code":-32602""")
+    gone should include("Unknown task")
+  }

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/TaskManager.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/manager/TaskManager.scala
@@ -635,6 +635,13 @@ class TaskManager[R] private[manager] (
       }
       _ <- exit match
         case Exit.Success(value) => promise.succeed(value).unit
+        // Cancelled (tasks/cancel, TTL sweep, session release): complete the promise with a
+        // failure VALUE, never the raw interrupt cause. `result` re-raises whatever is stored in
+        // the awaiting `tasks/result` handler fiber, and an interrupt-only cause there is
+        // indistinguishable from the *request* being cancelled — the router emits no response
+        // frame at all (TJC-2353). Real failures keep their full cause so defects keep traces.
+        case Exit.Failure(cause) if cause.isInterruptedOnly =>
+          promise.fail(new TaskCancelledError(taskId)).unit
         case Exit.Failure(cause) => promise.failCause(cause).unit
       _ <- ZIO.foreachDiscard(updated)(e => onStatusChange(e.toTask).ignore)
     yield ()
@@ -669,6 +676,17 @@ final class TaskCapacityExceeded(val kind: String, val limit: Int)
   */
 final class TaskNotFoundError(val taskId: String)
     extends RuntimeException(s"Unknown task: $taskId")
+    with McpErrorCarrier:
+  def toMcpError: McpError = McpError.invalidParams(getMessage)
+
+/** The answer a `tasks/result` waiter gets for a task that was cancelled — by `tasks/cancel`, by
+  * the TTL sweeper, or with its session's release. The task's promise is completed with this VALUE
+  * rather than the fiber's interrupt-only cause, which a parked handler would re-raise and the
+  * router would mistake for a cancelled request (no frame at all). Maps to JSON-RPC `-32602`, the
+  * same family as [[TaskNotFoundError]] and the "already in terminal status" cancel error.
+  */
+final class TaskCancelledError(val taskId: String)
+    extends RuntimeException(s"Task $taskId was cancelled")
     with McpErrorCarrier:
   def toMcpError: McpError = McpError.invalidParams(getMessage)
 


### PR DESCRIPTION
## What / why

A legacy (2025-11-25) `tasks/result` for a task that had been cancelled — by `tasks/cancel`, by the TTL sweeper, or with its session's release — was never answered. `TaskManager.recordTerminal` completed the cancelled task's promise with the fiber's interrupt-only cause; `TaskManager.result` re-raised that cause inside the awaiting `tasks/result` handler; `McpError.fromThrowable` maps only typed failures; and `McpRouter` treats an interrupt-only handler exit as "the *request* was cancelled — emit no response". Every legacy-capable transport therefore ended the request with nothing: the streamable-HTTP SSE stream closed after at most a keepalive ping (JVM and Bun), stdio wrote no frame, and the TypeScript SDK 1.29 `getTaskResult` hung until its 60 s timeout. Dogfood finding D6 5.1 (P1), confirmed twice per transport (JVM HTTP x3 variants, Bun HTTP, JVM stdio, Scala Native stdio); evidence under `$SCRATCH/d6/refute/` (`R1/L4-result-after-cancel.txt` ping-only SSE, `V1/A-result.txt` 0 bytes, `stdio/refute-stdio-1.transcript.ndjson` id 7 unanswered).

**Fix** (`shared/.../server/manager/TaskManager.scala`, one site + one carrier class). The interrupt-only branch of `recordTerminal` now completes the promise with a failure **value**, `new TaskCancelledError(taskId)` — `RuntimeException("Task <id> was cancelled") with McpErrorCarrier`, mapping to `-32602` like its siblings `TaskNotFoundError` and the "already in terminal status" cancel error. Real failures keep `failCause` so defects keep their traces. A parked waiter, a late `tasks/result`, and a waiter parked through a TTL sweep all get a frame; once the sweep has removed the entry the id is simply `Unknown task` (`-32602`, as `tasks/get`). `snapshot` / `renderSnapshot` are unaffected — a Cancelled task still renders without `result` / `error` details (guarded by a new test). Task status stays `cancelled`; nothing is reclassified as `failed`.

**Tests** (RED first, commit 913f5cf; GREEN fb99c8d):
- `TaskHttpTransportTest`: `tasks/result` after `tasks/cancel`; a parked `tasks/result` answered when the task is cancelled; a parked `tasks/result` answered when a 300 ms TTL expires (then `tasks/get` -> `Unknown task`); guard: a cancelled bearer task's modern `tasks/get` snapshot renders no `result`/`error` block.
- `TaskManagerSpec`: `result` after `cancel` fails with an `McpErrorCarrier` (`-32602`, message names the task id), both parked and after the fact; stored status stays `Cancelled`.
- `StdioLoopLifecycleTest`: initialize -> augmented `tools/call` -> `tasks/cancel` -> `tasks/result` over `StdioLoop`; request id 4 must come back.
- `JsServerHttpTest` (Bun twin, port 38937): cancel then `tasks/result` -> `-32602` frame instead of a closed stream.

**Docs**: `docs/tasks.md` legacy section — one sentence on the `-32602` answer for cancelled / swept tasks. CHANGELOG `[Unreleased] ### Fixed` bullet.

## Canary — RED on main's code (commit 913f5cf, tests only)

```
- tasks/result after tasks/cancel answers an error frame (-32602), never silence *** FAILED ***
  tasks/result body after cancel: <> "" did not include substring ""id":72" (TaskHttpTransportTest.scala:446)
- a parked tasks/result waiter is answered when the task is cancelled *** FAILED ***
  parked tasks/result body: <> "" did not include substring ""id":74" (TaskHttpTransportTest.scala:468)
- a parked tasks/result waiter is answered when the task's TTL expires *** FAILED ***
  tasks/result body during TTL expiry: <> "" did not include substring ""id":77" (TaskHttpTransportTest.scala:490)
- should make result fail with an McpErrorCarrier (-32602), parked or after the fact *** FAILED ***
  expected an McpErrorCarrier failure value but got None (cause: Interrupt(Runtime(...)) ...
- tasks/result for a cancelled task is answered over stdio (request id never left dangling) *** FAILED ***
  zio.FiberFailure: tasks/result (id 4) for a cancelled task was never answered
- should answer tasks/result for a cancelled task with -32602 instead of closing the stream *** FAILED ***
  tasks/result body after cancel: <> "" did not include substring ""id":4" (JsServerHttpTest.scala:1065)
```

GREEN with the fix (fb99c8d): `TaskHttpTransportTest` 22/22, `TaskManagerSpec` 34/34, `StdioLoopLifecycleTest` 3/3, `JsServerHttpTest` 33/33.

## Verification

| Gate | Command | Result |
|---|---|---|
| Format | `./mill --no-server fast-mcp-scala.checkFormat` | pass |
| Compile (JVM + Scala.js + Scala Native) | `./mill --no-server fast-mcp-scala.compile` | pass (168/168 tasks) |
| RED (test commit only) | `./mill --no-server fast-mcp-scala.jvm.test.testOnly` on the three JVM classes @ 913f5cf; `fast-mcp-scala.js.test.testOnly com.tjclp.fastmcp.conformance.JsServerHttpTest` @ 913f5cf | 5 failed / 53 passed (JVM); 1 failed / 32 passed (Bun) — text above |
| GREEN (targeted) | same @ fb99c8d | 58 passed / 0 failed (JVM); 33 / 0 (Bun) |
| JVM suite | `./mill --no-server fast-mcp-scala.jvm.test` | 489 passed / 0 failed |
| Scala Native suite | `./mill --no-server fast-mcp-scala.scalaNative.test` | 14 passed / 0 failed |
| Bun suites | `./mill --no-server fast-mcp-scala.js.test` | 71 passed / 0 failed |
| Conformance (JVM) | `scripts/conformance.sh jvm 8077 active` | 73 passed, 0 failed; baseline check passed (baseline stays empty) |
| Path scrub | `git grep` for absolute home / temp paths, session directory names and the dogfood coordinate, excluding `out/` | empty |

Legacy-only surface (`tasks/result` is `-32601` on 2026-07-28); the promise is consumed only by `result` and `snapshot`, so no other wire shape changes. Defence-in-depth for 1.0.1 (not here): make `McpRouter` emit "no response" only when the *request* itself was cancelled, not whenever a handler exits with an interrupt-only cause.

CHANGELOG: `[Unreleased] ### Fixed` bullet.

Linear: https://linear.app/tjc-technologies/issue/TJC-2353

Merge with a MERGE COMMIT (never squash); part of the pre-v1.0.0 stack, see TJC-2326

🤖 Generated with [Claude Code](https://claude.com/claude-code)
