### PR TITLE
build: bump the ZIO stack (zio 2.1.26, zio-json 0.10.0, zio-http 3.11.4) and drop the direct netty pins (TJC-2357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,7 +147,7 @@ Security-hardening wave (TJC-2294; findings F1–F12 of the 2026-09-04 scan). Um
   harness-running jobs restore the shared Mill/coursier cache read-only. `ci.yml` no longer exports
   `GITHUB_TOKEN` workflow-wide: it is scoped to the Mill steps that need it (as `native.yml`
   already did), so the third-party setup actions never see it.
-- **Netty pinned to 4.2.17.Final** (TJC-2327): zio-http 3.4.0 declares netty 4.2.3.Final, whose
+- **Netty 4.2.17.Final** (TJC-2327, TJC-2357): zio-http 3.4.0 declared netty 4.2.3.Final, whose
   16 modules carried 27 OSV advisories (12 HIGH / 13 MODERATE / 2 LOW), 7 of them reachable from
   the default JVM HTTP path — CVE-2026-33870 (HIGH, request smuggling), CVE-2026-42577 (HIGH,
   epoll DoS on every Linux JVM), CVE-2026-42585, CVE-2026-42580, CVE-2026-42581, CVE-2026-50020
@@ -156,16 +156,16 @@ Security-hardening wave (TJC-2294; findings F1–F12 of the 2026-09-04 scan). Um
   CVE-2026-42578, CVE-2026-42583, CVE-2026-42584, CVE-2026-42587, CVE-2026-44249,
   CVE-2026-45416, CVE-2026-45536, CVE-2026-50010, CVE-2026-55831, CVE-2026-55833,
   CVE-2026-56745, CVE-2026-56746, CVE-2026-59898, CVE-2026-59899, CVE-2026-59901,
-  CVE-2026-59903, CVE-2026-59921. `build.mill` now pins `Versions.netty`, and the JVM module
-  declares all 16 `io.netty` modules zio-http brings as direct dependencies and imports
-  `io.netty:netty-bom` into the published POM's `<dependencyManagement>`, so the resolved
-  classpath and every consumer's resolution (coursier, Maven, Gradle) see a single netty version;
-  the OSV audit of the resolved 1.0.0 classpath reports 0 advisories. zio-http itself stays at
-  3.4.0 (netty 4.2.x is binary-compatible within the line; the pairing is gated by the JVM test
-  suite, the official conformance suite and the GraalVM HTTP smoke). **Consequence for
-  stdio-only GraalVM builds**: netty is now a direct `<dependency>` of `fast-mcp-scala_3`, so
-  the netty-free recipe must exclude both `dev.zio:zio-http_3` and `io.netty:*` — excluding
-  zio-http alone no longer sheds netty (see [docs/native-image.md](docs/native-image.md)).
+  CVE-2026-59903, CVE-2026-59921. The 1.0.0 classpath resolves netty 4.2.17.Final, which clears
+  all 27; the version now comes from zio-http 3.11.4 itself (the ZIO stack bump under *Changed*),
+  and the JVM module imports `io.netty:netty-bom` at the same version (`Versions.netty`) into the
+  published POM, so a consumer's resolution sees a single netty version
+  — the classified native artifacts included — and a future netty advisory can be answered by
+  moving that one constant ahead of zio-http. The interim direct pins of all 16 `io.netty` modules
+  (in place while zio-http stayed at 3.4.0) are gone with the bump, so netty is a transitive
+  dependency again and a stdio-only GraalVM build sheds it by excluding `dev.zio:zio-http_3` alone
+  (see [docs/native-image.md](docs/native-image.md)). The OSV audit of the resolved 1.0.0
+  classpath reports 0 advisories.
 
 ### Added
 
@@ -219,6 +219,26 @@ Security-hardening wave (TJC-2294; findings F1–F12 of the 2026-09-04 scan). Um
 
 ### Changed
 
+- **ZIO stack bump** (TJC-2357): ZIO 2.1.20 → 2.1.26, zio-json 0.7.44 → 0.10.0 (JVM, Scala.js and
+  Scala Native artifacts alike) and zio-http 3.4.0 → 3.11.4 (JVM). zio-http 3.11.4 declares netty
+  4.2.17.Final itself, so the 16 direct `io.netty` pins the TJC-2327 override added to the JVM
+  module are removed again: netty is a transitive dependency of zio-http, the published
+  `fast-mcp-scala_3` POM lists only `zio`, `zio-json`, `zio-http` and the Scala 3 library as
+  dependencies plus the `import`-scoped `io.netty:netty-bom` entry (kept at `Versions.netty`,
+  equal to what zio-http declares, as the single switch for a future advisory),
+  and a stdio-only consumer sheds the HTTP stack by excluding `dev.zio:zio-http_3` alone (the
+  two-exclusion form stays valid). Two zio-http behaviour deltas reach the wire, neither on a
+  first-party path: a request netty's decoder rejects is now answered with zio-http's own status
+  mapping — 431 for an over-long header block, 414 for an over-long request line, 413 for a body
+  over the aggregator cap, 400 for any other decoder failure — where 3.4.0 routed every decoder
+  failure through its generic 500 error-response path (this library's 413 / `-32000` body-cap
+  replies and the aggregator's empty 413 are unchanged); and the channel's auto-read is paused
+  while a streamed SSE body is being written, so a pipelined follow-up request is no longer read
+  interleaved with it. Resolved-tree side effects: zio-schema 1.7.4 → 1.8.6, zio-prelude RC41 →
+  RC48, magnolia 1.3.18 → 1.3.23, izumi-reflect 3.0.5 → 3.0.9, scala-collection-compat 2.13.0 →
+  2.14.0, scala-java-time 2.6.0 → 2.7.0 (Scala.js / Scala Native). No source change was needed;
+  the three platforms' test suites, the official conformance suite (both revisions, JVM, Bun and
+  the GraalVM HTTP image) and the OSV audit (0 advisories) gate the pairing.
 - **Misplaced annotations are a compile error** (TJC-2331, C2.8): the scan still registers only
   members declared directly on the scanned object (inherited members would break default-argument
   getter lookup and exact-overload binding), but an annotated member it skips — inherited from a
@@ -263,7 +283,7 @@ Security-hardening wave (TJC-2294; findings F1–F12 of the 2026-09-04 scan). Um
   it as usual) instead of refusing the `initialize` with 503. The 503 remains only when no session
   qualifies under either rule, and `sessionIdleTimeout = None` keeps GET holders exempt. The
   periodic idle sweeper is unchanged (live GET streams stay exempt while capacity is free). Bun is
-  unaffected (no standalone GET channel). zio-http 3.4.0 exposes no accepted-socket option, so TCP
+  unaffected (no standalone GET channel). zio-http 3.11.4 exposes no accepted-socket option, so TCP
   keepalive is not set by the server; `docs/transports.md` describes how a vanished GET peer is
   detected.
 - **stdio servers log to stderr by default** (TJC-2338): on the stdio transport stdout is the wire,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,9 +336,9 @@ Then use the version printed by `./mill show fast-mcp-scala.jvm.publishVersion` 
 
 Key dependencies (versions in `build.mill`):
 - Scala 3.9.0 LTS
-- ZIO 2.1.20 - Effect system
-- ZIO JSON 0.7.44 - JSON codecs (shared)
-- ZIO HTTP 3.4.0 - HTTP transport
+- ZIO 2.1.26 - Effect system
+- ZIO JSON 0.10.0 - JSON codecs (shared)
+- ZIO HTTP 3.11.4 - HTTP transport (brings netty 4.2.17.Final transitively; the JVM module imports `io.netty:netty-bom` at `Versions.netty` but declares no `io.netty` dependency)
 - Native Scala 3 macros - Compile-time JSON Schema derivation
 - mill-bun-plugin 0.3.1 - Scala.js + Bun build integration (Scala.js 1.22.0 pinned via `Versions.scalaJs`)
 - `@modelcontextprotocol/sdk` 1.29.0 - TS MCP SDK, pinned in the js module's `bunDevDeps` and frozen by the committed `fast-mcp-scala/js/bun.lock`; consumed only by the `js.test` conformance client (zero production `@JSImport`s, absent from the published bun manifest)

--- a/DEPENDENCY_POLICY.md
+++ b/DEPENDENCY_POLICY.md
@@ -32,8 +32,12 @@ A production dependency is updated when one of these applies:
   `api.osv.dev/v1/querybatch`), run before every release and whenever `build.mill` or
   `package.mill` changes a dependency; GitHub's dependency graph cannot see Mill-resolved Maven
   dependencies, so Dependabot alerts cover only the Actions and bun ecosystems. A transitive
-  dependency with a security surface of its own (netty, via zio-http) is pinned explicitly in
-  `Versions` so it can move independently of the library that brings it;
+  dependency with a security surface of its own (netty, which reaches the JVM artifact only
+  through zio-http) is not declared directly: its version is governed by the `io.netty:netty-bom`
+  import the JVM module publishes in its POM (`Versions.netty`, kept equal to the
+  version zio-http declares — 4.2.17.Final with zio-http 3.11.4), so it can still move ahead of
+  the library that brings it when an advisory lands first, without becoming a direct dependency
+  that a stdio-only consumer would have to exclude on its own;
 - a bug in the dependency affects fast-mcp-scala's behavior;
 - a new dependency feature is needed;
 - the dependency drops support for a Scala, Scala.js, Scala Native, or JDK version this library

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ All settings, required request headers, error-code mapping, the legacy adapter, 
 
 ## Native image (GraalVM)
 
-Stdio servers compile to self-contained GraalVM binaries with **zero hand-written reachability metadata** (about 35 MB, instant startup, no JVM in the container): registration and schema derivation are compile-time macros, and the transport-seam split keeps zio-http/netty out of stdio-only images — exclude both `dev.zio:zio-http_3` and `io.netty:*` from the dependency (netty is a direct, version-pinned dependency of the JVM artifact, so excluding zio-http alone is not enough). HTTP servers compile too and pass the official conformance suite as a native binary in CI. Recipes, flags, and the metadata audit loop: [docs/native-image.md](docs/native-image.md).
+Stdio servers compile to self-contained GraalVM binaries with **zero hand-written reachability metadata** (about 35 MB, instant startup, no JVM in the container): registration and schema derivation are compile-time macros, and the transport-seam split keeps zio-http/netty out of stdio-only images — exclude `dev.zio:zio-http_3` from the dependency (netty arrives only through zio-http, so that single exclusion sheds both). HTTP servers compile too and pass the official conformance suite as a native binary in CI. Recipes, flags, and the metadata audit loop: [docs/native-image.md](docs/native-image.md).
 
 ## Platforms
 

--- a/build.mill
+++ b/build.mill
@@ -21,15 +21,19 @@ val organization = "com.tjclp"
 
 /** Version constants - centralized for maintenance */
 object Versions {
-  val zio = "2.1.20"
-  val zioJson = "0.7.44"
-  val zioHttp = "3.4.0"
-  // Netty is zio-http's transitive dependency, but it is the JVM artifact's largest CVE surface, so
-  // its version is pinned here rather than inherited: zio-http 3.4.0 declares 4.2.3.Final, which
-  // carries 27 OSV advisories (7 reachable on the default HTTP path). The jvm module pins every
-  // io.netty module zio-http brings AND imports the netty BOM, so the resolved classpath and every
-  // downstream POM consumer see a single netty version. Bump when a netty 4.2.x advisory lands;
-  // re-run the OSV audit (DEPENDENCY_POLICY.md) and the native-image HTTP smoke afterwards.
+  val zio = "2.1.26"
+  val zioJson = "0.10.0"
+  val zioHttp = "3.11.4"
+  // Netty reaches the JVM artifact only through zio-http: 3.11.4 declares 4.2.17.Final, so the
+  // io.netty modules are transitive again and nothing in the build declares them directly (the
+  // TJC-2327 direct pins were a stopgap while zio-http 3.4.0 still declared 4.2.3.Final, which
+  // carried 27 OSV advisories). This constant is what the jvm module's netty BOM import speaks:
+  // it keeps every io.netty module zio-http requests — the classified native artifacts included —
+  // on ONE version for POM consumers, and it is the single switch to flip should a netty 4.2.x
+  // advisory land before zio-http moves. Keep it equal to what zio-http declares
+  // (`cs resolve dev.zio:zio-http_3:<zioHttp> | grep io.netty`) unless an advisory forces it
+  // ahead; after any change re-run the OSV audit (DEPENDENCY_POLICY.md) and the native-image HTTP
+  // smoke. It is the JVM artifact's largest CVE surface, so it stays visible here.
   val netty = "4.2.17.Final"
   val scalaTest = "3.2.19"
   // Scala 3.9.0 emits Scala.js 1.22 IR, so the linker must be at least 1.22. mill-bun 0.3.x

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,7 +153,9 @@ Tool handlers return `ZIO[Any, Throwable, Out]`. Handler failures surface in-ban
 Pinned in `build.mill`:
 
 - **Scala** 3.9.0 LTS
-- **ZIO** 2.1.20, **zio-json** 0.7.44 (the wire codec on both platforms), **zio-http** 3.4.0
+- **ZIO** 2.1.26, **zio-json** 0.10.0 (the wire codec on both platforms), **zio-http** 3.11.4
+  (JVM HTTP transport; netty 4.2.17.Final arrives only through it — the JVM module imports
+  `io.netty:netty-bom` at `Versions.netty` but declares no `io.netty` dependency)
 - **Native Scala 3 macros** for JSON Schema derivation, emitted as `zio-json` ASTs
 - **mill-bun-plugin** 0.3.1 (Scala.js + Bun integration)
 - **WartRemover** 3.6.1 (linting)

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -29,10 +29,10 @@ object server extends ScalaModule with mill.javalib.NativeImageModule {
   def mainClass = Some("com.example.MyServer")
 
   def mvnDeps = Seq(
-    // stdio-only: exclude the HTTP stack. BOTH exclusions are needed — netty is a direct,
-    // version-pinned dependency of the JVM artifact — see "The stdio/HTTP split" below
+    // stdio-only: exclude the HTTP stack. netty arrives only through zio-http, so this single
+    // exclusion sheds both — see "The stdio/HTTP split" below
     mvn"com.tjclp::fast-mcp-scala:1.0.0-RC3"
-      .exclude("dev.zio" -> "zio-http_3", "io.netty" -> "*")
+      .exclude("dev.zio" -> "zio-http_3")
   )
 
   // GraalVM provisioned by Mill via the coursier JVM index — no GRAALVM_HOME, no setup-graalvm.
@@ -59,27 +59,33 @@ stack: `serveHttp` lives on the separate `HttpTransportBackend` trait, `runHttp(
 `using` parameter, and the `TransportRunner[Http]` given is conditional. Closed-world analysis
 therefore drops zio-http and netty from stdio-only binaries entirely.
 
-**Stdio-only builds must also exclude the HTTP stack from the dependency — both
-`dev.zio:zio-http_3` and `io.netty:*`** (as in the recipe above). Since 1.0.0 the JVM artifact
-pins every netty module zio-http brings as a direct dependency (the CVE override, see
-[DEPENDENCY_POLICY.md](../DEPENDENCY_POLICY.md)), so excluding zio-http alone no longer removes
-netty from the classpath. This is not just size hygiene: netty's own in-jar reflect-config
-unconditionally registers methods whose signatures mention netty buffer types, forcing them
-reachable, and netty's `--initialize-at-build-time=io.netty` directive then allocates a native
-`MemorySegment` in `EmptyByteBuf.<clinit>` on JDK 25 — failing the build with "Detected a native
-MemorySegment in the image heap". With both exclusions in place, none of that metadata is on the
-image classpath — and Mill's GraalVM-reachability-metadata-repo integration can stay at its
-defaults, so any OTHER dependency you add keeps its repo metadata. (HTTP builds keep netty and
-counter the stale-repo problem with a scoped override — see the HTTP section below.)
+**Stdio-only builds must also exclude the HTTP stack from the dependency: `dev.zio:zio-http_3`**
+(as in the recipe above). netty reaches `fast-mcp-scala_3` only through zio-http — 3.11.4 declares
+netty 4.2.17.Final, and the JVM artifact declares no `io.netty` dependency of its own, only an
+`import`-scoped `io.netty:netty-bom` entry, which adds no dependency — so excluding
+zio-http removes every netty jar with it. The two-exclusion form
+`.exclude("dev.zio" -> "zio-http_3", "io.netty" -> "*")` is also valid: the second exclusion
+matches nothing in the published tree today, so it is harmless, and it keeps the recipe correct
+should a future release ever have to declare netty directly again (as the 1.0.0 pre-releases did
+briefly to override zio-http 3.4.0's netty 4.2.3.Final; see
+[DEPENDENCY_POLICY.md](../DEPENDENCY_POLICY.md)). Shedding netty is not just size hygiene:
+netty's own in-jar reflect-config unconditionally registers methods whose signatures mention
+netty buffer types, forcing them reachable, and netty's `--initialize-at-build-time=io.netty`
+directive then allocates a native `MemorySegment` in `EmptyByteBuf.<clinit>` on JDK 25 — failing
+the build with "Detected a native MemorySegment in the image heap". With the exclusion in place,
+none of that metadata is on the image classpath — and Mill's GraalVM-reachability-metadata-repo
+integration can stay at its defaults, so any OTHER dependency you add keeps its repo metadata.
+(HTTP builds keep netty and counter the stale-repo problem with a scoped override — see the HTTP
+section below.)
 
 The in-repo proof: `fast-mcp-scala.nativeSmoke.stdio` builds `examples.AnnotatedServer` with
 the same classpath shape — it filters the `netty-*` and `zio-http*` jars from
-`nativeImageClasspath`, the moduleDeps stand-in for the two dependency exclusions (a module
+`nativeImageClasspath`, the moduleDeps stand-in for the dependency exclusion (a module
 dependency cannot carry an exclusion) — and `scripts/native-smoke.sh` asserts both the full MCP
 handshake and that the binary contains no `io.netty` / `zio.http` strings. That filter proves the
 transport seam, not the published recipe; the recipe is checked against the published POM instead:
-`cs resolve com.tjclp:fast-mcp-scala_3:<version> --exclude dev.zio:zio-http_3 --exclude 'io.netty:*' | grep -c io.netty`
-must print `0`.
+`cs resolve com.tjclp:fast-mcp-scala_3:<version> --exclude dev.zio:zio-http_3 | grep -c io.netty`
+must print `0` (it does for 1.0.0: nothing but zio-http brings netty in).
 
 ## Notes and troubleshooting
 

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -20,9 +20,9 @@ use. One durable session per process; shutdown is EOF-driven (the client closing
 loop). The stdio lifecycle (`StdioLoop`: session, single-writer stdout, outbound drainer, EOF
 teardown) is shared by the JVM and Scala Native backends; the Scala.js backend drives Node's
 callback IO directly. Because `runStdio()` has no reachable call path into the HTTP stack,
-stdio-only programs never link zio-http or netty; exclude both `dev.zio:zio-http_3` and `io.netty:*`
-from the dependency (netty is a direct, version-pinned dependency of the JVM artifact) to keep them
-off the classpath too. That is what makes small GraalVM images possible
+stdio-only programs never link zio-http or netty; exclude `dev.zio:zio-http_3` from the dependency
+(netty reaches the JVM artifact only through zio-http, so that one exclusion sheds both) to keep
+them off the classpath too. That is what makes small GraalVM images possible
 (see [native-image.md](./native-image.md)).
 
 ### stdout is the wire — log to stderr
@@ -134,7 +134,7 @@ running legacy tasks are released.
 A GET peer that disappears without closing its connection (NAT expiry, a suspended machine) leaves
 the stream "live" from the server's point of view: the OS only notices such a peer once the server
 writes to the socket — that is, with `keepAliveInterval` set — and only after its own TCP
-retransmission budget (zio-http 3.4.0 exposes no accepted-socket option, so the server does not
+retransmission budget (zio-http 3.11.4 exposes no accepted-socket option, so the server does not
 set TCP keepalive itself). The cap-time rule above bounds the session store regardless.
 
 `stateless` controls **only** this adapter. Modern requests are stateless regardless of the flag.

--- a/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/transport/JvmHttpBackend.scala
+++ b/fast-mcp-scala/jvm/src/com/tjclp/fastmcp/server/transport/JvmHttpBackend.scala
@@ -569,7 +569,10 @@ object JvmHttpBackend extends HttpTransportBackend:
 
   /** Merge a heartbeat into an SSE stream so proxies / idle timeouts don't kill long-quiet
     * connections. The `ping` event type is ignored by conforming clients (the TS SDK only parses
-    * `message` events); zio-http 3.4.0 has no comment-frame support. Halts with the data stream.
+    * `message` events). zio-http 3.11.4 can write an SSE comment frame (a `data` string starting
+    * with `:` is emitted verbatim, no `data:` prefix), but the heartbeat keeps the `ping` event
+    * shape it has had since zio-http 3.4.0 (which had no comment support) so the wire is unchanged
+    * across the bump. Halts with the data stream.
     */
   private def withKeepAlive(
       sse: ZStream[Any, Nothing, ServerSentEvent[String]],

--- a/fast-mcp-scala/package.mill
+++ b/fast-mcp-scala/package.mill
@@ -60,41 +60,21 @@ object `package` extends Module {
       // ZIO Core
       mvn"dev.zio::zio:${Versions.zio}",
       mvn"dev.zio::zio-json:${Versions.zioJson}",
-      // ZIO HTTP for HTTP transports (stateless + streamable)
-      mvn"dev.zio::zio-http:${Versions.zioHttp}",
-      // Netty override (TJC-2327). zio-http 3.4.0 declares netty 4.2.3.Final, which carries 27 OSV
-      // advisories, 7 of them reachable on the default HTTP path (request smuggling in
-      // HttpRequestDecoder/HttpObjectAggregator, epoll RST DoS). Every io.netty module zio-http
-      // resolves is pinned directly — ALL of them, not just codec-http: a partial pin leaves the
-      // rest (incl. transport-classes-epoll, the HIGH epoll CVE) at 4.2.3 and mixes netty versions
-      // in one JVM. Direct pins are resolver-agnostic (coursier, Maven, Gradle all pick 4.2.17), at
-      // the cost that netty is now a direct <dependency> of the published POM: a stdio-only
-      // consumer that sheds the HTTP stack must exclude BOTH `dev.zio:zio-http_3` and
-      // `io.netty:*` (docs/native-image.md). Keep this list in sync with
-      // `cs resolve dev.zio:zio-http_3:${Versions.zioHttp} | grep io.netty`.
-      mvn"io.netty:netty-buffer:${Versions.netty}",
-      mvn"io.netty:netty-codec-base:${Versions.netty}",
-      mvn"io.netty:netty-codec-compression:${Versions.netty}",
-      mvn"io.netty:netty-codec-http:${Versions.netty}",
-      mvn"io.netty:netty-codec-socks:${Versions.netty}",
-      mvn"io.netty:netty-common:${Versions.netty}",
-      mvn"io.netty:netty-handler:${Versions.netty}",
-      mvn"io.netty:netty-handler-proxy:${Versions.netty}",
-      mvn"io.netty:netty-pkitesting:${Versions.netty}",
-      mvn"io.netty:netty-resolver:${Versions.netty}",
-      mvn"io.netty:netty-transport:${Versions.netty}",
-      mvn"io.netty:netty-transport-classes-epoll:${Versions.netty}",
-      mvn"io.netty:netty-transport-classes-kqueue:${Versions.netty}",
-      mvn"io.netty:netty-transport-native-epoll:${Versions.netty}",
-      mvn"io.netty:netty-transport-native-kqueue:${Versions.netty}",
-      mvn"io.netty:netty-transport-native-unix-common:${Versions.netty}"
+      // ZIO HTTP for HTTP transports (stateless + streamable). Netty is deliberately NOT declared
+      // here: zio-http 3.11.4 brings netty 4.2.17.Final itself, so the io.netty tree is a
+      // transitive dependency again and a stdio-only consumer sheds it by excluding
+      // `dev.zio:zio-http_3` alone (docs/native-image.md). The TJC-2327 direct pins that overrode
+      // zio-http 3.4.0's 4.2.3.Final are gone with the bump.
+      mvn"dev.zio::zio-http:${Versions.zioHttp}"
     )
 
-    // Belt and braces for the pins above: the netty BOM lands in the published POM as a
-    // `<dependencyManagement>` import, so a consumer whose resolver honours it (coursier: Mill,
-    // sbt, scala-cli) stays on `Versions.netty` even for the classified native artifacts
-    // (`linux-x86_64`, `osx-aarch_64`, ...) that zio-http requests and that a plain
-    // `groupId:artifactId` pin cannot address under Maven's per-classifier mediation.
+    // The netty BOM lands in the published POM as an `import`-scoped `pom` entry — the one place
+    // this build speaks about netty's version. A consumer whose resolver honours it (coursier: Mill,
+    // sbt, scala-cli) keeps every io.netty module zio-http requests on `Versions.netty`, including
+    // the classified native artifacts (`linux-x86_64`, `osx-aarch_64`, ...) that a plain
+    // `groupId:artifactId` pin cannot address under Maven's per-classifier mediation; and it is the
+    // switch to flip if a netty advisory lands before zio-http moves. A BOM import pulls in no
+    // artifact of its own, so excluding zio-http still removes netty from the classpath.
     override def bomMvnDeps = Seq(mvn"io.netty:netty-bom:${Versions.netty}")
 
     object test extends ScalaTests with FastMCPTestModule {

--- a/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServerSettings.scala
+++ b/fast-mcp-scala/shared/src/com/tjclp/fastmcp/server/McpServerSettings.scala
@@ -112,8 +112,8 @@ case class McpServerSettings(
     stateless: Boolean = false,
     // SSE heartbeat period. Also the only thing that makes the OS probe a GET peer that vanished
     // without closing its connection (a socket is probed only when written to; the OS then gives
-    // up after its own retransmission budget) — zio-http 3.4.0 exposes no accepted-socket option,
-    // so the server sets no TCP keepalive itself.
+    // up after its own retransmission budget) — zio-http 3.11.4 exposes no accepted-socket option
+    // (only TCP_NODELAY is set on accepted channels), so the server sets no TCP keepalive itself.
     keepAliveInterval: Option[java.time.Duration] = None,
     // Streamable HTTP only: evict sessions idle longer than this (no POST/GET/DELETE activity).
     // Sessions with a live GET stream are exempt from the periodic sweep, but at the `maxSessions`


### PR DESCRIPTION
## What

Bumps the ZIO stack — **ZIO 2.1.20 → 2.1.26**, **zio-json 0.7.44 → 0.10.0** (JVM, Scala.js and Scala Native artifacts alike), **zio-http 3.4.0 → 3.11.4** (JVM) — and removes the 16 direct `io.netty` pins the TJC-2327 override had added to the JVM module. zio-http 3.11.4 declares netty 4.2.17.Final itself, so netty is a transitive dependency again: the published `fast-mcp-scala_3` POM lists only `zio_3`, `zio-json_3`, `zio-http_3` and `scala-library` as dependencies plus the `import`-scoped `io.netty:netty-bom` entry (kept at `Versions.netty` = the version zio-http declares, as the single switch should a netty advisory land before zio-http moves). A stdio-only consumer sheds the whole HTTP stack by excluding `dev.zio:zio-http_3` alone again; the two-exclusion form stays valid.

## Why

The direct pins were a stopgap: they made netty a direct `<dependency>` of the JVM artifact, which forced the netty-free GraalVM recipe to exclude both `dev.zio:zio-http_3` and `io.netty:*`, and they had to be kept in lock-step with whatever zio-http resolves. Moving zio-http to a release that already ships the patched netty line restores the pre-TJC-2327 shape while keeping the 4.2.17.Final security outcome (0 OSV advisories on the resolved classpath). No source change was needed; the two touched Scala files only lose stale `zio-http 3.4.0` remarks in comments.

## Probe evidence

A throwaway probe worktree applied exactly this build diff on top of `origin/main` first: the JVM, Scala.js and Scala Native modules compiled unchanged, the full JVM suite passed (138/138 targets), and the resolved JVM tree showed one netty version (4.2.17.Final, all 16 modules plus the classified `linux-x86_64` / `linux-aarch_64` / `osx-x86_64` / `osx-aarch_64` natives) with zio 2.1.26 / zio-json 0.10.0 / zio-http 3.11.4 and the expected resolved-tree side effects (zio-schema 1.8.6, zio-prelude RC48, magnolia 1.3.23, izumi-reflect 3.0.9, scala-collection-compat 2.14.0, scala-java-time 2.7.0 on JS/Native). Reading zio-http 3.4.0 vs 3.11.4 sources found two server-side behaviour deltas that reach the wire, neither on a first-party path: requests netty's decoder rejects are now answered with zio-http's own status mapping (`TooLongHttpHeaderException` → 431, `TooLongHttpLineException` → 414, `TooLongHttpContentException` → 413, other `DecoderException` → 400) where 3.4.0 routed every decoder failure through its generic error-response path, and channel auto-read is paused while a streamed SSE body is written so a pipelined follow-up request is not read interleaved with it. 3.11.4 still exposes no accepted-socket option (only `TCP_NODELAY` on child channels), so the TCP-keepalive remarks stay true with the version corrected; it can emit SSE comment frames (`data` starting with `:`), but the heartbeat keeps its `event: ping` shape so the wire is unchanged.

## Gates (this branch, cold `out/`)

| Gate | Result |
|---|---|
| `show fast-mcp-scala.jvm.resolvedMvnDeps` | single netty **4.2.17.Final** (16 modules + classified natives); zio 2.1.26; zio-json 0.10.0; zio-http 3.11.4 |
| `fast-mcp-scala.checkFormat` (after `reformat`) | pass |
| `fast-mcp-scala.compile` (JVM + Scala.js + Scala Native) | 168/168 SUCCESS |
| `fast-mcp-scala.jvm.test` | 138/138 targets, 612 tests, 0 failed |
| `fast-mcp-scala.js.test` (Bun) | 78 tests, 0 failed |
| `fast-mcp-scala.scalaNative.test` | 16 tests, 0 failed |
| `scripts/conformance.sh jvm 8077 active` | Total: 73 passed, 0 failed; baseline check passed |
| `scripts/conformance.sh js 8077 active` | Total: 73 passed, 0 failed; baseline check passed |
| `scripts/conformance.sh jvm 8078 2026` | Total: 146 passed, 36 failed → **37/37 scored scenarios pass**; 13 not scored (11 failing: 10 `tasks-*` extension with tasks off, `json-schema-2020-12` + `http-custom-header-server-validation` pending) — identical to the zio-http 3.4.0 run |
| `scripts/conformance.sh js 8079 2026` | same: 146/36, 37/37 scored, identical to the 3.4.0 run |
| `scripts/native-smoke.sh` (stdio GraalVM image) | OK; netty-shed check: `io.netty` 0, `zio.http` 0 strings (32 MB image) |
| `fast-mcp-scala.nativeSmoke.http.nativeImage` | built in 36.4 s (66 MB) |
| `scripts/conformance.sh native 8077 active` (that image) | Total: 73 passed, 0 failed; baseline check passed |
| OSV audit of `publishLocal` `1.0.0-n15` (`cs resolve` → `api.osv.dev`) | 41 coordinates, **0 advisories** |
| published POM | dependencies: `zio_3` 2.1.26, `zio-json_3` 0.10.0, `zio-http_3` 3.11.4, `scala-library` 3.9.0, `netty-bom` 4.2.17.Final (`scope: import`, `type: pom`); **no direct `io.netty` entry** |
| `cs resolve com.tjclp:fast-mcp-scala_3:1.0.0-n15 --exclude dev.zio:zio-http_3 \| grep -c io.netty` | **0** (single-exclusion shed works again; 12 coordinates remain) |

## HTTP gate-matrix parity (D3)

`ConformanceServerJvm` on zio-http 3.11.4 was walked with the 78-row D3 gate matrix (Content-Type / Accept gates, body-size caps at 1 MiB ± 1 with Content-Length and chunked, UTF-8 straddle, frame-limit `-32700`s, 100 000-deep literals, ids, URI length, modern header sentinels, oversized/malformed initialize, Host/Origin guard incl. raw duplicated headers, GET/DELETE shapes, live-GET 409, paths, six protocol revisions, teardown) and diffed against the R3 baseline taken on zio-http 3.4.0: **78/78 rows identical** in status, content-type, JSON-RPC error code and body head (session ids normalised); process alive throughout; the same three netty `PrematureChannelClosureException` warnings appear in both server logs (the client-aborted oversized bodies). Zero rows changed, so nothing to classify. Three extra probes exercised the new decoder mapping directly: a 9 000-byte header block → **431**, a 5 000-byte request line → **414**, a header line without a colon → **400** (all empty-bodied, connection closed) — benign, and spec-appropriate statuses where 3.4.0 answered with its generic error path.

## Docs in this PR

`DEPENDENCY_POLICY.md` (netty is transitive; the BOM import governs the version), `docs/native-image.md` (single-exclusion recipe, two-exclusion form kept as also-valid with the reason, `cs resolve` check), `docs/transports.md` (netty sentence; 3.11.4 accepted-socket remark), `README.md` (netty-free sentence), `CLAUDE.md` + `docs/architecture.md` (dependency versions), `JvmHttpBackend.scala` / `McpServerSettings.scala` comments, `CHANGELOG.md` (`### Changed` stack-bump bullet; `### Security` netty bullet now says the version comes from zio-http 3.11.4; the TJC-2355 remark says 3.11.4), `build.mill` / `package.mill` comments.

Observation (pre-existing, not changed here): Mill 1.1.8 writes `bomMvnDeps` into the published POM as an `import`-scoped `pom` `<dependency>` inside `<dependencies>`, not under `<dependencyManagement>`; coursier honours it, Maven treats `import` outside `dependencyManagement` as a validation warning. The wording in this PR describes the POM as it is; the version outcome no longer depends on it since zio-http declares 4.2.17.Final itself.

TJC-2357

**Merge with a MERGE COMMIT (never squash); part of the pre-v1.0.0 stack, see TJC-2326.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
