### PR TITLE
test(js): idleTimeout test binds 38938, not JsServerLimitsTest's 38932 (TJC-2337)

### DIFF
--- a/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerHttpTest.scala
+++ b/fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerHttpTest.scala
@@ -1284,8 +1284,12 @@ class JsServerHttpTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAl
     * default 10 s `idleTimeout` (measured ~12 s on Bun 1.4.1), so a quiet per-request SSE response
     * is exposed to the runtime's own idle close. One call, once — the whole suite pays these
     * seconds exactly one time.
+    *
+    * The port must be unique across every Bun test suite in this module (they share one process):
+    * 38932 is `JsServerLimitsTest`'s stateful port, and sharing it made this test fail with
+    * "Failed to start server. Is port 38932 in use?" whenever the suites interleaved that way.
     */
-  private val idleTimeoutPort = 38932
+  private val idleTimeoutPort = 38938
   private val slowReplyMs = 14000
 
   @SuppressWarnings(Array("org.wartremover.warts.Var"))


### PR DESCRIPTION
## What

One-line test fix: `JsServerHttpTest`'s "Bun idleTimeout should not cut a quiet legacy POST SSE stream before a 14 s tool reply" test moves from port **38932** to **38938**, with a comment stating that every Bun test suite in the module shares one process and must bind a unique fixed port.

## Why

Port 38932 was bound by two suites in the same Bun test process:

- `fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerLimitsTest.scala:183` — `withServer(38932, stateful)` (163d224, TJC-2295)
- `fast-mcp-scala/js/test/src/com/tjclp/fastmcp/conformance/JsServerHttpTest.scala:1288` — `idleTimeoutPort = 38932` (cdb48d2, TJC-2337 follow-up)

Whether the second bind fails depends on how the suites interleave, so the collision surfaced as a flake: `Build and Test (17)` on the release-prep PR #99 (CI run 34269828007, a docs-only commit) failed 77/78 with

```
scala.scalajs.js.JavaScriptException: Error: Failed to start server. Is port 38932 in use?
  at serve@native  (JsTransportBackend.scala:275)
```

while the same test passed on the previous commit twelve minutes earlier, on every `main` run since #100, and 5/5 in the pre-release flake soak. 38917-38937 are each taken exactly once by the Bun suites; 38938 is the first free port. No production code changes; no behaviour changes.

Found by the pre-v1.0.0 release gate (R3 step 4, TJC-2277); the design's rule for a flake that reproduces on the release-prep CI run is a last small PR before the tag. Follow-up for 1.0.1: replace the literal ports in the Bun suites with a per-suite allocator.

## Verification

| Gate | Command | Result |
|---|---|---|
| Format | `./mill --no-server fast-mcp-scala.reformat && ./mill --no-server fast-mcp-scala.checkFormat` | 16/16 SUCCESS, no reformat needed |
| Bun tests | `./mill --no-server fast-mcp-scala.js.test` (serialized on the 389xx ports) | 279/279 SUCCESS, 72 s: 78 tests, 78 succeeded, 0 failed |
| Port uniqueness | `grep -rhoE '\b389[0-9]{2}\b' fast-mcp-scala/js/test/src \| sort \| uniq -c` | 38917-38938: every port used exactly once |

CI on this PR runs the full `Build and Test` matrix (JDK 17/21/25), which is where the collision fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
