### PR TITLE
docs(changelog): date 1.0.0 2026-09-09 (TJC-2277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-09-10
-<!-- TAG DATE: re-date at merge -->
+## [1.0.0] - 2026-09-08
 
 Highlights since 0.4.0, the last published stable release (the `[0.5.0]` section
 below was never tagged or published; its changes first shipped in 1.0.0-RC1):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-09-08
+## [1.0.0] - 2026-09-09
 
 Highlights since 0.4.0, the last published stable release (the `[0.5.0]` section
 below was never tagged or published; its changes first shipped in 1.0.0-RC1):


### PR DESCRIPTION
Docs-only follow-up to #99, which merged on 2026-09-08 with the provisional `## [1.0.0] - 2026-09-10` header and the `<!-- TAG DATE: re-date at merge -->` marker.

- `CHANGELOG.md`: `[1.0.0]` dated **2026-09-09** (the tag day); marker line removed. No other file referenced the provisional date.
- Release-readiness assertions re-run against this tree with the new date: 20 PASS, 0 FAIL.
- Tree otherwise identical to #99's merge commit `f15ca70` (no Scala/build change), so the R3 gates and the rehearsal publish still cover it.

**Merge with a merge commit, then tag `v1.0.0` on this PR's merge commit** (not on `f15ca70`), so the tagged tree carries the real release date. If the tag slips to another day, re-date once more before merging.

Refs TJC-2277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)